### PR TITLE
Pull the unexpected-promise plugin into core.

### DIFF
--- a/documentation/assertions/Promise/to-be-fulfilled.md
+++ b/documentation/assertions/Promise/to-be-fulfilled.md
@@ -21,7 +21,8 @@ return expect(rejectedPromise, 'to be fulfilled');
 ```
 
 ```output
-expected Promise (rejected) to be fulfilled
+expected Promise (rejected) => Error('argh') to be fulfilled
+  Promise (rejected) => Error('argh') unexpectedly rejected with Error('argh')
 ```
 
 You can assert the promise is fulfilled with a specific value by
@@ -36,7 +37,7 @@ var promiseThatWillBeFulfilledWithAValue = expect.promise(function (resolve, rej
 ```
 
 ```javascript#async:true
-return expect(promiseThatWillBeFulfilledWithAValue, 'to be fulfilled with', 'def');
+return expect(promiseThatWillBeFulfilledWithAValue, 'to be fulfilled with', 'abc');
 ```
 
 The expected value will be matched against the value with
@@ -56,8 +57,8 @@ return expect(promiseThatWillBeFulfilledWithAValue, 'to be fulfilled with', 'def
 
 ```output
 expected Promise (fulfilled) => 'abc' to be fulfilled with 'def'
-  expected 'abc' to equal 'def'
+  expected 'abc' to satisfy 'def'
 
-  -def
-  +abc
+  -abc
+  +def
 ```

--- a/documentation/assertions/Promise/to-be-fulfilled.md
+++ b/documentation/assertions/Promise/to-be-fulfilled.md
@@ -57,7 +57,7 @@ return expect(promiseThatWillBeFulfilledWithAValue, 'to be fulfilled with', 'def
 
 ```output
 expected Promise (fulfilled) => 'abc' to be fulfilled with 'def'
-  expected 'abc' to satisfy 'def'
+  expected 'abc' to equal 'def'
 
   -abc
   +def

--- a/documentation/assertions/Promise/to-be-fulfilled.md
+++ b/documentation/assertions/Promise/to-be-fulfilled.md
@@ -1,11 +1,11 @@
-Asserts that a promise is resolved.
+Asserts that a promise is fulfilled.
 
 ```javascript#async:true
-var promiseThatWillBeResolved = expect.promise(function (resolve, reject) {
+var promiseThatWillBeFulfilled = expect.promise(function (resolve, reject) {
     setTimeout(resolve, 1);
 });
 
-return expect(promiseThatWillBeResolved, 'to be resolved');
+return expect(promiseThatWillBeFulfilled, 'to be fulfilled');
 ```
 
 If the promise is rejected, the assertion will fail with the following output:
@@ -17,18 +17,18 @@ var rejectedPromise = expect.promise(function (resolve, reject) {
     }, 1);
 });
 
-return expect(rejectedPromise, 'to be resolved');
+return expect(rejectedPromise, 'to be fulfilled');
 ```
 
 ```output
-expected Promise (rejected) to be resolved
+expected Promise (rejected) to be fulfilled
 ```
 
-You can assert the promise is resolved with a specific value by
+You can assert the promise is fulfilled with a specific value by
 passing a second parameter:
 
 ```javascript
-var promiseThatWillBeResolvedWithAValue = expect.promise(function (resolve, reject) {
+var promiseThatWillBeFulfilledWithAValue = expect.promise(function (resolve, reject) {
     setTimeout(function () {
         resolve('abc');
     }, 1);
@@ -36,7 +36,7 @@ var promiseThatWillBeResolvedWithAValue = expect.promise(function (resolve, reje
 ```
 
 ```javascript#async:true
-return expect(promiseThatWillBeResolvedWithAValue, 'to be resolved with', 'def');
+return expect(promiseThatWillBeFulfilledWithAValue, 'to be fulfilled with', 'def');
 ```
 
 The expected value will be matched against the value with
@@ -45,17 +45,17 @@ a regular expression, a function, or an object:
 
 
 ```javascript#async:true
-return expect(promiseThatWillBeResolvedWithAValue, 'to be resolved with', /b/);
+return expect(promiseThatWillBeFulfilledWithAValue, 'to be fulfilled with', /b/);
 ```
 
 You get a nice diff if the assertion fails:
 
 ```javascript#async:true
-return expect(promiseThatWillBeResolvedWithAValue, 'to be resolved with', 'def');
+return expect(promiseThatWillBeFulfilledWithAValue, 'to be fulfilled with', 'def');
 ```
 
 ```output
-expected Promise (resolved) => 'abc' to be resolved with 'def'
+expected Promise (fulfilled) => 'abc' to be fulfilled with 'def'
   expected 'abc' to equal 'def'
 
   -def

--- a/documentation/assertions/Promise/to-be-rejected.md
+++ b/documentation/assertions/Promise/to-be-rejected.md
@@ -1,0 +1,65 @@
+Asserts that a promise is rejected.
+
+```javascript#async:true
+var promiseThatWillBeRejected = expect.promise(function (resolve, reject) {
+    setTimeout(reject, 1);
+});
+
+return expect(promiseThatWillBeRejected, 'to be rejected');
+```
+
+If the promise is resolved, the assertion will fail with the following output:
+
+```javascript#async:true
+var resolvedPromise = expect.promise(function (resolve, reject) {
+    setTimeout(resolve, 1);
+});
+
+return expect(resolvedPromise, 'to be rejected');
+```
+
+```output
+expected Promise (fulfilled) to be rejected
+  Promise (fulfilled) unexpectedly fulfilled
+```
+
+You can assert the promise is rejected with a specific reason (error) by
+passing a second parameter:
+
+```javascript
+var promiseThatWillBeRejectedWithAReason = expect.promise(function (resolve, reject) {
+    setTimeout(function () {
+        reject(new Error('Oh dear'));
+    }, 1);
+});
+```
+
+```javascript#async:true
+return expect(promiseThatWillBeRejectedWithAReason, 'to be rejected with', new Error('Oh dear'));
+```
+
+The expected reason will be matched against the rejection reason with
+[to satisfy](/assertions/any/to-satisfy/) semantics, so you can also pass a string,
+a regular expression, a function, or an object:
+
+
+```javascript#async:true
+return expect(promiseThatWillBeRejectedWithAReason, 'to be rejected with', /dear/);
+```
+
+You get a nice diff if the assertion fails:
+
+```javascript#async:true
+return expect(promiseThatWillBeRejectedWithAReason, 'to be rejected with', new Error('bugger'));
+```
+
+```output
+expected Promise (rejected) => Error('Oh dear') to be rejected with Error('bugger')
+  expected Error('Oh dear') to satisfy Error('bugger')
+
+  Error({
+    message: 'Oh dear' // should equal 'bugger'
+                       // -Oh dear
+                       // +bugger
+  })
+```

--- a/documentation/assertions/Promise/to-be-resolved.md
+++ b/documentation/assertions/Promise/to-be-resolved.md
@@ -1,0 +1,63 @@
+Asserts that a promise is resolved.
+
+```javascript#async:true
+var promiseThatWillBeResolved = expect.promise(function (resolve, reject) {
+    setTimeout(resolve, 1);
+});
+
+return expect(promiseThatWillBeResolved, 'to be resolved');
+```
+
+If the promise is rejected, the assertion will fail with the following output:
+
+```javascript#async:true
+var rejectedPromise = expect.promise(function (resolve, reject) {
+    setTimeout(function () {
+        reject(new Error('argh'));
+    }, 1);
+});
+
+return expect(rejectedPromise, 'to be resolved');
+```
+
+```output
+expected Promise (rejected) to be resolved
+```
+
+You can assert the promise is resolved with a specific value by
+passing a second parameter:
+
+```javascript
+var promiseThatWillBeResolvedWithAValue = expect.promise(function (resolve, reject) {
+    setTimeout(function () {
+        resolve('abc');
+    }, 1);
+});
+```
+
+```javascript#async:true
+return expect(promiseThatWillBeResolvedWithAValue, 'to be resolved with', 'def');
+```
+
+The expected value will be matched against the value with
+[to satisfy](/assertions/any/to-satisfy/) semantics, so you can also pass a string,
+a regular expression, a function, or an object:
+
+
+```javascript#async:true
+return expect(promiseThatWillBeResolvedWithAValue, 'to be resolved with', /b/);
+```
+
+You get a nice diff if the assertion fails:
+
+```javascript#async:true
+return expect(promiseThatWillBeResolvedWithAValue, 'to be resolved with', 'def');
+```
+
+```output
+expected Promise (resolved) => 'abc' to be resolved with 'def'
+  expected 'abc' to equal 'def'
+
+  -def
+  +abc
+```

--- a/documentation/assertions/Promise/when-fulfilled.md
+++ b/documentation/assertions/Promise/when-fulfilled.md
@@ -1,0 +1,36 @@
+Wait for a promise to be fulfilled, then delegate the value to another assertion.
+
+```javascript
+var fulfilledPromise = expect.promise(function (resolve, reject) {
+    setTimeout(function () {
+        resolve(123);
+    });
+});
+```
+
+```javascript#async:true
+return expect(fulfilledPromise, 'when fulfilled', 'to equal', 123);
+```
+
+It works with any assertion or `expect.it` construct:
+
+```javascript#async:true
+return expect(fulfilledPromise, 'when fulfilled', expect.it('to be greater than', 100));
+```
+
+If the response is rejected, the assertion fails with the following output:
+
+```javascript#async:true
+var rejectedPromise = expect.promise(function (resolve, reject) {
+    setTimeout(function () {
+        reject(new Error('argh'));
+    });
+});
+
+return expect(rejectedPromise, 'when fulfilled', 'to equal', 123);
+```
+
+```output
+expected Promise (rejected) => Error('argh') when fulfilled to equal 123
+  Promise (rejected) => Error('argh') unexpectedly rejected with Error('argh')
+```

--- a/documentation/assertions/Promise/when-rejected.md
+++ b/documentation/assertions/Promise/when-rejected.md
@@ -1,0 +1,36 @@
+Wait for a promise to be rejected, then delegate the reason to another assertion.
+
+```javascript
+var rejectedPromise = expect.promise(function (resolve, reject) {
+    setTimeout(function () {
+        reject(new Error('argh'));
+    });
+});
+```
+
+```javascript#async:true
+return expect(rejectedPromise, 'when rejected', 'to equal', new Error('argh'));
+```
+
+It works with any assertion or `expect.it` construct:
+
+```javascript#async:true
+return expect(rejectedPromise, 'when rejected', expect.it('to have message', 'argh'));
+```
+
+If the response is fulfilled, the assertion fails with the following output:
+
+```javascript#async:true
+var fulfilledPromise = expect.promise(function (resolve, reject) {
+    setTimeout(function () {
+        resolve(123);
+    });
+});
+
+return expect(fulfilledPromise, 'when rejected', 'to have message', 'argh');
+```
+
+```output
+expected Promise (fulfilled) => 123 when rejected to have message 'argh'
+  Promise (fulfilled) => 123 unexpectedly fulfilled with 123
+```

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -937,6 +937,13 @@ module.exports = function (expect) {
             if (flags['with'] || typeof value !== 'undefined') {
                 return expect(obj, 'to satisfy', value);
             }
+        }, function (err) {
+            expect.fail(function (output) {
+                output.append(expect.inspect(subject)).sp().text('unexpectedly rejected');
+                if (typeof err !== 'undefined') {
+                    output.sp().text('with').sp().append(expect.inspect(err));
+                }
+            });
         });
     });
 

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -962,7 +962,7 @@ module.exports = function (expect) {
         });
     });
 
-    expect.addAssertion('Promise', 'when resolved', function (expect, subject) {
+    expect.addAssertion('Promise', 'when fulfilled', function (expect, subject) {
         this.errorMode = 'nested';
         var that = this;
         return subject.then(function (value) {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -947,10 +947,13 @@ module.exports = function (expect) {
         });
     });
 
-    expect.addAssertion('Promise', 'when rejected', function (expect, subject) {
+    expect.addAssertion('Promise', 'when rejected', function (expect, subject, nextAssertion) {
         this.errorMode = 'nested';
         var that = this;
         return subject.then(function (obj) {
+            if (typeof nextAssertion === 'string') {
+                that.args[0] = expect.output.clone().error(nextAssertion);
+            }
             expect.fail(function (output) {
                 output.append(expect.inspect(subject)).sp().text('unexpectedly fulfilled');
                 if (typeof obj !== 'undefined') {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -930,7 +930,7 @@ module.exports = function (expect) {
         });
     });
 
-    expect.addAssertion('Promise', 'to be resolved [with]', function (expect, subject, value) {
+    expect.addAssertion('Promise', 'to be fulfilled [with]', function (expect, subject, value) {
         this.errorMode = 'nested';
         var flags = this.flags;
         return subject.then(function (obj) {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -962,11 +962,21 @@ module.exports = function (expect) {
         });
     });
 
-    expect.addAssertion('Promise', 'when fulfilled', function (expect, subject) {
+    expect.addAssertion('Promise', 'when fulfilled', function (expect, subject, nextAssertion) {
         this.errorMode = 'nested';
         var that = this;
         return subject.then(function (value) {
             return that.shift(value, 0);
+        }, function (err) {
+            if (typeof nextAssertion === 'string') {
+                that.args[0] = expect.output.clone().error(nextAssertion);
+            }
+            expect.fail(function (output) {
+                output.append(expect.inspect(subject)).sp().text('unexpectedly rejected');
+                if (typeof err !== 'undefined') {
+                    output.sp().text('with').sp().append(expect.inspect(err));
+                }
+            });
         });
     });
 };

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -908,4 +908,58 @@ module.exports = function (expect) {
         this.errorMode = 'bubble';
         return expect.apply(expect, [[subject], 'when passed as parameters to [async] [constructor]'].concat(this.args));
     });
+
+    expect.addAssertion('Promise', 'to be rejected [with]', function (expect, subject, value) {
+        this.errorMode = 'nested';
+        var flags = this.flags;
+        return subject.then(function (obj) {
+            expect.fail(function (output) {
+                output.append(expect.inspect(subject)).sp().text('unexpectedly fulfilled');
+                if (typeof obj !== 'undefined') {
+                    output.sp().text('with').sp().append(expect.inspect(obj));
+                }
+            });
+        }, function (err) {
+            if (flags['with'] || typeof value !== 'undefined') {
+                if (err && err._isUnexpected && (typeof value === 'string' || isRegExp(value))) {
+                    return expect(err.getErrorMessage().toString(), 'to satisfy', value);
+                } else {
+                    return expect(err, 'to satisfy', value);
+                }
+            }
+        });
+    });
+
+    expect.addAssertion('Promise', 'to be resolved [with]', function (expect, subject, value) {
+        this.errorMode = 'nested';
+        var flags = this.flags;
+        return subject.then(function (obj) {
+            if (flags['with'] || typeof value !== 'undefined') {
+                return expect(obj, 'to satisfy', value);
+            }
+        });
+    });
+
+    expect.addAssertion('Promise', 'when rejected', function (expect, subject) {
+        this.errorMode = 'nested';
+        var that = this;
+        return subject.then(function (obj) {
+            expect.fail(function (output) {
+                output.append(expect.inspect(subject)).sp().text('unexpectedly fulfilled');
+                if (typeof obj !== 'undefined') {
+                    output.sp().text('with').sp().append(expect.inspect(obj));
+                }
+            });
+        }, function (err) {
+            return that.shift(err, 0);
+        });
+    });
+
+    expect.addAssertion('Promise', 'when resolved', function (expect, subject) {
+        this.errorMode = 'nested';
+        var that = this;
+        return subject.then(function (value) {
+            return that.shift(value, 0);
+        });
+    });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,25 +11,7 @@ assertions(unexpected);
 
 // Add an inspect method to all the promises we return that will make the REPL, console.log, and util.inspect render it nicely in node.js:
 require('bluebird').prototype.inspect = function () {
-    var output = unexpected.output.clone()
-        .jsFunctionName('Promise')
-        .sp();
-    if (this.isPending()) {
-        output.yellow('(pending)');
-    } else if (this.isFulfilled()) {
-        output.green('(fulfilled)');
-        var value = this.value();
-        if (typeof value !== 'undefined') {
-            output.sp().text('=>').sp().append(unexpected.inspect(value));
-        }
-    } else if (this.isRejected()) {
-        output.red('(rejected)');
-        var reason = this.reason();
-        if (typeof reason !== 'undefined') {
-            output.sp().text('=>').sp().append(unexpected.inspect(this.reason()));
-        }
-    }
-    return output.toString(require('magicpen').defaultFormat);
+    return unexpected.inspect(this).toString(require('magicpen').defaultFormat);
 };
 
 module.exports = unexpected;

--- a/lib/types.js
+++ b/lib/types.js
@@ -680,6 +680,34 @@ module.exports = function (expect) {
     });
 
     expect.addType({
+        name: 'Promise',
+        base: 'object',
+        identify: function (obj) {
+            return obj && this.baseType.identify(obj) && typeof obj.then === 'function';
+        },
+        inspect: function (promise, depth, output, inspect) {
+            output.jsFunctionName('Promise');
+            if (promise.isPending && promise.isPending()) {
+                output.sp().yellow('(pending)');
+            } else if (promise.isFulfilled && promise.isFulfilled()) {
+                output.sp().green('(fulfilled)');
+                if (promise.value) {
+                    var value = promise.value();
+                    if (typeof value !== 'undefined') {
+                        output.sp().text('=>').sp().append(inspect(value));
+                    }
+                }
+            } else if (promise.isRejected && promise.isRejected()) {
+                output.sp().red('(rejected)');
+                var reason = promise.reason();
+                if (typeof reason !== 'undefined') {
+                    output.sp().text('=>').sp().append(inspect(promise.reason()));
+                }
+            }
+        }
+    });
+
+    expect.addType({
         name: 'regexp',
         identify: isRegExp,
         equal: function (a, b) {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "mocha-phantomjs": "3.5.3",
     "mocha-slow-reporter": "*",
     "phantomjs": "1.9.15",
+    "rsvp": "3.0.18",
     "serve": "*",
     "unexpected-documentation-site-generator": "2.3.1"
   }

--- a/test/documentation.spec.js
+++ b/test/documentation.spec.js
@@ -1187,6 +1187,83 @@ describe("documentation tests", function () {
         return expect.promise.all(testPromises);
     });
 
+    it("assertions/Promise/to-be-fulfilled.md contains correct examples", function () {
+        var testPromises = [];
+        testPromises.push(expect.promise(function () {
+            var promiseThatWillBeFulfilled = expect.promise(function (resolve, reject) {
+                setTimeout(resolve, 1);
+            });
+
+            return expect(promiseThatWillBeFulfilled, 'to be fulfilled');
+        }));
+
+        testPromises.push(expect.promise(function () {
+            var rejectedPromise = expect.promise(function (resolve, reject) {
+                setTimeout(function () {
+                    reject(new Error('argh'));
+                }, 1);
+            });
+
+            return expect(rejectedPromise, 'to be fulfilled');
+        }).then(function () {
+            return expect.promise(function () {
+                expect.fail(function (output) {
+                    output.error("expected:").nl();
+                    output.code("var rejectedPromise = expect.promise(function (resolve, reject) {").nl();
+                    output.code("    setTimeout(function () {").nl();
+                    output.code("        reject(new Error('argh'));").nl();
+                    output.code("    }, 1);").nl();
+                    output.code("});").nl();
+                    output.code("").nl();
+                    output.code("return expect(rejectedPromise, 'to be fulfilled');").nl();
+                    output.error("to throw");
+                });
+            });
+        }).caught(function (e) {
+            expect(e, "to have message",
+                "expected Promise (rejected) => Error('argh') to be fulfilled\n" +
+                "  Promise (rejected) => Error('argh') unexpectedly rejected with Error('argh')"
+            );
+        }));
+
+
+        var promiseThatWillBeFulfilledWithAValue = expect.promise(function (resolve, reject) {
+            setTimeout(function () {
+                resolve('abc');
+            }, 1);
+        });
+
+        testPromises.push(expect.promise(function () {
+            return expect(promiseThatWillBeFulfilledWithAValue, 'to be fulfilled with', 'abc');
+        }));
+
+        testPromises.push(expect.promise(function () {
+            return expect(promiseThatWillBeFulfilledWithAValue, 'to be fulfilled with', /b/);
+        }));
+
+        testPromises.push(expect.promise(function () {
+            return expect(promiseThatWillBeFulfilledWithAValue, 'to be fulfilled with', 'def');
+        }).then(function () {
+            return expect.promise(function () {
+                expect.fail(function (output) {
+                    output.error("expected:").nl();
+                    output.code("return expect(promiseThatWillBeFulfilledWithAValue, 'to be fulfilled with', 'def');").nl();
+                    output.error("to throw");
+                });
+            });
+        }).caught(function (e) {
+            expect(e, "to have message",
+                "expected Promise (fulfilled) => 'abc' to be fulfilled with 'def'\n" +
+                "  expected 'abc' to satisfy 'def'\n" +
+                "\n" +
+                "  -abc\n" +
+                "  +def"
+            );
+        }));
+
+        return expect.promise.all(testPromises);
+    });
+
     it("assertions/Promise/to-be-rejected.md contains correct examples", function () {
         var testPromises = [];
         testPromises.push(expect.promise(function () {

--- a/test/documentation.spec.js
+++ b/test/documentation.spec.js
@@ -1254,7 +1254,7 @@ describe("documentation tests", function () {
         }).caught(function (e) {
             expect(e, "to have message",
                 "expected Promise (fulfilled) => 'abc' to be fulfilled with 'def'\n" +
-                "  expected 'abc' to satisfy 'def'\n" +
+                "  expected 'abc' to equal 'def'\n" +
                 "\n" +
                 "  -abc\n" +
                 "  +def"
@@ -1334,6 +1334,102 @@ describe("documentation tests", function () {
                 "                       // -Oh dear\n" +
                 "                       // +bugger\n" +
                 "  })"
+            );
+        }));
+
+        return expect.promise.all(testPromises);
+    });
+
+    it("assertions/Promise/when-fulfilled.md contains correct examples", function () {
+        var testPromises = [];
+        var fulfilledPromise = expect.promise(function (resolve, reject) {
+            setTimeout(function () {
+                resolve(123);
+            });
+        });
+
+        testPromises.push(expect.promise(function () {
+            return expect(fulfilledPromise, 'when fulfilled', 'to equal', 123);
+        }));
+
+        testPromises.push(expect.promise(function () {
+            return expect(fulfilledPromise, 'when fulfilled', expect.it('to be greater than', 100));
+        }));
+
+        testPromises.push(expect.promise(function () {
+            var rejectedPromise = expect.promise(function (resolve, reject) {
+                setTimeout(function () {
+                    reject(new Error('argh'));
+                });
+            });
+
+            return expect(rejectedPromise, 'when fulfilled', 'to equal', 123);
+        }).then(function () {
+            return expect.promise(function () {
+                expect.fail(function (output) {
+                    output.error("expected:").nl();
+                    output.code("var rejectedPromise = expect.promise(function (resolve, reject) {").nl();
+                    output.code("    setTimeout(function () {").nl();
+                    output.code("        reject(new Error('argh'));").nl();
+                    output.code("    });").nl();
+                    output.code("});").nl();
+                    output.code("").nl();
+                    output.code("return expect(rejectedPromise, 'when fulfilled', 'to equal', 123);").nl();
+                    output.error("to throw");
+                });
+            });
+        }).caught(function (e) {
+            expect(e, "to have message",
+                "expected Promise (rejected) => Error('argh') when fulfilled to equal 123\n" +
+                "  Promise (rejected) => Error('argh') unexpectedly rejected with Error('argh')"
+            );
+        }));
+
+        return expect.promise.all(testPromises);
+    });
+
+    it("assertions/Promise/when-rejected.md contains correct examples", function () {
+        var testPromises = [];
+        var rejectedPromise = expect.promise(function (resolve, reject) {
+            setTimeout(function () {
+                reject(new Error('argh'));
+            });
+        });
+
+        testPromises.push(expect.promise(function () {
+            return expect(rejectedPromise, 'when rejected', 'to equal', new Error('argh'));
+        }));
+
+        testPromises.push(expect.promise(function () {
+            return expect(rejectedPromise, 'when rejected', expect.it('to have message', 'argh'));
+        }));
+
+        testPromises.push(expect.promise(function () {
+            var fulfilledPromise = expect.promise(function (resolve, reject) {
+                setTimeout(function () {
+                    resolve(123);
+                });
+            });
+
+            return expect(fulfilledPromise, 'when rejected', 'to have message', 'argh');
+        }).then(function () {
+            return expect.promise(function () {
+                expect.fail(function (output) {
+                    output.error("expected:").nl();
+                    output.code("var fulfilledPromise = expect.promise(function (resolve, reject) {").nl();
+                    output.code("    setTimeout(function () {").nl();
+                    output.code("        resolve(123);").nl();
+                    output.code("    });").nl();
+                    output.code("});").nl();
+                    output.code("").nl();
+                    output.code("return expect(fulfilledPromise, 'when rejected', 'to have message', 'argh');").nl();
+                    output.error("to throw");
+                });
+            });
+        }).caught(function (e) {
+            expect(e, "to have message",
+                "expected Promise (fulfilled) => 123 when rejected to have message 'argh'\n" +
+                "  Promise (fulfilled) => 123 unexpectedly fulfilled with 123"
             );
         }));
 

--- a/test/documentation.spec.js
+++ b/test/documentation.spec.js
@@ -1187,6 +1187,82 @@ describe("documentation tests", function () {
         return expect.promise.all(testPromises);
     });
 
+    it("assertions/Promise/to-be-rejected.md contains correct examples", function () {
+        var testPromises = [];
+        testPromises.push(expect.promise(function () {
+            var promiseThatWillBeRejected = expect.promise(function (resolve, reject) {
+                setTimeout(reject, 1);
+            });
+
+            return expect(promiseThatWillBeRejected, 'to be rejected');
+        }));
+
+        testPromises.push(expect.promise(function () {
+            var resolvedPromise = expect.promise(function (resolve, reject) {
+                setTimeout(resolve, 1);
+            });
+
+            return expect(resolvedPromise, 'to be rejected');
+        }).then(function () {
+            return expect.promise(function () {
+                expect.fail(function (output) {
+                    output.error("expected:").nl();
+                    output.code("var resolvedPromise = expect.promise(function (resolve, reject) {").nl();
+                    output.code("    setTimeout(resolve, 1);").nl();
+                    output.code("});").nl();
+                    output.code("").nl();
+                    output.code("return expect(resolvedPromise, 'to be rejected');").nl();
+                    output.error("to throw");
+                });
+            });
+        }).caught(function (e) {
+            expect(e, "to have message",
+                "expected Promise (fulfilled) to be rejected\n" +
+                "  Promise (fulfilled) unexpectedly fulfilled"
+            );
+        }));
+
+
+        var promiseThatWillBeRejectedWithAReason = expect.promise(function (resolve, reject) {
+            setTimeout(function () {
+                reject(new Error('Oh dear'));
+            }, 1);
+        });
+
+        testPromises.push(expect.promise(function () {
+            return expect(promiseThatWillBeRejectedWithAReason, 'to be rejected with', new Error('Oh dear'));
+        }));
+
+        testPromises.push(expect.promise(function () {
+            return expect(promiseThatWillBeRejectedWithAReason, 'to be rejected with', /dear/);
+        }));
+
+        testPromises.push(expect.promise(function () {
+            return expect(promiseThatWillBeRejectedWithAReason, 'to be rejected with', new Error('bugger'));
+        }).then(function () {
+            return expect.promise(function () {
+                expect.fail(function (output) {
+                    output.error("expected:").nl();
+                    output.code("return expect(promiseThatWillBeRejectedWithAReason, 'to be rejected with', new Error('bugger'));").nl();
+                    output.error("to throw");
+                });
+            });
+        }).caught(function (e) {
+            expect(e, "to have message",
+                "expected Promise (rejected) => Error('Oh dear') to be rejected with Error('bugger')\n" +
+                "  expected Error('Oh dear') to satisfy Error('bugger')\n" +
+                "\n" +
+                "  Error({\n" +
+                "    message: 'Oh dear' // should equal 'bugger'\n" +
+                "                       // -Oh dear\n" +
+                "                       // +bugger\n" +
+                "  })"
+            );
+        }));
+
+        return expect.promise.all(testPromises);
+    });
+
     it("assertions/any/to-be-a.md contains correct examples", function () {
         var testPromises = [];
         expect(true, 'to be a', 'boolean');

--- a/test/tests.html
+++ b/test/tests.html
@@ -8,6 +8,7 @@
     <div id="mocha"></div>
     <script src="../vendor/es5-shim.js"></script>
     <script src="../vendor/es5-sham.js"></script>
+    <script src="../vendor/rsvp.js"></script>
     <script src="../vendor/mocha.js"></script>
     <script>mocha.setup('bdd')</script>
     <script src="../unexpected.js"></script>

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -1373,6 +1373,19 @@ describe('unexpected', function () {
                 }), 'when fulfilled', 'to satisfy', { foo: 'bar' });
             });
 
+            it('should fail when the promise is rejected', function () {
+                return expect(
+                    expect(new Promise(function (resolve, reject) {
+                        setTimeout(function () {
+                            reject(new Error('ugh'));
+                        }, 0);
+                    }), 'when fulfilled', 'to satisfy', { foo: 'baz' }),
+                    'to be rejected with',
+                        "expected Promise when fulfilled to satisfy { foo: 'baz' }\n" +
+                        "  Promise unexpectedly rejected with Error('ugh')"
+                );
+            });
+
             it('should fail when the next assertion fails', function () {
                 return expect(
                     expect(new Promise(function (resolve, reject) {

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -1364,13 +1364,13 @@ describe('unexpected', function () {
             });
         });
 
-        describe('"when resolved" adverbial assertion', function () {
+        describe('"when fulfilled" adverbial assertion', function () {
             it('should delegate to the next assertion with the resolved value', function () {
                 return expect(new Promise(function (resolve, reject) {
                     setTimeout(function () {
                         resolve({ foo: 'bar' });
                     }, 0);
-                }), 'when resolved', 'to satisfy', { foo: 'bar' });
+                }), 'when fulfilled', 'to satisfy', { foo: 'bar' });
             });
 
             it('should fail when the next assertion fails', function () {
@@ -1379,9 +1379,9 @@ describe('unexpected', function () {
                         setTimeout(function () {
                             resolve({ foo: 'bar' });
                         }, 0);
-                    }), 'when resolved', 'to satisfy', { foo: 'baz' }),
+                    }), 'when fulfilled', 'to satisfy', { foo: 'baz' }),
                     'to be rejected with',
-                        "expected Promise when resolved to satisfy { foo: 'baz' }\n" +
+                        "expected Promise when fulfilled to satisfy { foo: 'baz' }\n" +
                         "  expected { foo: 'bar' } to satisfy { foo: 'baz' }\n" +
                         "\n" +
                         "  {\n" +

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -1440,7 +1440,7 @@ describe('unexpected', function () {
                         setTimeout(resolve, 0);
                     }), 'when rejected', 'to equal', new Error('unhappy times')),
                     'to be rejected with',
-                        "expected Promise when rejected 'to equal', Error('unhappy times')\n" +
+                        "expected Promise when rejected to equal Error('unhappy times')\n" +
                         "  Promise unexpectedly fulfilled"
                 );
             });
@@ -1453,7 +1453,7 @@ describe('unexpected', function () {
                         }, 0);
                     }), 'when rejected', 'to equal', new Error('unhappy times')),
                     'to be rejected with',
-                        "expected Promise when rejected 'to equal', Error('unhappy times')\n" +
+                        "expected Promise when rejected to equal Error('unhappy times')\n" +
                         "  Promise unexpectedly fulfilled with 'happy times'"
                 );
             });

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -1210,14 +1210,14 @@ describe('unexpected', function () {
             Promise = window.RSVP.Promise;
         }
 
-        describe('"to be resolved" assertion', function () {
+        describe('"to be fulfilled" assertion', function () {
             describe('with no additional argument', function () {
                 it('should succeed if the response is resolved with any value', function () {
                     return expect(new Promise(function (resolve, reject) {
                         setTimeout(function () {
                             resolve('yay');
                         }, 0);
-                    }), 'to be resolved');
+                    }), 'to be fulfilled');
                 });
 
                 it('should fail if the promise is rejected', function () {
@@ -1226,7 +1226,7 @@ describe('unexpected', function () {
                             setTimeout(function () {
                                 reject('unhappy times');
                             }, 0);
-                        }), 'to be resolved'),
+                        }), 'to be fulfilled'),
                         'to be rejected'
                     );
                 });
@@ -1238,7 +1238,7 @@ describe('unexpected', function () {
                         setTimeout(function () {
                             resolve(123);
                         }, 0);
-                    }), 'to be resolved with', 123);
+                    }), 'to be fulfilled with', 123);
                 });
 
                 it('should fail if the promise is resolved with a value that does not satisfy the argument', function () {
@@ -1247,9 +1247,9 @@ describe('unexpected', function () {
                             setTimeout(function () {
                                 resolve({ foo: 'bar', baz: 'quux' });
                             }, 1);
-                        }), 'to be resolved with', { baz: 'qux' }),
+                        }), 'to be fulfilled with', { baz: 'qux' }),
                         'to be rejected with',
-                            "expected Promise to be resolved with { baz: 'qux' }\n" +
+                            "expected Promise to be fulfilled with { baz: 'qux' }\n" +
                             "  expected { foo: 'bar', baz: 'quux' } to satisfy { baz: 'qux' }\n" +
                             "\n" +
                             "  {\n" +
@@ -6366,7 +6366,7 @@ describe('unexpected', function () {
                     return 'bar';
                 });
             });
-            expect(clonedExpect('foo', 'to foo'), 'to be resolved', 'bar');
+            expect(clonedExpect('foo', 'to foo'), 'to be fulfilled', 'bar');
         });
 
         it('should preserve the resolved value when an assertion contains a non-oathbreakable promise', function (done) {

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -1227,7 +1227,9 @@ describe('unexpected', function () {
                                 reject('unhappy times');
                             }, 0);
                         }), 'to be fulfilled'),
-                        'to be rejected'
+                        'to be rejected',
+                            "expected Promise to be fulfilled\n" +
+                            "  Promise unexpectedly rejected with 'unhappy times'"
                     );
                 });
             });
@@ -1269,9 +1271,22 @@ describe('unexpected', function () {
                 it('should succeed if the response is rejected for any reason', function () {
                     return expect(new Promise(function (resolve, reject) {
                         setTimeout(function () {
-                            reject(new Error('OMG!'));
+                            reject();
                         }, 0);
                     }), 'to be rejected');
+                });
+
+                it('should succeed if the promise is rejected without a reason', function () {
+                    return expect(
+                        expect(new Promise(function (resolve, reject) {
+                            setTimeout(function () {
+                                resolve('happy times');
+                            }, 0);
+                        }), 'to be rejected'),
+                        'to be rejected with',
+                            "expected Promise to be rejected\n" +
+                            "  Promise unexpectedly fulfilled with 'happy times'"
+                    );
                 });
 
                 it('should fail if the promise is fulfilled', function () {

--- a/vendor/rsvp.js
+++ b/vendor/rsvp.js
@@ -1,0 +1,1 @@
+../node_modules/rsvp/dist/rsvp.js


### PR DESCRIPTION
Includes some tweaks so `expect(promise, 'to be rejected with', string/regexp)` work like 'to error' and 'to throw'.

Adds the RSVP library so the tests from unexpected-promise are still checked against a non-Bluebird implementation.