### PR TITLE
Fix patching of the test framework's 'it' function in test suites spanning multiple files

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -47,7 +47,6 @@ var anyType = {
 
 
 function Unexpected(options) {
-    testFrameworkPatch.applyPatch();
     options = options || {};
     this.assertions = options.assertions || {any: {}};
     this.typeByName = options.typeByName || {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,16 @@
+/*global __filename*/
+var testFrameworkPatch = require('./testFrameworkPatch');
+if (testFrameworkPatch.applyPatch() && typeof require === 'function' && require.cache) {
+    // Make sure that the 'it' global gets patched in every context where Unexpected is required,
+    // but prevent rereading index.js from disc each time:
+    Object.defineProperty(require.cache, __filename, {
+        get: function () {
+            testFrameworkPatch.applyPatch();
+            return module;
+        }
+    });
+}
+
 module.exports = require('./Unexpected').create()
     .use(require('./styles'))
     .use(require('./types'))

--- a/lib/testFrameworkPatch.js
+++ b/lib/testFrameworkPatch.js
@@ -100,6 +100,7 @@ module.exports = {
                 it[methodName] = originalIt[methodName];
             });
             it.patchApplied = true;
+            return true;
         }
     }
 };


### PR DESCRIPTION
As reported by @alexjeffburke and discussed on the gitter channel.

The fix should only affect multi-file mocha suites, and I've tested that the test framework patch still does the correct thing with `make test-jasmine`, and `make test-browser` in Chrome.