### PR TITLE
expect.it: Indicate success/failure for all clauses.

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -128,7 +128,8 @@ function writeGroupEvaluationsToOutput(expect, output, groupEvaluations) {
             if (j > 0) {
                 output.jsComment(' and').nl();
             }
-            if (evaluation.promise.isRejected() && !groupFailed) {
+            var isRejected = evaluation.promise.isRejected();
+            if (isRejected && !groupFailed) {
                 groupFailed = true;
                 var err = evaluation.promise.reason();
 
@@ -147,9 +148,9 @@ function writeGroupEvaluationsToOutput(expect, output, groupEvaluations) {
                 });
             } else {
                 var style;
-                if (groupFailed) {
-                    style = 'text';
-                    output.sp(2);
+                if (isRejected) {
+                    style = 'error';
+                    output.error('⨯ ');
                 } else {
                     style = 'success';
                     output.success('✓ ');

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -2822,7 +2822,7 @@ describe('unexpected', function () {
                         "⨯ expected 123 when delayed a little bit to equal 456\n" +
                         "or\n" +
                         "⨯ expected 123 when delayed a little bit to be a string and\n" +
-                        "  expected 123 to be greater than 100\n" +
+                        "✓ expected 123 to be greater than 100\n" +
                         "or\n" +
                         "✓ expected 123 when delayed a little bit 'to be a number' and\n" +
                         "⨯ expected 123 when delayed a little bit to be within 100, 110"
@@ -4615,7 +4615,7 @@ describe('unexpected', function () {
                 }, 'to throw',
                        "✓ expected 20 to be a number and\n" +
                        "⨯ expected 20 to be less than 14 and\n" +
-                       "  expected 20 to be negative");
+                       "⨯ expected 20 to be negative");
             });
 
             it('returns a new function', function () {
@@ -4664,7 +4664,7 @@ describe('unexpected', function () {
                     expectation('foobarbaz');
                 }, 'to throw',
                        "⨯ expected 'foobarbaz' to be a number and\n" +
-                       "  expected 'foobarbaz' to be greater than 6\n" +
+                       "⨯ expected 'foobarbaz' to be greater than 6\n" +
                        "or\n" +
                        "✓ expected 'foobarbaz' to be a string and\n" +
                        "⨯ expected 'foobarbaz' to have length 6\n" +
@@ -4758,7 +4758,7 @@ describe('unexpected', function () {
                         'to be rejected',
                             '⨯ expected false to be a number after a short delay and\n' +
                             '    expected false to be a number\n' +
-                            '  expected false to be finite after a short delay'
+                            '⨯ expected false to be finite after a short delay'
                     );
                 });
             });
@@ -4780,7 +4780,7 @@ describe('unexpected', function () {
                         'to be rejected',
                             '⨯ expected false to be a number after a short delay and\n' +
                             '    expected false to be a number\n' +
-                            '  expected false to be finite after a short delay\n' +
+                            '⨯ expected false to be finite after a short delay\n' +
                             'or\n' +
                             '⨯ expected false to be a string after a short delay\n' +
                             '    expected false to be a string'


### PR DESCRIPTION
To conserve space, only the first error message is displayed.