### PR TITLE
Fix stack trace of errors that has been thrown when the work queue has been drained

### DIFF
--- a/lib/oathbreaker.js
+++ b/lib/oathbreaker.js
@@ -43,6 +43,9 @@ module.exports = function oathbreaker(value) {
     workQueue.drain();
 
     if (evaluated && error) {
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(error);
+        }
         throw error;
     } else if (evaluated) {
         return value;


### PR DESCRIPTION
This problem still puzzles me, but I think the fix is a bit cleaner than #194 and will work in more situations.