### PR TITLE
Corrected a spelling mistake in an usage example

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -61,7 +61,7 @@ var expect = weknowhow.expect;
 Include the library with RequireJS the following way:
 
 ```js
-define(['unexpected/lib/unexpected.js'], funtion (expect) {
+define(['unexpected/lib/unexpected.js'], function (expect) {
    // Your code
 });
 ```


### PR DESCRIPTION
Taking the fun(tion) out of usage examples (sorry, just spotted a typing error in an usage example ;)).
