### PR TITLE
Added custom inspect function for UnexpectedError.

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -568,6 +568,16 @@ module.exports = function (expect) {
             return this.baseType.getKeys(value).filter(function (key) {
                 return !unexpectedErrorMethodBlacklist[key];
             });
+        },
+        inspect: function (value, depth, output) {
+            output.jsFunctionName(this.name).text('(');
+            var errorMessage = value.getErrorMessage();
+            if (errorMessage.isMultiline()) {
+                output.nl().indentLines().i().block(errorMessage).nl();
+            } else {
+                output.append(errorMessage);
+            }
+            output.text(')');
         }
     });
 

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -1149,7 +1149,7 @@ describe('unexpected', function () {
                                 "  -expected 1 to equal 2\n" +
                                 "  +expected 3 to equal 2"
                         );
-                        expect(message, 'to match', /^expected\sUnexpectedError\(\{[\s\S]*\}\)/);
+                        expect(message, 'to match', /^expected\sUnexpectedError\([\s\S]*\)/);
                     });
                 });
             });
@@ -1169,6 +1169,37 @@ describe('unexpected', function () {
                         "\n" +
                         "  -Bummer!\n" +
                         "  +Dammit!"
+                    );
+                });
+            });
+        });
+    });
+
+    describe('UnexpectedError', function () {
+        describe('with a single line message', function () {
+            it('should be inspected correctly', function () {
+                expect(function () {
+                    expect(2, 'to equal', 4);
+                }, 'to throw', function (err) {
+                    expect(err, 'to inspect as', 'UnexpectedError(expected 2 to equal 4)');
+                });
+            });
+        });
+
+        describe('with a multiline message', function () {
+            it('should be inspected correctly', function () {
+                expect(function () {
+                    expect('foo', 'to equal', 'bar');
+                }, 'to throw', function (err) {
+                    expect(
+                        err,
+                        'to inspect as',
+                        "UnexpectedError(\n" +
+                        "  expected 'foo' to equal 'bar'\n" +
+                        "\n" +
+                        "  -foo\n" +
+                        "  +bar\n" +
+                        ")"
                     );
                 });
             });

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -1204,6 +1204,14 @@ describe('unexpected', function () {
                 });
             });
         });
+
+        it('#getKeys should return a trimmed-down list', function () {
+            expect(function () {
+                expect('foo', 'to equal', 'bar');
+            }, 'to throw', function (err) {
+                expect(expect.findTypeOf(err).getKeys(err), 'to equal', [ 'message', 'errorMode', 'parent' ]);
+            });
+        });
     });
 
     describe('Date type', function () {


### PR DESCRIPTION
It now simply inspects as `UnexpectedError(<message>)`.

Multiline messages are inspected as:

```
UnexpectedError(
  <first line of message>...
  <second line of message>
  ...
)
```

This is a prerequisite for getting promises returned from `expect` inspected nicely in the node.js repl.