### PR TITLE
Use the "control pictures" unicode chars to represent bytes < 0x20 in hex dumps

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -649,16 +649,33 @@ module.exports = function (expect) {
                 for (var j = 0 ; j < result.diff.output[i].length ; j += 1) {
                     var obj = result.diff.output[i][j];
                     var replacement = '';
+                    var leftover;
                     for (var k = 0 ; k < obj.args[0].length ; k += 1) {
                         var ch = obj.args[0].charAt(k);
                         if (ch === '│') {
                             isInAsciiChars = true;
                         } else if (isInAsciiChars) {
-                            if (/[\x00-\x1f\x7f-\xff]/.test(ch)) {
+                            if (/[\x00-\x1f]/.test(ch)) {
+                                ch = String.fromCharCode(9216 + ch.charCodeAt(0));
+                                leftover = obj.args[0].substr(k + 1);
+                                if (replacement) {
+                                    obj.args[0] = replacement;
+                                    j += 1;
+                                } else {
+                                    result.diff.output[i].splice(j, 1);
+                                }
+                                result.diff.output[i].splice(j, 0, {style: 'text', args: [ch, (obj.args[1] ? obj.args[1] + ', ' : '') + 'bold']});
+                                replacement = '';
+                                if (leftover.length > 0) {
+                                    result.diff.output[i].splice(j + 1, 0, {style: 'text', args: [leftover, obj.args[1]]});
+                                }
+                                obj = result.diff.output[i][j];
+                                k = 1;
+                            } else if (/[\x7f-\xff]/.test(ch)) {
                                 ch = '.';
                             }
                         } else if (ch === ' ' && /\bbg/.test(obj.args[1])) {
-                            var leftover = obj.args[0].substr(k + 1);
+                            leftover = obj.args[0].substr(k + 1);
                             if (replacement) {
                                 obj.args[0] = replacement;
                                 j += 1;

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -500,7 +500,7 @@ describe('unexpected', function () {
                    '\n' +
                    'Diff:\n' +
                    '\n' +
-                   ' 00 01 02 48 65 72 65 20 69 73 20 74 68 65 20 74  │...Here is the t│\n' +
+                   ' 00 01 02 48 65 72 65 20 69 73 20 74 68 65 20 74  │␀␁␂Here is the t│\n' +
                    '-68 69 6E 67 20 49 20 77 61 73 20 74 61 6C 6B 69  │hing I was talki│\n' +
                    '+68 69 6E 67 20 49 20 77 61 73 20 71 75 75 78 69  │hing I was quuxi│\n' +
                    ' 6E 67 20 61 62 6F 75 74                          │ng about│');
@@ -527,7 +527,7 @@ describe('unexpected', function () {
                    '\n' +
                    'Diff:\n' +
                    '\n' +
-                   ' 00 01 02 48 65 72 65 20 69 73 20 74 68 65 20 74  │...Here is the t│\n' +
+                   ' 00 01 02 48 65 72 65 20 69 73 20 74 68 65 20 74  │␀␁␂Here is the t│\n' +
                    '-68 69 6E 67 20 49 20 77 61 73 20 74 61 6C 6B 69  │hing I was talki│\n' +
                    '+68 69 6E 67 20 49 20 77 61 73 20 71 75 75 78 69  │hing I was quuxi│\n' +
                    ' 6E 67 20 61 62 6F 75 74                          │ng about│');
@@ -554,7 +554,7 @@ describe('unexpected', function () {
                    '\n' +
                    'Diff:\n' +
                    '\n' +
-                   ' 00 01 02 48 65 72 65 20 69 73 20 74 68 65 20 74  │...Here is the t│\n' +
+                   ' 00 01 02 48 65 72 65 20 69 73 20 74 68 65 20 74  │␀␁␂Here is the t│\n' +
                    '-68 69 6E 67 20 49 20 77 61 73 20 74 61 6C 6B 69  │hing I was talki│\n' +
                    '+68 69 6E 67 20 49 20 77 61 73 20 71 75 75 78 69  │hing I was quuxi│\n' +
                    ' 6E 67 20 61 62 6F 75 74                          │ng about│');


### PR DESCRIPTION
Tried adding this just to see how it behaves -- I think it's sort of nice. As a bonus, it makes the hex dump string diffs light up the same differing chars in the left and right part, except for bytes >= 0x7f, which will need a separate strategy.

@sunesimonsen Did you say that your terminal doesn't even render these? What does it render instead?

Looking through the diff here on github it seems like the monospace font they're using in the "Files changed" view renders the control pictures slightly wider than regular chars, which might be annoying if the same thing is the case when rendering HTML for the browser.
