### PR TITLE
to call the callback: Resolve the promise with an array containing th…

### DIFF
--- a/documentation/assertions/function/to-call-the-callback.md
+++ b/documentation/assertions/function/to-call-the-callback.md
@@ -35,3 +35,28 @@ If you want the parameters passed to the callback to be the subject of further a
 you might be able to use the
 [when passed as parameters to](/assertions/array/when-passed-as-parameters-to/) assertion.
 
+The parameters passed to the callback are also provided as the value of the returned promise,
+so you can do further assertions like this:
+
+```javascript
+function asyncFn(cb) {
+    setTimeout(function () {
+        cb(null, 'foo');
+    });
+}
+```
+
+```javascript#async:true
+return expect(asyncFn, 'to call the callback').then(function (args) {
+    // args will be [null, 'foo'];
+});
+```
+
+Or using the Bluebird-specific `.spread` extension:
+
+```javascript#async:true
+return expect(asyncFn, 'to call the callback').spread(function (err, result) {
+    // err will be null
+    // result will be 'foo'
+});
+```

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1011,6 +1011,7 @@ module.exports = function (expect) {
                         }
                     }
                 }
+                return Array.prototype.slice.call(arguments, alternation === 'without error' ? 1 : 0);
             }));
         });
     });

--- a/test/documentation.spec.js
+++ b/test/documentation.spec.js
@@ -2424,6 +2424,25 @@ describe("documentation tests", function () {
             );
         }));
 
+
+        function asyncFn(cb) {
+            setTimeout(function () {
+                cb(null, 'foo');
+            });
+        }
+
+        testPromises.push(expect.promise(function () {
+            return expect(asyncFn, 'to call the callback').then(function (args) {
+                // args will be [null, 'foo'];
+            });
+        }));
+
+        testPromises.push(expect.promise(function () {
+            return expect(asyncFn, 'to call the callback').spread(function (err, result) {
+                // err will be null
+                // result will be 'foo'
+            });
+        }));
         return expect.promise.all(testPromises);
     });
 

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -6170,6 +6170,24 @@ describe('unexpected', function () {
             }, 'to call the callback');
         });
 
+        it('should return a promise that is fulfilled with the values passed to the callback', function () {
+            return expect(function (cb) {
+                cb(1, 2, 3, 4);
+            }, 'to call the callback').then(function (args) {
+                expect(args, 'to equal', [1, 2, 3, 4]);
+            });
+        });
+
+        it('should return a promise that is compatible with Bluebird\'s spread feature', function () {
+            return expect(function (cb) {
+                cb(1, 2);
+            }, 'to call the callback').spread(function (arg1, arg2) {
+                expect(arg1, 'to equal', 1);
+                expect(arg2, 'to equal', 2);
+                expect(arguments, 'to satisfy', [1, 2]);
+            });
+        });
+
         it('should succeed when the callback is called asynchronously', function () {
             return expect(function (cb) {
                 setTimeout(function () {
@@ -6393,6 +6411,14 @@ describe('unexpected', function () {
                     "to call the callback without error\n" +
                     "  called the callback with: Error('wat')"
                 );
+            });
+
+            it('should return a promise that is fulfilled with the values passed to the callback excluding the first (falsy error) parameter', function () {
+                return expect(function (cb) {
+                    cb(null, 1, 2);
+                }, 'to call the callback without error').then(function (args) {
+                    expect(args, 'to equal', [1, 2]);
+                });
             });
 
             it('should support UnexpectedError instances', function () {


### PR DESCRIPTION
…e parameters passed to the callback so they can be referenced in a .then() or .spread() block.