### PR TITLE
Inspect own function properties

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -553,7 +553,8 @@ module.exports = function (expect) {
                         .append(inspect(f[ownPropertyName]))
                         .code(';', 'javascript');
                 });
-                output.nl().append(propertiesOutput.prependLinesWith('error', '// '));
+                output.nl().append(propertiesOutput.prependLinesWith('comment', '// '));
+                output = output.clone().block(output);
             }
             return output;
         }

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -2720,7 +2720,7 @@ describe('unexpected', function () {
         });
 
         it('should output ellipsis when the toString method of a function returns something unparsable', function () {
-            function foo () {}
+            function foo() {}
             foo.toString = function () {
                 return 'quux';
             };
@@ -2732,7 +2732,7 @@ describe('unexpected', function () {
         });
 
         it('should render a function within a nested structure ellipsis when the toString method of a function returns something unparsable', function () {
-            function foo () {}
+            function foo() {}
             foo.toString = function () {
                 return 'quux';
             };
@@ -2740,9 +2740,9 @@ describe('unexpected', function () {
                 '{\n' +
                 '  bar: {\n' +
                 '    quux: function foo( /*...*/ ) { /*...*/ }\n' +
-                '    // foo.toString = function () {\n' +
-                "    //     return 'quux';\n" +
-                '    // };\n' +
+                '          // foo.toString = function () {\n' +
+                "          //     return 'quux';\n" +
+                '          // };\n' +
                 '  }\n' +
                 '}');
         });


### PR DESCRIPTION
Replaces #70. Had to create a new PR because the old one had `v5` as the base, and apparently you can't change that after the fact.

We concluded offline that the diffs are fine, but that it would be ideal for the `inspect` output to include the extra properties. The best idea on the table was to put the extra properties in a comment, so I went ahead and implemented that.

As far as I can tell, the only thing that needs more work is the indentation of the extra properties when rendered as part of an object: https://github.com/sunesimonsen/unexpected/blob/e7843c24b833d5ad417c884495ccbc718a9f4790/test/unexpected.spec.js#L2743-L2745

@sunesimonsen Any idea for how to make the extra properties line up with `function`?
