### PR TITLE
Fixed grammar: (less|greater) than or equal{s =>}

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -222,10 +222,10 @@ expect(4, 'to be >', 3);
 expect(4, '>', 3);
 ```
 
-**greater than or equals to**: asserts `>`
+**greater than or equal to**: asserts `>`
 
 ```js
-expect(3, 'to be greater than or equals to', 2);
+expect(3, 'to be greater than or equal to', 2);
 expect(3, 'to be >=', 3);
 expect(3, '>=', 3);
 ```
@@ -239,10 +239,10 @@ expect(3, 'to be <', 4);
 expect(3, '<', 4);
 ```
 
-**less than or equals to**: asserts `>`
+**less than or equal to**: asserts `>`
 
 ```js
-expect(0, 'to be less than or equals to', 4);
+expect(0, 'to be less than or equal to', 4);
 expect(4, 'to be <=', 4);
 expect(3, '<=', 4);
 ```

--- a/lib/unexpected.js
+++ b/lib/unexpected.js
@@ -355,7 +355,7 @@ var root = this;
         this.assert(this.obj < value);
     });
 
-    expect.addAssertion('<=', 'to be (<=|less than or equals to)', function (value) {
+    expect.addAssertion('<=', 'to be (<=|less than or equal to)', function (value) {
         this.assert(this.obj <= value);
     });
 
@@ -363,7 +363,7 @@ var root = this;
         this.assert(this.obj > value);
     });
 
-    expect.addAssertion('>=', 'to be (>=|greater than or equals to)', function (value) {
+    expect.addAssertion('>=', 'to be (>=|greater than or equal to)', function (value) {
         this.assert(this.obj >= value);
     });
 

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -359,17 +359,17 @@ describe('unexpected', function () {
         });
     });
 
-    describe('less than or equals assertion', function () {
+    describe('less than or equal assertion', function () {
         it('asserts <=', function () {
-            expect(0, 'to be less than or equals to', 4);
+            expect(0, 'to be less than or equal to', 4);
             expect(4, 'to be <=', 4);
             expect(3, '<=', 4);
         });
 
         it('throws when the assertion fails', function () {
             expect(function () {
-                expect(0, 'to be less than or equals to', -1);
-            }, 'to throw exception', "expected 0 to be less than or equals to -1");
+                expect(0, 'to be less than or equal to', -1);
+            }, 'to throw exception', "expected 0 to be less than or equal to -1");
         });
     });
 
@@ -388,17 +388,17 @@ describe('unexpected', function () {
         });
     });
 
-    describe('greater than or equals assertion', function () {
+    describe('greater than or equal assertion', function () {
         it('assert >=', function () {
-            expect(3, 'to be greater than or equals to', 2);
+            expect(3, 'to be greater than or equal to', 2);
             expect(3, 'to be >=', 3);
             expect(3, '>=', 3);
         });
 
         it('throws when the assertion fails', function () {
             expect(function () {
-                expect(-1, 'to be greater than or equals to', 0);
-            }, 'to throw exception', "expected -1 to be greater than or equals to 0");
+                expect(-1, 'to be greater than or equal to', 0);
+            }, 'to throw exception', "expected -1 to be greater than or equal to 0");
         });
     });
 


### PR DESCRIPTION
This doesn't sound right:

``` javascript
expect(foo, "to be greater than or equals to", bar);
```
