### PR TITLE
Add gitter chat badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ Extensible BDD assertion toolkit
 [![Build Status](https://travis-ci.org/unexpectedjs/unexpected.svg?branch=master)](https://travis-ci.org/unexpectedjs/unexpected)
 [![Coverage Status](https://coveralls.io/repos/unexpectedjs/unexpected/badge.svg)](https://coveralls.io/r/unexpectedjs/unexpected)
 [![Dependency Status](https://david-dm.org/unexpectedjs/unexpected.svg)](https://david-dm.org/unexpectedjs/unexpected)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/unexpectedjs/unexpected?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Read [the documentation](http://unexpected.js.org/).


### PR DESCRIPTION
If people want to get in contact with people authoring or using the project there is no reason the require them to navigate to the documentation