### PR TITLE
Update bluebird from 2.9.34 to 3.1.1.

### DIFF
--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -91,8 +91,21 @@ function extractPromisesFromObject(obj) {
 }
 
 ['all', 'any', 'settle'].forEach(function (staticMethodName) {
+    var originalFn = Promise[staticMethodName];
+    if (!originalFn && staticMethodName === 'settle') {
+        originalFn = function (promises) {
+            return Promise.all(promises.map(function (promise) {
+                return new Promise(function (resolve, reject) {
+                    return promise.then(resolve, resolve);
+                });
+            })).then(function () {
+                return promises;
+            });
+        };
+    }
+
     makePromise[staticMethodName] = function (obj) {
-        var result = Promise[staticMethodName](extractPromisesFromObject(obj));
+        var result = originalFn(extractPromisesFromObject(obj));
         if (staticMethodName === 'settle') {
             return result.then(function (promises) {
                 promises.forEach(function (promise) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "array-changes": "1.2.1",
     "array-changes-async": "2.0.2",
-    "bluebird": "2.9.34",
+    "bluebird": "3.1.1",
     "detect-indent": "3.0.1",
     "diff": "1.1.0",
     "leven": "1.0.0",


### PR DESCRIPTION
Our test suite works fine with bluebird 3, so we might as well update now.

Here's what's new in Bluebird 3: http://bluebirdjs.com/docs/new-in-bluebird-3.html

http://bluebirdjs.com/docs/changelog.html