### PR TITLE
Implement to be (a|an) [non-empty] (map|hash|object) whose properties satisfy

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -386,7 +386,7 @@ module.exports = function (expect) {
         });
     });
 
-    expect.addAssertion('object', 'to be (a|an) [non-empty] (map|hash|object) whose keys satisfy', function (expect, subject) {
+    expect.addAssertion('object', 'to be (a|an) [non-empty] (map|hash|object) whose (keys|properties) satisfy', function (expect, subject) {
         var extraArgs = Array.prototype.slice.call(arguments, 2);
         if (extraArgs.length === 0) {
             throw new Error('Assertion "' + this.testDescription + '" expects a third argument');
@@ -401,7 +401,11 @@ module.exports = function (expect) {
         var errors = {};
         forEach(getKeys(subject), function (key, index) {
             try {
-                expect.apply(expect, [key, 'to satisfy assertion'].concat(extraArgs));
+                if (typeof extraArgs[0] === 'function') {
+                    extraArgs[0](key, subject[key]);
+                } else {
+                    expect.apply(expect, [key, 'to satisfy assertion'].concat(extraArgs));
+                }
             } catch (e) {
                 errors[key] = e;
             }

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -1570,6 +1570,13 @@ describe('unexpected', function () {
             expect({ foo: 0, bar: 1, baz: 2, qux: 3 }, 'to be a map whose keys satisfy', 'to match', /^[a-z]{3}$/);
         });
 
+        it('receives the key and the value when the third argument is a function', function () {
+            expect({ foo: 123 }, 'to be a map whose keys satisfy', function (key, value) {
+                expect(key, 'to equal', 'foo');
+                expect(value, 'to equal', 123);
+            });
+        });
+
         it('supports the non-empty clause', function () {
             expect({ foo: '0' }, 'to be a non-empty map whose keys satisfy', function (key) {
                 expect(key, 'to match', /^[a-z]{3}$/);


### PR DESCRIPTION
Turns out it was easy to implement just overload the "function" case of the "whose keys satisfy" variant.
