### PR TITLE
Allow plugins to have a version property.

### DIFF
--- a/documentation/api/use.md
+++ b/documentation/api/use.md
@@ -12,6 +12,7 @@ Unexpected plugins are functions or objects that adhere to the following interfa
 Optional properties:
 
 * __name__: `String` - the name of the plugin.
+* __version__: `String` - the semver version of the plugin (string).
 * __dependencies__: `String array` - a list of dependencies.
 
 Required:

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -504,12 +504,18 @@ Unexpected.prototype.use = function (plugin) {
     });
 
     if (existingPlugin) {
-        if (existingPlugin === plugin) {
+        if (existingPlugin === plugin || (typeof plugin.version !== 'undefined' && plugin.version === existingPlugin.version)) {
             // No-op
             return this.expect;
         } else {
-            throw new Error("Another instance of the plugin '" + plugin.name + "' is already installed. " +
-                            "Please check your node_modules folder for unmet peerDependencies.");
+            throw new Error("Another instance of the plugin '" + plugin.name + "' " +
+                            "is already installed" +
+                            (typeof existingPlugin.version !== 'undefined' ?
+                                ' (version ' + existingPlugin.version +
+                                (typeof plugin.version !== 'undefined' ?
+                                    ', trying to install ' + plugin.version : '') +
+                                ')' : '') +
+                            ". Please check your node_modules folder for unmet peerDependencies.");
         }
     }
 
@@ -519,6 +525,7 @@ Unexpected.prototype.use = function (plugin) {
         throw new Error('Plugins must be functions or adhere to the following interface\n' +
                         '{\n' +
                         '  name: <an optional plugin name>,\n' +
+                        '  version: <an optional semver version string>,\n' +
                         '  dependencies: <an optional list of dependencies>,\n' +
                         '  installInto: <a function that will update the given expect instance>\n' +
                         '}');


### PR DESCRIPTION
Don't throw if a plugin is installed more than once as long as the version number is the same (despite the plugins not being === each other).