### PR TITLE
installPlugin: Error out if an already installed plugin has the same …

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -492,12 +492,18 @@ Unexpected.prototype.installTheme = function () { // ...
 };
 
 Unexpected.prototype.installPlugin = function (plugin) {
-    var alreadyInstalled = this.installedPlugins.some(function (installedPlugin) {
-        return installedPlugin === plugin.name;
+    var existingPlugin = utils.findFirst(this.installedPlugins, function (installedPlugin) {
+        return installedPlugin.name === plugin.name;
     });
 
-    if (alreadyInstalled) {
-        return this.expect;
+    if (existingPlugin) {
+        if (existingPlugin === plugin) {
+            // No-op
+            return this.expect;
+        } else {
+            throw new Error("Another instance of the plugin '" + plugin.name + "' is already installed. " +
+                            "Please check your node_modules folder for unmet peerDependencies.");
+        }
     }
 
     if (typeof plugin !== 'object' ||
@@ -520,7 +526,7 @@ Unexpected.prototype.installPlugin = function (plugin) {
         var installedPlugins = this.installedPlugins;
         var unfulfilledDependencies = plugin.dependencies.filter(function (dependency) {
             return !installedPlugins.some(function (plugin) {
-                return plugin === dependency;
+                return plugin.name === dependency;
             });
         });
 
@@ -533,7 +539,7 @@ Unexpected.prototype.installPlugin = function (plugin) {
         }
     }
 
-    this.installedPlugins.push(plugin.name);
+    this.installedPlugins.push(plugin);
     plugin.installInto(this.expect);
 
     return this.expect; // for chaining

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -4875,6 +4875,19 @@ describe('unexpected', function () {
             expect.installPlugin(plugin);
             expect(callCount, 'to be', 1);
         });
+
+        it('installing a plugin with the same name as another plugin (but not ===) throws an error', function () {
+            expect.installPlugin({
+                name: 'test',
+                installInto: function () {}
+            });
+            expect(function () {
+                expect.installPlugin({
+                    name: 'test',
+                    installInto: function () {}
+                });
+            }, 'to throw', "Another instance of the plugin 'test' is already installed. Please check your node_modules folder for unmet peerDependencies.");
+        });
     });
 
     describe('addType', function () {


### PR DESCRIPTION
…name as the one being installed, but isn't the same instance.

I think this would be a good supplement to whatever the npm 3 story will be.