### PR TITLE
expect: Always return a thenable

### DIFF
--- a/documentation/assertions/string/to-match.md
+++ b/documentation/assertions/string/to-match.md
@@ -32,3 +32,24 @@ expected 'Hello beautiful world!' not to match /beautiful/
 Hello beautiful world!
       ^^^^^^^^^
 ```
+
+The return value of `String.prototype.match` will be provided as the fulfillment
+value of the returned promise, so the values captured by the regular expression
+are available to `then` function:
+
+```javascript#async:true
+return expect('Hello world!', 'to match', /(\w+)!/).then(function (captures) {
+    expect(captures[0], 'to equal', 'world!');
+    expect(captures[1], 'to equal', 'world');
+    expect(captures.index, 'to equal', 6);
+});
+```
+
+Or using the Bluebird-specific `.spread` extension:
+
+```javascript#async:true
+return expect('Hello world!', 'to match', /(\w+)!/).spread(function ($0, $1) {
+    expect($0, 'to equal', 'world!');
+    expect($1, 'to equal', 'world');
+});
+```

--- a/documentation/assertions/string/to-match.md
+++ b/documentation/assertions/string/to-match.md
@@ -35,7 +35,7 @@ Hello beautiful world!
 
 The return value of `String.prototype.match` will be provided as the fulfillment
 value of the returned promise, so the values captured by the regular expression
-are available to `then` function:
+are available to the `then` function:
 
 ```javascript#async:true
 return expect('Hello world!', 'to match', /(\w+)!/).then(function (captures) {

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -614,15 +614,22 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
                     var result = oathbreaker(callback());
                     if (isPendingPromise(result)) {
                         testFrameworkPatch.promiseCreated();
-                        return result.then(undefined, function (e) {
+                        result = result.then(undefined, function (e) {
                             if (e && e._isUnexpected) {
                                 throw new UnexpectedError(that.expect, assertion, e);
                             }
                             throw e;
                         });
-                    } else {
-                        return result;
+                    } else if (!result || typeof result.then !== 'function') {
+                        result = makePromise.resolve(result);
                     }
+                    result.and = function () { // ...
+                        var args = [subject].concat(Array.prototype.slice.call(arguments));
+                        return this.then(function () {
+                            return that.expect.apply(that.expect, args);
+                        });
+                    };
+                    return result;
                 } catch (e) {
                     if (e && e._isUnexpected) {
                         var wrappedError = new UnexpectedError(that.expect, assertion, e);
@@ -758,10 +765,10 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
 
     var args = Array.prototype.slice.call(arguments, 2);
     try {
-        var promise = executeExpect(subject, testDescriptionString, args);
-        if (isPendingPromise(promise)) {
+        var result = executeExpect(subject, testDescriptionString, args);
+        if (isPendingPromise(result)) {
             testFrameworkPatch.promiseCreated();
-            return promise.then(undefined, function (e) {
+            result = result.then(undefined, function (e) {
                 if (e && e._isUnexpected) {
                     that.setErrorMessage(e);
                 }
@@ -769,8 +776,17 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
             });
         } else {
             serializeErrorsFromWrappedExpect = true;
+            if (!result || typeof result.then !== 'function') {
+                result = makePromise.resolve(result);
+            }
         }
-        return promise;
+        result.and = function () { // ...
+            var args = [subject].concat(Array.prototype.slice.call(arguments));
+            return this.then(function () {
+                return that.expect.apply(that.expect, args);
+            });
+        };
+        return result;
     } catch (e) {
         if (e && e._isUnexpected) {
             var newError = e;

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -120,8 +120,10 @@ module.exports = function (expect) {
     expect.addAssertion('string', '[not] to match', function (expect, subject, regexp) {
         var flags = this.flags;
         subject = String(subject);
-        expect.withError(function () {
-            expect(String(subject).match(regexp), '[not] to be truthy');
+        return expect.withError(function () {
+            var captures = String(subject).match(regexp);
+            expect(captures, '[not] to be truthy');
+            return captures;
         }, function (e) {
             expect.fail({
                 label: 'should match',

--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -109,4 +109,8 @@ function extractPromisesFromObject(obj) {
     };
 });
 
+['resolve', 'reject'].forEach(function (staticMethodName) {
+    makePromise[staticMethodName] = Promise[staticMethodName];
+});
+
 module.exports = makePromise;

--- a/test/documentation.spec.js
+++ b/test/documentation.spec.js
@@ -4010,6 +4010,21 @@ describe("documentation tests", function () {
                 "      ^^^^^^^^^"
             );
         }
+
+        testPromises.push(expect.promise(function () {
+            return expect('Hello world!', 'to match', /(\w+)!/).then(function (captures) {
+                expect(captures[0], 'to equal', 'world!');
+                expect(captures[1], 'to equal', 'world');
+                expect(captures.index, 'to equal', 6);
+            });
+        }));
+
+        testPromises.push(expect.promise(function () {
+            return expect('Hello world!', 'to match', /(\w+)!/).spread(function ($0, $1) {
+                expect($0, 'to equal', 'world!');
+                expect($1, 'to equal', 'world');
+            });
+        }));
         return expect.promise.all(testPromises);
     });
 

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -1636,6 +1636,41 @@ describe('unexpected', function () {
             }, 'to throw exception', "expected 'test' to match /foo/");
         });
 
+        it('should provide the return value of String.prototype.match as the fulfillment value', function () {
+            return expect('foo', 'to match', /(f)(o)/).then(function (captures) {
+                expect(captures, 'to satisfy', {
+                    0: 'fo',
+                    1: 'f',
+                    2: 'o',
+                    input: 'foo',
+                    index: 0
+                });
+            });
+        });
+
+        it('should provide the captured values and the index as the fulfillment value so that the captures are spreadable', function () {
+            return expect('foo', 'to match', /(f)(o)/).spread(function ($0, $1, $2) {
+                expect($0, 'to equal', 'fo');
+                expect($1, 'to equal', 'f');
+                expect($2, 'to equal', 'o');
+            });
+        });
+
+        describe('with a regular expression that has the global flag', function () {
+            it('should provide the return value of String.prototype.match as the fulfillment value', function () {
+                return expect('abc abc', 'to match', /a(b)c/g).then(function (captures) {
+                    expect(captures, 'to equal', ['abc', 'abc']);
+                });
+            });
+
+            it('should provide the captured values and the index as the fulfillment value so that the matched values are spreadable', function () {
+                return expect('abc abc', 'to match', /a(b)c/g).spread(function (firstMatch, secondMatch) {
+                    expect(firstMatch, 'to equal', 'abc');
+                    expect(secondMatch, 'to equal', 'abc');
+                });
+            });
+        });
+
         describe('with the not flag', function () {
             it('provides a diff when the assertion fails', function () {
                 expect(function () {

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -4065,6 +4065,24 @@ describe('unexpected', function () {
         }, 'to throw exception', "Unknown assertion 'to bee', did you mean: 'to be'");
     });
 
+    describe('expect', function () {
+        it('should catch non-Unexpected error caught from a nested assertion', function () {
+            var clonedExpect = expect.clone().addAssertion('to foo', function (expect, subject) {
+                return expect(subject, 'to bar');
+            }).addAssertion('to bar', function (expect, subject) {
+                return expect.promise(function (run) {
+                    setTimeout(run(function () {
+                        throw new Error('foo');
+                    }), 1);
+                });
+            });
+
+            return expect(function () {
+                return clonedExpect('bar', 'to foo');
+            }, 'to error', new Error('foo'));
+        });
+    });
+
     describe('addAssertion', function () {
         it('is chainable', function () {
             expect.addAssertion('foo', function () {})
@@ -6891,6 +6909,21 @@ describe('unexpected', function () {
                         "-foo\n" +
                         "+bar"
                     );
+                });
+            });
+
+            describe('with a nested asynchronous assertion', function () {
+                it('should mount the and method on an error caught from the nested assertion', function () {
+                    var clonedExpect = expect.clone().addAssertion('to foo', function (expect, subject) {
+                        return expect(subject, 'to bar').and('to equal', 'foo');
+                    }).addAssertion('to bar', function (expect, subject) {
+                        return expect.promise(function (run) {
+                            setTimeout(run(function () {
+                                expect(subject, 'to be truthy');
+                            }), 1);
+                        });
+                    });
+                    return clonedExpect('foo', 'to foo');
                 });
             });
         });

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -6913,7 +6913,7 @@ describe('unexpected', function () {
             });
 
             describe('with a nested asynchronous assertion', function () {
-                it('should mount the and method on an error caught from the nested assertion', function () {
+                it('should mount the and method on a promise returned from a nested assertion', function () {
                     var clonedExpect = expect.clone().addAssertion('to foo', function (expect, subject) {
                         return expect(subject, 'to bar').and('to equal', 'foo');
                     }).addAssertion('to bar', function (expect, subject) {


### PR DESCRIPTION
I think my spike is ready for review.

See discussion here: https://github.com/unexpectedjs/unexpected/issues/187

I implemented the extra suggestions as well (`and` and the `to match` enhancement).