### PR TITLE
Throw if an assertion is redefined.

### DIFF
--- a/lib/unexpected-core.js
+++ b/lib/unexpected-core.js
@@ -157,13 +157,21 @@
         var assertions = this.assertions;
         var patterns = Array.prototype.slice.call(arguments, 0, -1);
         var handler = Array.prototype.slice.call(arguments, -1)[0];
+        var isSeenByExpandedPattern = {};
         forEach(patterns, function (pattern) {
             ensureValidPattern(pattern);
             forEach(expandPattern(pattern), function (expandedPattern) {
-                assertions[expandedPattern.text] = {
-                    handler: handler,
-                    flags: expandedPattern.flags
-                };
+                if (expandedPattern.text in assertions) {
+                    if (!isSeenByExpandedPattern[expandedPattern.text]) {
+                        throw new Error('Cannot redefine assertion: ' + expandedPattern.text);
+                    }
+                } else {
+                    isSeenByExpandedPattern[expandedPattern.text] = true;
+                    assertions[expandedPattern.text] = {
+                        handler: handler,
+                        flags: expandedPattern.flags
+                    };
+                }
             });
         });
 

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -1246,6 +1246,28 @@ describe('unexpected', function () {
             }, 'to throw', 'expected [ 1, 2, 3 ] not to be sorted');
         });
 
+        it('throws when attempting to redefine an assertion', function () {
+            var clonedExpect = expect.clone()
+                .addAssertion('to foo', function () {});
+            expect(function () {
+                clonedExpect.addAssertion('to foo', function () {});
+            }, 'to throw', 'Cannot redefine assertion: to foo');
+        });
+
+        it('throws when implicitly attempting to redefine an assertion', function () {
+            var clonedExpect = expect.clone()
+                .addAssertion('to foo [bar]', function () {});
+            expect(function () {
+                clonedExpect.addAssertion('to foo (bar|quux)', function () {});
+            }, 'to throw', 'Cannot redefine assertion: to foo bar');
+        });
+
+        it('allows overlapping patterns within a single addAssertion call', function () {
+            expect(function () {
+                expect.clone().addAssertion('to foo', 'to [really] foo', function () {});
+            }, 'not to throw');
+        });
+
         describe('pattern', function () {
             it("must be a string", function () {
                 expect(function () {


### PR DESCRIPTION
This will detect when you have big test suite where you add the same generically named assertion multiple times without cloning first.

Fixes #38.
