### PR TITLE
Include 'expected' and 'actual' properties on the exception object

### DIFF
--- a/lib/unexpected.js
+++ b/lib/unexpected.js
@@ -400,7 +400,15 @@ var root = this;
     });
 
     expect.addAssertion('to [not] equal', function (value) {
-        this.assert(expect.eql(value, this.obj));
+        try {
+            this.assert(expect.eql(value, this.obj));
+        } catch (e) {
+            if (!this.flags.not) {
+                e.expected = value;
+                e.actual = this.obj;
+            }
+            throw e;
+        }
     });
 
     expect.addAssertion('to [not] throw (error|exception)', function (fn) {

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -134,6 +134,26 @@ describe('unexpected', function () {
                 expect({ a: 'b' }, 'to not equal', { a: 'b' });
             }, 'to throw exception', "expected { a: 'b' } to not equal { a: 'b' }");
         });
+
+        it("throws an error with 'expected' and 'actual' properties when not negated", function () {
+            var expected = 123,
+                actual = 456;
+            expect(function () {
+                expect(actual, 'to equal', expected);
+            }, 'to throw exception', function (e) {
+                expect(e.expected, 'to equal', expected);
+                expect(e.actual, 'to equal', actual);
+            });
+        });
+
+        it("throws an error without 'expected' and 'actual' properties when negated", function () {
+            expect(function () {
+                expect(123, 'not to equal', 123);
+            }, 'to throw exception', function (e) {
+                expect(e.expected, 'to not be ok');
+                expect(e.actual, 'to not be ok');
+            });
+        });
     });
 
     describe('exception assertion', function () {


### PR DESCRIPTION
... when a non-negated equality assertion fails.

Fixes #5.
