### PR TITLE
Stop truncating the stack of thrown errors

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -2,7 +2,6 @@ var Assertion = require('./Assertion');
 var createStandardErrorMessage = require('./createStandardErrorMessage');
 var utils = require('./utils');
 var magicpen = require('magicpen');
-var truncateStack = utils.truncateStack;
 var extend = utils.extend;
 var leven = require('leven');
 var makePromise = require('./makePromise');
@@ -591,9 +590,7 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
                         testFrameworkPatch.promiseCreated();
                         return result.then(undefined, function (e) {
                             if (e && e._isUnexpected) {
-                                var newError = new UnexpectedError(that.expect, assertion, e);
-                                truncateStack(newError, wrappedExpect);
-                                throw newError;
+                                throw new UnexpectedError(that.expect, assertion, e);
                             }
                             throw e;
                         });
@@ -602,7 +599,6 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
                     }
                 } catch (e) {
                     if (e && e._isUnexpected) {
-                        truncateStack(e, wrappedExpect);
                         var wrappedError = new UnexpectedError(that.expect, assertion, e);
                         if (serializeErrorsFromWrappedExpect) {
                             that.setErrorMessage(wrappedError);
@@ -746,7 +742,6 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
             if (typeof mochaPhantomJS !== 'undefined') {
                 newError = e.clone();
             }
-            truncateStack(newError, that.expect);
             that.setErrorMessage(newError);
             throw newError;
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,23 +36,6 @@ var utils = module.exports = {
         return target;
     },
 
-    truncateStack: function (err, fn) {
-        if (Error.captureStackTrace) {
-            Error.captureStackTrace(err, fn);
-        } else if ('stack' in err) {
-            // Excludes IE<10, and fn cannot be anonymous for this backup plan to work:
-            var stackEntries = err.stack.split(/\r\n?|\n\r?/),
-            needle = 'at ' + fn.name + ' ';
-            for (var i = 0 ; i < stackEntries.length ; i += 1) {
-                if (stackEntries[i].indexOf(needle) !== -1) {
-                    stackEntries.splice(1, i);
-                    err.stack = stackEntries.join("\n");
-                }
-            }
-        }
-        return err;
-    },
-
     findFirst: function (arr, predicate, thisObj) {
         var scope = thisObj || null;
         for (var i = 0 ; i < arr.length ; i += 1) {

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -199,16 +199,6 @@ describe('unexpected', function () {
                        "})");
             });
         });
-
-        it('throws with a stack trace that has the calling function as the top frame when the assertion fails (if the environment supports it)', function () {
-            if (Error.captureStackTrace || 'stack' in new Error()) {
-                expect(function TheCallingFunction() {
-                    expect(4 < 4, 'to be ok');
-                }, 'to throw exception', function (err) {
-                    expect(err.stack.split('\n')[2], 'to match', /TheCallingFunction/);
-                });
-            }
-        });
     });
 
     describe('be assertion', function () {
@@ -4099,45 +4089,6 @@ describe('unexpected', function () {
                         "  +foo"
                     );
                 });
-            });
-        });
-
-        it('truncates the stack when a custom assertion throws a regular assertion error', function () {
-            var clonedExpect = expect.clone().addAssertion('to equal foo', function theCustomAssertion(expect, subject) {
-                expect(subject, 'to equal', 'foo');
-            });
-            expect(function () {
-                clonedExpect('bar', 'to equal foo');
-            }, 'to throw', function (err) {
-                expect(err.stack, 'not to contain', 'theCustomAssertion');
-            });
-        });
-
-        it('does not truncate the stack or replace the error message when the assertion function itself contains an error', function () {
-            var clonedExpect = expect.clone().addAssertion('to equal foo', function theCustomAssertion(expect, subject) {
-                expect(subject, 'to equal', 'foo');
-                this(); // Will throw a TypeError
-            });
-            expect(function () {
-                clonedExpect('foo', 'to equal foo');
-            }, 'to throw', function (err) {
-                expect(err.stack, 'to contain', 'theCustomAssertion');
-                expect(err.message, 'to match', /is not a function|Function expected/);
-            });
-        });
-
-        it('does not truncate the stack or replace the error message when a nested custom assertion contains an error', function () {
-            var clonedExpect = expect.clone().addAssertion('to equal foo', function theCustomAssertion(expect, subject) {
-                expect(subject, 'to equal', 'foo');
-                this(); // Will throw a TypeError
-            }).addAssertion('to foo', function (expect, subject) {
-                expect(subject, 'to equal foo');
-            });
-            expect(function () {
-                clonedExpect('foo', 'to foo');
-            }, 'to throw', function (err) {
-                expect(err.stack, 'not to contain', "expected 'foo' to foo");
-                expect(err.message, 'not to contain', "expected 'foo' to foo");
             });
         });
 

--- a/unexpected.js
+++ b/unexpected.js
@@ -64,7 +64,6 @@ var Assertion = require(1);
 var createStandardErrorMessage = require(5);
 var utils = require(13);
 var magicpen = require(30);
-var truncateStack = utils.truncateStack;
 var extend = utils.extend;
 var leven = require(26);
 var makePromise = require(7);
@@ -653,9 +652,7 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
                         testFrameworkPatch.promiseCreated();
                         return result.then(undefined, function (e) {
                             if (e && e._isUnexpected) {
-                                var newError = new UnexpectedError(that.expect, assertion, e);
-                                truncateStack(newError, wrappedExpect);
-                                throw newError;
+                                throw new UnexpectedError(that.expect, assertion, e);
                             }
                             throw e;
                         });
@@ -664,7 +661,6 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
                     }
                 } catch (e) {
                     if (e && e._isUnexpected) {
-                        truncateStack(e, wrappedExpect);
                         var wrappedError = new UnexpectedError(that.expect, assertion, e);
                         if (serializeErrorsFromWrappedExpect) {
                             that.setErrorMessage(wrappedError);
@@ -808,7 +804,6 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
             if (typeof mochaPhantomJS !== 'undefined') {
                 newError = e.clone();
             }
-            truncateStack(newError, that.expect);
             that.setErrorMessage(newError);
             throw newError;
         }
@@ -3606,23 +3601,6 @@ var utils = module.exports = {
             });
         }
         return target;
-    },
-
-    truncateStack: function (err, fn) {
-        if (Error.captureStackTrace) {
-            Error.captureStackTrace(err, fn);
-        } else if ('stack' in err) {
-            // Excludes IE<10, and fn cannot be anonymous for this backup plan to work:
-            var stackEntries = err.stack.split(/\r\n?|\n\r?/),
-            needle = 'at ' + fn.name + ' ';
-            for (var i = 0 ; i < stackEntries.length ; i += 1) {
-                if (stackEntries[i].indexOf(needle) !== -1) {
-                    stackEntries.splice(1, i);
-                    err.stack = stackEntries.join("\n");
-                }
-            }
-        }
-        return err;
     },
 
     findFirst: function (arr, predicate, thisObj) {


### PR DESCRIPTION
Seems like mocha >2.2.2 is doing a better job than we are in most cases, so I think we should stop trying.

Here's the discussion of the mocha feature: https://github.com/mochajs/mocha/pull/1564