### PR TITLE
Consider Error instances different when their 'message' properties differ

### DIFF
--- a/lib/unexpected-utils.js
+++ b/lib/unexpected-utils.js
@@ -81,9 +81,15 @@
         },
 
         getKeysOfDefinedProperties: function (object) {
-            return filter(getKeys(object), function (key) {
+            var keys = filter(getKeys(object), function (key) {
                 return typeof object[key] !== 'undefined';
             });
+            // The 'message' property of Error instances is enumerable for some reason, but we want
+            // to include it in the set when comparing:
+            if (Object.prototype.toString.call(object) === '[object Error]') {
+                keys.push('message');
+            }
+            return keys;
         },
 
         /**

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -68,6 +68,48 @@ describe('unexpected', function () {
             }, 'to throw', "expected [Error: { message: 'error message', data: 'extra' }] to be a number");
         });
 
+        describe('with Error instances', function () {
+            it('considers Error instances with different messages to be different', function () {
+                expect(function () {
+                    expect(new Error('foo'), 'to equal', new Error('bar'));
+                }, 'to throw exception', function (err) {
+                    expect(err.message, 'to equal', "expected [Error: { message: 'foo' }] to equal [Error: { message: 'bar' }]");
+                });
+            });
+
+            it('considers Error instances with the same message but different stacks to be equal', function () {
+                var err1 = new Error('foo'),
+                    err2 = new Error('foo');
+                expect(err1, 'to equal', err2);
+            });
+
+            it('considers Error instances with the same message and extra properties to be equal', function () {
+                var err1 = new Error('foo'),
+                    err2 = new Error('foo');
+                err1.extra = 'foo';
+                err2.extra = 'foo';
+                expect(err1, 'to equal', err2);
+            });
+
+            it('considers Error instances with the same message but different extra properties to be different', function () {
+                var err1 = new Error('foo'),
+                    err2 = new Error('foo');
+                err1.extra = 'foo';
+                err2.extra = 'bar';
+                expect(function () {
+                    expect(err1, 'to equal', err2);
+                }, 'to throw exception', "expected [Error: { message: 'foo', extra: 'foo' }] to equal [Error: { message: 'foo', extra: 'bar' }]");
+            });
+
+            it('considers Error instances with the same message and stack to be equal', function () {
+                var errors = [];
+                for (var i = 0 ; i < 2 ; i += 1) {
+                    errors.push(new Error('foo'));
+                }
+                expect(errors[0], 'to equal', errors[1]);
+            });
+        });
+
         it('throws with a stack trace that has the calling function as the top frame when the assertion fails (if the environment supports it)', function () {
             if (Error.captureStackTrace || 'stack' in new Error()) {
                 expect(function TheCallingFunction() {


### PR DESCRIPTION
This adopts the tests from #39 and makes sure that `expect(new Error('foo'), 'to equal', new Error('bar'));` fails without introducing the ability to for a custom type to delegate equality testing to the next type.
