### PR TITLE
Throw a nice exception if expect.promise() is called without a function.

### DIFF
--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -4,6 +4,10 @@ var oathbreaker = require('./oathbreaker');
 var throwIfNonUnexpectedError = require('./throwIfNonUnexpectedError');
 
 function makePromise(body) {
+    if (typeof body !== 'function') {
+        throw new TypeError('A function argument must be supplied.');
+    }
+
     if (body.length === 2) {
         return new Promise(body);
     }

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -5598,6 +5598,33 @@ describe('unexpected', function () {
             });
             expect(clonedExpect('foo', 'to foo'), 'to equal', 'bar');
         });
+
+        it('should throw an exception if the argument was not a function', function () {
+            function validateError(e) {
+                expect(e, 'to be a', TypeError);
+                expect(e, 'to have message', 'A function argument must be supplied.');
+            }
+
+            expect(function () {
+                expect.promise();
+            }, 'to throw', validateError);
+
+            expect(function () {
+                expect.promise(null);
+            }, 'to throw', validateError);
+
+            expect(function () {
+                expect.promise('');
+            }, 'to throw', validateError);
+
+            expect(function () {
+                expect.promise([]);
+            }, 'to throw', validateError);
+
+            expect(function () {
+                expect.promise({});
+            }, 'to throw', validateError);
+        });
     });
 
     describe.skipIf(typeof Buffer === 'undefined', 'when decoded as assertion', function () {


### PR DESCRIPTION
This pull request addresses #148 avoiding the 'cannot ready property 'length' of undefined error. Test cases are included.