### PR TITLE
to not only have keys should expect the given keys to be present

### DIFF
--- a/lib/unexpected-assertions.js
+++ b/lib/unexpected-assertions.js
@@ -163,7 +163,8 @@
             return subject.hasOwnProperty(key);
         });
         if (this.flags.only) {
-            expect(hasKeys && getKeys(subject).length === keys.length, '[not] to be truthy');
+            expect(hasKeys, 'to be truthy');
+            expect(getKeys(subject).length === keys.length, '[not] to be truthy');
         } else {
             expect(hasKeys, '[not] to be truthy');
         }


### PR DESCRIPTION
`to not only have keys` means that it is not only the given keys that are
present on the object.
