### PR TITLE
Fix stack trace of errors propagated by expect.withError

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -692,11 +692,23 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
                 });
             };
             wrappedExpect.promise = makePromise;
+
             wrappedExpect.withError = function (body, handler) {
-                return oathbreaker(makePromise(body).caught(function (e) {
+                var returnValue;
+                try {
+                    returnValue = body();
+                } catch (e) {
                     throwIfNonUnexpectedError(e);
                     return handler(e);
-                }));
+                }
+                if (returnValue && typeof returnValue.then === 'function') {
+                    return oathbreaker(returnValue.then(undefined, function (e) {
+                        throwIfNonUnexpectedError(e);
+                        return handler(e);
+                    }));
+                } else {
+                    return returnValue;
+                }
             };
 
             wrappedExpect.format = that.format;


### PR DESCRIPTION
I don't understand exactly how this fixes the problem, but it changes the stack from:

```
UnexpectedError: 
expected 2 to equal 'wat'
    at callInNestedContext (/home/andreas/work/unexpected/lib/Unexpected.js:653:44)
    at Function.wrappedExpect.fail (/home/andreas/work/unexpected/lib/Unexpected.js:690:17)
    at /home/andreas/work/unexpected/lib/assertions.js:425:20
    at /home/andreas/work/unexpected/lib/Unexpected.js:698:28
    at tryCatcher (/home/andreas/work/unexpected/node_modules/bluebird/js/main/util.js:24:31)
    at Promise._settlePromiseFromHandler (/home/andreas/work/unexpected/node_modules/bluebird/js/main/promise.js:454:31)
    at Promise._settlePromiseAt (/home/andreas/work/unexpected/node_modules/bluebird/js/main/promise.js:530:18)
    at Promise._settlePromiseAtPostResolution (/home/andreas/work/unexpected/node_modules/bluebird/js/main/promise.js:224:10)
    at Async._drainQueue (/home/andreas/work/unexpected/node_modules/bluebird/js/main/async.js:182:12)
    at Async._drainQueues (/home/andreas/work/unexpected/node_modules/bluebird/js/main/async.js:187:10)
    at Async.drainQueues (/home/andreas/work/unexpected/node_modules/bluebird/js/main/async.js:15:14)
    at /home/andreas/work/unexpected/lib/workQueue.js:8:13
    at Array.forEach (native)
    at Object.workQueue.drain (/home/andreas/work/unexpected/lib/workQueue.js:7:20)
    at oathbreaker (/home/andreas/work/unexpected/lib/oathbreaker.js:43:15)
    at Function.wrappedExpect.withError (/home/andreas/work/unexpected/lib/Unexpected.js:696:24)
```

to

```
UnexpectedError: 
expected 2 to equal 'wat'
    at callInNestedContext (/home/andreas/work/unexpected/lib/Unexpected.js:653:44)
    at Function.wrappedExpect.fail (/home/andreas/work/unexpected/lib/Unexpected.js:690:17)
    at /home/andreas/work/unexpected/lib/assertions.js:425:20
    at Function.wrappedExpect.withError (/home/andreas/work/unexpected/lib/Unexpected.js:702:28)
    at Assertion.<anonymous> (/home/andreas/work/unexpected/lib/assertions.js:422:16)
    at executeExpect (/home/andreas/work/unexpected/lib/Unexpected.js:720:34)
    at Unexpected.expect (/home/andreas/work/unexpected/lib/Unexpected.js:798:22)
    at Object.<anonymous> (/home/andreas/work/unexpected/argh.js:3:1)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```

when I run my test script, `argh.js` with this content from the root of my unexpected checkout:

```js
var expect = require('./lib/');

expect(2, 'to equal', 'wat');
```

It's seems very likely that it's just masking a bug in oathbreaker or makePromise, though :/