### PR TITLE
Add diffs for 'to satisfy'

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -326,7 +326,14 @@ Unexpected.prototype.setErrorMessage = function (err) {
     var message = err.output.clone().append(err.output);
 
     if (err.createDiff) {
-        var comparison = err.createDiff(message.clone());
+        var that = this;
+        var comparison = err.createDiff(message.clone(), function (actual, expected) {
+            return that.diff(actual, expected);
+        }, function (v, depth) {
+            return that.inspect(v, depth || Infinity);
+        }, function (actual, expected) {
+            return that.equal(actual, expected);
+        });
         if (comparison) {
             message.nl(2).blue('Diff:').nl(2).append(comparison.diff);
         }

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -90,8 +90,7 @@ module.exports = function (expect) {
             expect(String(subject).match(regexp), '[not] to be truthy');
         } catch (e) {
             if (e._isUnexpected && this.flags.not) {
-                e.createDiff = function () {
-                    var output = expect.output.clone();
+                e.createDiff = function (output) {
                     var lastIndex = 0;
                     function flushUntilIndex(i) {
                         if (i > lastIndex) {
@@ -148,7 +147,7 @@ module.exports = function (expect) {
                     });
                 } catch (e) {
                     if (e._isUnexpected) {
-                        e.createDiff = function () {
+                        e.createDiff = function (output, diff) {
                             var expected = extend({}, properties);
                             var actual = {};
                             for (var propertyName in subject) {
@@ -159,7 +158,7 @@ module.exports = function (expect) {
                                     actual[propertyName] = subject[propertyName];
                                 }
                             }
-                            return expect.diff(actual, expected);
+                            return diff(actual, expected);
                         };
                     }
                     expect.fail(e);
@@ -219,8 +218,7 @@ module.exports = function (expect) {
                 });
             } catch (e) {
                 if (e._isUnexpected && this.flags.not) {
-                    e.createDiff = function () {
-                        var output = expect.output.clone();
+                    e.createDiff = function (output) {
                         var lastIndex = 0;
                         function flushUntilIndex(i) {
                             if (i > lastIndex) {
@@ -249,10 +247,10 @@ module.exports = function (expect) {
                 });
             } catch (e) {
                 if (e._isUnexpected && this.flags.not) {
-                    e.createDiff = function () {
-                        return expect.diff(subject, subject.filter(function (item) {
+                    e.createDiff = function (output, diff, inspect, equal) {
+                        return diff(subject, subject.filter(function (item) {
                             return !args.some(function (arg) {
-                                return expect.equal(item, arg);
+                                return equal(item, arg);
                             });
                         }));
                     };
@@ -304,8 +302,8 @@ module.exports = function (expect) {
             expect(expect.equal(value, subject), '[not] to be true');
         } catch (e) {
             if (!this.flags.not && e._isUnexpected) {
-                e.createDiff = function () {
-                    return expect.diff(subject, value);
+                e.createDiff = function (output, diff) {
+                    return diff(subject, value);
                 };
             }
             expect.fail(e);
@@ -540,8 +538,7 @@ module.exports = function (expect) {
                 } catch (e) {
                     if (e._isUnexpected) {
                         var flags = this.flags;
-                        // FIXME: Calls to expect.inspect won't know the actual depth
-                        e.createDiff = function (output) {
+                        e.createDiff = function (output, diff, inspect, equal) {
                             var result = {
                                 diff: output,
                                 inline: true
@@ -575,10 +572,10 @@ module.exports = function (expect) {
                                                 annotation.error('should be removed');
                                             }
                                         } else {
-                                            var keyDiff = conflicting.createDiff && conflicting.createDiff(output.clone());
+                                            var keyDiff = conflicting.createDiff && conflicting.createDiff(output.clone(), diff, inspect, equal);
                                             if (!keyDiff || (keyDiff && !keyDiff.inline)) {
                                                 annotation.error('should satisfy: ')
-                                                    .block(expect.inspect(value[key]));
+                                                    .block(inspect(value[key]));
 
                                                 if (keyDiff) {
                                                     annotation.nl().append(keyDiff.diff);
@@ -592,13 +589,13 @@ module.exports = function (expect) {
 
                                     var last = index === keys.length - 1;
                                     if (!valueOutput) {
-                                        valueOutput = expect.inspect(subject[key], conflicting ? Infinity : 1);
+                                        valueOutput = inspect(subject[key], conflicting ? Infinity : 1);
                                     }
 
                                     if (/^[a-z\$\_][a-z0-9\$\_]*$/i.test(key)) {
                                         this.key(key);
                                     } else {
-                                        this.append(expect.inspect(key));
+                                        this.append(inspect(key));
                                     }
                                     this.text(':').sp();
                                     valueOutput.text(last ? '' : ',');

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -1437,6 +1437,47 @@ describe('unexpected', function () {
             expect({foo: {}}, 'not to satisfy', {foo: 123});
         });
 
+        it('collapses subtrees without conflicts', function () {
+            expect(function () {
+                expect({
+                    pill: {
+                        red: "I'll show you how deep the rabbit hole goes",
+                        blue: { ignorance: { of: 'illusion' } }
+                    }
+                }, 'to satisfy', {
+                    pill: {
+                        red: "I'll show you how deep the rabbit hole goes.",
+                        blue: { ignorance: { of: 'illusion' } }
+                    }
+                });
+            }, 'to throw',
+                   "expected\n" +
+                   "{\n" +
+                   "  pill: {\n" +
+                   "    red: 'I\\'ll show you how deep the rabbit hole goes',\n" +
+                   "    blue: { ignorance: ... }\n" +
+                   "  }\n" +
+                   "}\n" +
+                   "to satisfy\n" +
+                   "{\n" +
+                   "  pill: {\n" +
+                   "    red: 'I\\'ll show you how deep the rabbit hole goes.',\n" +
+                   "    blue: { ignorance: ... }\n" +
+                   "  }\n" +
+                   "}\n" +
+                   "\n" +
+                   "Diff:\n" +
+                   "\n" +
+                   "{\n" +
+                   "  pill: {\n" +
+                   "    red: 'I\\'ll show you how deep the rabbit hole goes', // should satisfy: 'I\\'ll show you how deep the rabbit hole goes.'\n" +
+                   "                                                         // -I'll show you how deep the rabbit hole goes\n" +
+                   "                                                         // +I'll show you how deep the rabbit hole goes.\n" +
+                   "    blue: { ignorance: ... }\n" +
+                   "  }\n" +
+                   "}");
+        });
+
         describe('with a custom type', function () {
             function MysteryBox(value) {
                 this.propertyName = 'prop' + Math.floor(1000 * Math.random());


### PR DESCRIPTION
This is incomplete and has a lot of loose ends, but I would like to get some feedback :)

Should `e.createDiff` receive an `output` parameter? How about `inspect` (or maybe just `depth`) so that the collapsing of unimportant subtrees can work.

Regarding the `MagicBox` etc. tests -- it would be really nice to somehow generalize the code that inspects/diffs `ko.observable` in unexpected-knockout so that the output can look nicer. Maybe we could have an "abstract" type for that, sort of like https://github.com/sunesimonsen/unexpected/blob/master/lib/types.js#L570-L675
