### PR TITLE
oathbreaker: Don't recapture the stack of non-Unexpected errors.

### DIFF
--- a/lib/oathbreaker.js
+++ b/lib/oathbreaker.js
@@ -43,7 +43,7 @@ module.exports = function oathbreaker(value) {
     workQueue.drain();
 
     if (evaluated && error) {
-        if (Error.captureStackTrace) {
+        if (error._isUnexpected && Error.captureStackTrace) {
             Error.captureStackTrace(error);
         }
         throw error;


### PR DESCRIPTION
Lately I've run into some cases where the stack trace of an error happening in the code being tested ended up pointing at oathbreaker, eg.:

```
  1) expressExtractHeaders should leave a non-text/html response alone:
     TypeError: Cannot convert null to object
      at oathbreaker (node_modules/unexpected/lib/oathbreaker.js:47:19)
      at executeExpect (node_modules/unexpected/lib/Unexpected.js:698:16)
      at Unexpected.expect (node_modules/unexpected/lib/Unexpected.js:703:22)
      at Context.<anonymous> (test/expressExtractHeaders.js:25:16)
      at Context.wrapper (node_modules/unexpected/lib/testFrameworkPatch.js:72:41)
```

This patch seems to fix that, although I can't testify that it doesn't break something. @sunesimonsen, can you think of any downsides?