### PR TITLE
Add some docs about the expect function.

### DIFF
--- a/documentation/api/expect.md
+++ b/documentation/api/expect.md
@@ -1,0 +1,60 @@
+### expect(subject, assertionName, [value, ...])
+
+Perform an assertion about `subject`.
+
+The `expect` function will throw an `UnexpectedError` if the assertion can be
+decided synchronously and isn't fulfilled:
+
+```javascript
+expect(123, 'to equal', 456);
+```
+
+```output
+expected 123 to equal 456
+```
+
+In all other cases `expect` will return a
+[Bluebird promise](https://github.com/petkaantonov/bluebird) which will either be
+rejected or fulfilled. For consistency, even successful synchronous assertions will
+return a promise.
+
+The idea is that you can return the promise to your test framework (from an `it`
+block or equivalent), so that the outcome of the test will be decided by whether
+the promise is fulfilled. This works natively in mocha 1.18+, and Unexpected
+does some unholy trickery so it also works in Jasmine.
+
+Note that if the assertion is asynchronous, you'll have to return the promise
+to the `it` block:
+
+```javascript#eval:false
+it('should call the callback', function () {
+    return expect(setImmediate, 'to call the callback');
+});
+```
+
+Otherwise your test framework will assume that the test has passed and won't wait
+for the asynchronous work to complete.
+
+As of 8.0.0 Unexpected will detect created promises that were never returned
+and make the test fail synchronously. This will uncover some extremely nasty
+bugs where the test suite succeeds when it should actually fail. However, this
+feature only works in Mocha and Jasmine.
+
+
+### expect(...).and(assertionName, [value, ...])
+
+The returned promise will be augmented with an `and` method that allows you to
+perform more assertions on the same subject:
+
+```javascript
+expect('abc', 'to be a string').and('to have length', 3);
+```
+
+Again, note that you need to return the value returned by `expect` to your `it`
+block if any of the assertions are asynchronous:
+
+```javascript#eval:false
+it('should do the right thing', function () {
+    return expect(setImmediate, 'to be a function').and('to call the callback');
+});
+```

--- a/test/documentation.spec.js
+++ b/test/documentation.spec.js
@@ -704,6 +704,33 @@ describe("documentation tests", function () {
         return expect.promise.all(testPromises);
     });
 
+    it("api/expect.md contains correct examples", function () {
+        var testPromises = [];
+        try {
+            expect(123, 'to equal', 456);
+            expect.fail(function (output) {
+                output.error("expected:").nl();
+                output.code("expect(123, 'to equal', 456);").nl();
+                output.error("to throw");
+            });
+        } catch (e) {
+            expect(e, "to have message",
+                "expected 123 to equal 456"
+            );
+        }
+
+        it('should call the callback', function () {
+            return expect(setImmediate, 'to call the callback');
+        });
+
+        expect('abc', 'to be a string').and('to have length', 3);
+
+        it('should do the right thing', function () {
+            return expect(setImmediate, 'to be a function').and('to call the callback');
+        });
+        return expect.promise.all(testPromises);
+    });
+
     it("api/fail.md contains correct examples", function () {
         var testPromises = [];
         try {
@@ -820,50 +847,6 @@ describe("documentation tests", function () {
                 "\n" +
                 "-You have been a very bad boy!\n" +
                 "+You have been a very mad boy!"
-            );
-        }
-        return expect.promise.all(testPromises);
-    });
-
-    it("api/installPlugin.md contains correct examples", function () {
-        var testPromises = [];
-        function IntegerInterval(from, to) {
-          this.from = from;
-          this.to = to;
-        }
-
-        expect.installPlugin({
-          name: 'unexpected-integer-intervals',
-          installInto: function (expect) {
-              expect.addType({
-                name: 'IntegerInterval',
-                base: 'object',
-                identify: function (value) {
-                  return value && value instanceof IntegerInterval;
-                },
-                inspect: function (value, depth, output) {
-                  output.text('[').jsNumber(value.from).text(',').jsNumber(value.to).text(']');
-                }
-              });
-
-             expect.addAssertion('[not] to contain', function (expect, subject, value) {
-               expect(value, '[not] to be within', subject.from, subject.to);
-             });
-          }
-        });
-
-        expect(new IntegerInterval(7, 13), 'to contain', 9);
-
-        try {
-            expect(new IntegerInterval(7, 13), 'to contain', 27);
-            expect.fail(function (output) {
-                output.error("expected:").nl();
-                output.code("expect(new IntegerInterval(7, 13), 'to contain', 27);").nl();
-                output.error("to throw");
-            });
-        } catch (e) {
-            expect(e, "to have message",
-                "expected [7,13] to contain 27"
             );
         }
         return expect.promise.all(testPromises);
@@ -1135,6 +1118,50 @@ describe("documentation tests", function () {
             );
         }));
 
+        return expect.promise.all(testPromises);
+    });
+
+    it("api/use.md contains correct examples", function () {
+        var testPromises = [];
+        function IntegerInterval(from, to) {
+          this.from = from;
+          this.to = to;
+        }
+
+        expect.use({
+          name: 'unexpected-integer-intervals',
+          installInto: function (expect) {
+              expect.addType({
+                name: 'IntegerInterval',
+                base: 'object',
+                identify: function (value) {
+                  return value && value instanceof IntegerInterval;
+                },
+                inspect: function (value, depth, output) {
+                  output.text('[').jsNumber(value.from).text(',').jsNumber(value.to).text(']');
+                }
+              });
+
+             expect.addAssertion('[not] to contain', function (expect, subject, value) {
+               expect(value, '[not] to be within', subject.from, subject.to);
+             });
+          }
+        });
+
+        expect(new IntegerInterval(7, 13), 'to contain', 9);
+
+        try {
+            expect(new IntegerInterval(7, 13), 'to contain', 27);
+            expect.fail(function (output) {
+                output.error("expected:").nl();
+                output.code("expect(new IntegerInterval(7, 13), 'to contain', 27);").nl();
+                output.error("to throw");
+            });
+        } catch (e) {
+            expect(e, "to have message",
+                "expected [7,13] to contain 27"
+            );
+        }
         return expect.promise.all(testPromises);
     });
 


### PR DESCRIPTION
I wanted to link to the list of assertions, but there's no assertions index page, and my attempt to copy the `<a href="<%= relative(assertionsByType[Object.keys(assertionsByType)[0]][0].url) %>">Assertions</a>` construct from `node_modules/unexpected-documentation-site-generator/templates/_header.ejs` failed because the markdown files don't seem to be run through ejs.

Also, it would probably make sense if we could get `expect` to appear at the top of the API menu.