### PR TITLE
Remove unexpected's entries from the stack traces of the thrown error objects

### DIFF
--- a/lib/unexpected.js
+++ b/lib/unexpected.js
@@ -54,6 +54,23 @@ var root = this;
     };
 
     var assertions = {};
+
+    function truncateStack(err, fn) {
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(err, fn);
+        } else if ('stack' in err) {
+            // Excludes IE<10, and fn cannot be anonymous for this backup plan to work:
+            var stackEntries = err.stack.split(/\r\n?|\n\r?/),
+                needle = 'at ' + fn.name + ' ';
+            for (var i = 0 ; i < stackEntries.length ; i += 1) {
+                if (stackEntries[i].indexOf(needle) !== -1) {
+                    stackEntries.splice(1, i);
+                    err.stack = stackEntries.join("\n");
+                }
+            }
+        }
+    }
+
     function expect(subject, testDescriptionString) {
         var assertionRule = assertions[testDescriptionString];
         if (assertionRule) {
@@ -64,13 +81,20 @@ var root = this;
             var args = Array.prototype.slice.call(arguments, 2);
             var assertion = new Assertion(subject, testDescriptionString, flags, args);
             var handler = assertionRule.handler;
-            handler.apply(assertion, args);
+            try {
+                handler.apply(assertion, args);
+            } catch (e) {
+                truncateStack(e, expect);
+                throw e;
+            }
         } else {
             var similarAssertions = expect.findAssertionSimilarTo(testDescriptionString);
             var message =
                 'Unknown assertion "' + testDescriptionString + '", ' +
                 'did you mean: "' + similarAssertions[0] + '"';
-            throw new Error(message);
+            var err = new Error(message);
+            truncateStack(err, expect);
+            throw err;
         }
     }
 

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -32,6 +32,16 @@ describe('unexpected', function () {
                 expect(4 < 4, 'to be ok', '4 < 4');
             }, "to throw exception", "expected false to be ok '4 < 4'");
         });
+
+        it('throws with a stack trace that has the calling function as the top frame when the assertion fails (if the environment supports it)', function () {
+            if (Error.captureStackTrace || 'stack' in new Error()) {
+                expect(function TheCallingFunction() {
+                    expect(4 < 4, 'to be ok');
+                }, 'to throw exception', function (err) {
+                    expect(err.stack.split('\n')[1], 'to match', /TheCallingFunction/);
+                });
+            }
+        });
     });
 
     describe('be assertion', function () {


### PR DESCRIPTION
This fix makes sure that the top stack frame is the place that calls `expect`, which makes the output easier to parse.

Previously you'd get something like:

```
Error: expected foo to be bar
      at Assertion.throwStandardError (/path/to/unexpected/lib/unexpected.js:41:15)
      at Assertion.assert (/path/to/unexpected/lib/unexpected.js:52:18)
      at Assertion.<anonymous> (/path/to/unexpected/lib/unexpected.js:258:18)
      at expect (/path/to/unexpected/lib/unexpected.js:67:21)
      at theActualTestSuite (/path/to/testSuite:22:13)
```

With this patch it'll be:

```
Error: expected foo to be bar
      at theActualTestSuite (/path/to/testSuite:22:13)
```
