### PR TITLE
expect.fail with an object: Set all properties on the UnexpectedError.

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -273,8 +273,7 @@ Unexpected.prototype.fail = function (arg) {
         throw arg;
     }
     var output = this.output.clone();
-    var createDiff = null;
-    var label = null;
+    var additionalProperties = {};
     if (typeof arg === 'function') {
         arg.call(output, output);
     } else if (arg && typeof arg === 'object') {
@@ -289,12 +288,14 @@ Unexpected.prototype.fail = function (arg) {
         } else {
             output.error('Explicit failure');
         }
-        if (typeof arg.diff === 'function') {
-            createDiff = arg.diff;
-        }
-        if (typeof arg.label === 'string') {
-            label = arg.label;
-        }
+        Object.keys(arg).forEach(function (key) {
+            var value = arg[key];
+            if (key === 'diff') {
+                additionalProperties.createDiff = value;
+            } else if (key !== 'message') {
+                additionalProperties[key] = value;
+            }
+        });
     } else {
         var that = this;
         var message = arg ? String(arg) : 'Explicit failure';
@@ -323,12 +324,9 @@ Unexpected.prototype.fail = function (arg) {
 
     var error = new UnexpectedError(this.expect);
     error.output = output;
-    if (createDiff) {
-        error.createDiff = createDiff;
-    }
-    if (typeof label === 'string') {
-        error.label = label;
-    }
+    Object.keys(additionalProperties).forEach(function (key) {
+        error[key] = additionalProperties[key];
+    });
     throw error;
 };
 

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -5855,6 +5855,30 @@ describe('unexpected', function () {
         });
     });
 
+    describe('fail', function () {
+        describe('with an object', function () {
+            it('should support specifying a label', function () {
+                expect(function () {
+                    expect.fail({
+                        label: 'to yadda'
+                    });
+                }, 'to throw', {
+                    label: 'to yadda'
+                });
+            });
+
+            it('should set additional properties on the thrown error', function () {
+                expect(function () {
+                    expect.fail({
+                        foobarquux: 123
+                    });
+                }, 'to throw', {
+                    foobarquux: 123
+                });
+            });
+        });
+    });
+
     describe('async', function () {
         before(function () {
             expect = expect.clone()

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -5876,6 +5876,26 @@ describe('unexpected', function () {
                     foobarquux: 123
                 });
             });
+
+            it('should support message passed as a string', function () {
+                expect(function () {
+                    expect.fail({
+                        message: 'hey'
+                    });
+                }, 'to throw', {
+                    message: '\nhey'
+                });
+            });
+
+            it('should support message passed as a MagicPen instance', function () {
+                expect(function () {
+                    expect.fail({
+                        message: expect.output.clone().text('hey')
+                    });
+                }, 'to throw', {
+                    message: '\nhey'
+                });
+            });
         });
     });
 


### PR DESCRIPTION
Fixes #173.