### PR TITLE
Spike/compound assertion

### DIFF
--- a/lib/AssertionStringType.js
+++ b/lib/AssertionStringType.js
@@ -1,8 +1,0 @@
-var AssertionString = require('./AssertionString');
-
-module.exports = {
-    name: 'assertion-string',
-    identify: function (obj) {
-        return obj instanceof AssertionString;
-    }
-};

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -1023,7 +1023,7 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
             for (var n = tokens.length - 1; n > 0 ; n -= 1) {
                 var prefix = tokens.slice(0, n).join(' ');
                 var argsWithAssertionPrepended = [ tokens.slice(n).join(' ') ].concat(args);
-                assertionRule = that.assertions[prefix] && that.lookupAssertionRule(subject, prefix, argsWithAssertionPrepended, true);
+                assertionRule = that.lookupAssertionRule(subject, prefix, argsWithAssertionPrepended, true);
                 if (assertionRule) {
                     // Great, found the longest prefix of the string that yielded a suitable assertion for the given subject and args
                     testDescriptionString = prefix;

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -917,7 +917,7 @@ Unexpected.prototype.lookupAssertionRule = function (subject, testDescriptionStr
     }
     var handlers = this.assertions[testDescriptionString];
     if (!handlers) {
-        return;
+        return null;
     }
     var cachedTypes = {};
 
@@ -986,6 +986,8 @@ Unexpected.prototype.lookupAssertionRule = function (subject, testDescriptionStr
             return handler;
         }
     }
+
+    return null;
 };
 
 function makeExpectFunction(unexpected) {

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -299,7 +299,7 @@ Unexpected.prototype.expandTypeAlternations = function (assertion) {
                 });
             } else if (arg.type.is('assertion')) {
                 result.push([
-                    { type: arg.type, minimum: 1, maximum: 1, isAssertion: true },
+                    { type: arg.type, minimum: 1, maximum: 1 },
                     { type: that.typeByName['any'], minimum: 0, maximum: Infinity }
                 ]);
                 result.push([

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -14,6 +14,10 @@ var createWrappedExpectProto = require('./createWrappedExpectProto');
 var AssertionString = require('./AssertionString');
 var throwIfNonUnexpectedError = require('./throwIfNonUnexpectedError');
 
+function isAssertionArg(arg) {
+    return arg.type.is('assertion');
+}
+
 var anyType = {
     _unexpectedType: true,
     name: 'any',
@@ -951,7 +955,7 @@ Unexpected.prototype.lookupAssertionRule = function (subject, testDescriptionStr
         if (!matches(subject, handler.subject.type, 'subject', relaxed)) {
             return false;
         }
-        if (requireAssertionSuffix && !handler.args.some(function (arg) { return arg.type.is('assertion'); })) {
+        if (requireAssertionSuffix && !handler.args.some(isAssertionArg)) {
             return false;
         }
 

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -12,7 +12,6 @@ var testFrameworkPatch = require('./testFrameworkPatch');
 var defaultDepth = require('./defaultDepth');
 var createWrappedExpectProto = require('./createWrappedExpectProto');
 var AssertionString = require('./AssertionString');
-var AssertionStringType = require('./AssertionStringType');
 var throwIfNonUnexpectedError = require('./throwIfNonUnexpectedError');
 
 var anyType = {
@@ -298,9 +297,9 @@ Unexpected.prototype.expandTypeAlternations = function (assertion) {
                 tails.forEach(function (tail) {
                     result.push([arg].concat(tail));
                 });
-            } else if (arg.type === AssertionStringType) {
+            } else if (arg.type.is('assertion')) {
                 result.push([
-                    { type: AssertionStringType, minimum: 1, maximum: 1, isAssertion: true },
+                    { type: arg.type, minimum: 1, maximum: 1, isAssertion: true },
                     { type: that.typeByName['any'], minimum: 0, maximum: Infinity }
                 ]);
                 result.push([
@@ -340,9 +339,6 @@ Unexpected.prototype.parseAssertion = function (assertionString) {
     var nextIndex = 0;
 
     function lookupType(typeName) {
-        if (typeName === 'assertion') {
-            return AssertionStringType;
-        }
         var result = that.typeByName[typeName];
         if (!result) {
             throw new Error('Unknown type: ' + typeName + ' in ' + assertionString);
@@ -371,7 +367,6 @@ Unexpected.prototype.parseAssertion = function (assertionString) {
         });
     }
     assertionString.replace(/\s*<((?:[a-z_](?:|[a-z0-9_.-]*[_a-z0-9])[?*+]?)(?:\|(?:[a-z_](?:|[a-z0-9_.-]*[_a-z0-9])[?*+]?))*)>|\s*([^<]+)/ig, function ($0, $1, $2, index) {
-
         if (index !== nextIndex) {
             throw new SyntaxError('Cannot parse token at index ' + nextIndex + ' in ' + assertionString);
         }
@@ -412,7 +407,7 @@ Unexpected.prototype.parseAssertion = function (assertionString) {
     }
     if ([assertion.subject].concat(assertion.args.slice(0, -1)).some(function (argRequirements) {
         return argRequirements.some(function (argRequirement) {
-            return argRequirement.type === AssertionStringType;
+            return argRequirement.type.is('assertion');
         });
     })) {
         throw new SyntaxError('Only the last argument type can be <assertion>: ' + assertionString);
@@ -420,7 +415,7 @@ Unexpected.prototype.parseAssertion = function (assertionString) {
 
     var lastArgRequirements = assertion.args[assertion.args.length - 1] || [];
     var assertionRequirements = lastArgRequirements.filter(function (argRequirement) {
-        return argRequirement.type === AssertionStringType;
+        return argRequirement.type.is('assertion');
     });
 
     if (assertionRequirements.length > 0 && lastArgRequirements.length > 1) {
@@ -623,7 +618,7 @@ Unexpected.prototype.addType = function (type) {
         throw new Error('Type ' + type.name + ' must specify an identify function or be declared abstract by setting identify to false');
     }
 
-    if (this.getType(type.name) || type.name === 'assertion') {
+    if (this.getType(type.name)) {
         throw new Error('The type with the name ' + type.name + ' already exists');
     }
 
@@ -829,21 +824,38 @@ function calculateLimits(items) {
 }
 
 Unexpected.prototype.throwAssertionNotFoundError = function (subject, testDescriptionString, args) {
+    var candidateHandlers = this.assertions[testDescriptionString];
+    if (candidateHandlers) {
+        this.fail({
+            errorMode: 'bubbleThrough',
+            message: function (output) {
+                var subjectOutput = function (output) {
+                    output.appendInspected(subject);
+                };
+                var argsOutput = function (output) {
+                    output.appendItems(args, ', ');
+                };
+                output.append(createStandardErrorMessage(output.clone(), subjectOutput, testDescriptionString, argsOutput)).nl()
+                    .indentLines();
+                output.i().error('No matching assertion, did you mean:').nl();
+                var assertionDeclarations = Object.keys(candidateHandlers.reduce(function (result, handler) {
+                    result[handler.declaration] = true;
+                    return result;
+                }, {})).sort();
+                assertionDeclarations.forEach(function (declaration, i) {
+                    output.nl(i > 0 ? 1 : 0).i().text(declaration);
+                });
+            }
+        });
+    }
+
     var assertionsWithScore = [];
     var assertionStrings = Object.keys(this.assertions);
     var that = this;
 
-    function lookup(assertionString) {
-        try {
-            return that.lookupAssertionRule(subject, assertionString, args);
-        } catch (e) {
-            return null;
-        }
-    }
-
     function compareAssertions(a, b) {
-        var aAssertion = lookup(a);
-        var bAssertion = lookup(b);
+        var aAssertion = that.lookupAssertionRule(subject, a, args);
+        var bAssertion = that.lookupAssertionRule(subject, b, args);
         if (!aAssertion && !bAssertion) {
             return 0;
         }
@@ -898,15 +910,14 @@ Unexpected.prototype.throwAssertionNotFoundError = function (subject, testDescri
     });
 };
 
-Unexpected.prototype.lookupAssertionRule = function (subject, testDescriptionString, args) {
+Unexpected.prototype.lookupAssertionRule = function (subject, testDescriptionString, args, requireAssertionSuffix) {
     var that = this;
     if (typeof testDescriptionString !== 'string') {
         throw new Error('The expect function requires the second parameter to be a string.');
     }
-
     var handlers = this.assertions[testDescriptionString];
     if (!handlers) {
-        this.throwAssertionNotFoundError(subject, testDescriptionString, args);
+        return;
     }
     var cachedTypes = {};
 
@@ -920,7 +931,7 @@ Unexpected.prototype.lookupAssertionRule = function (subject, testDescriptionStr
     }
 
     function matches(value, assertionType, key, relaxed) {
-        if (assertionType === AssertionStringType && typeof value === 'string') {
+        if (assertionType.is('assertion') && typeof value === 'string') {
             return true;
         }
 
@@ -938,6 +949,9 @@ Unexpected.prototype.lookupAssertionRule = function (subject, testDescriptionStr
 
     function matchesHandler(handler, relaxed) {
         if (!matches(subject, handler.subject.type, 'subject', relaxed)) {
+            return false;
+        }
+        if (requireAssertionSuffix && !handler.args.some(function (arg) { return arg.type.is('assertion'); })) {
             return false;
         }
 
@@ -972,28 +986,6 @@ Unexpected.prototype.lookupAssertionRule = function (subject, testDescriptionStr
             return handler;
         }
     }
-
-    that.fail({
-        errorMode: 'bubbleThrough',
-        message: function (output) {
-            var subjectOutput = function (output) {
-                output.appendInspected(subject);
-            };
-            var argsOutput = function (output) {
-                output.appendItems(args, ', ');
-            };
-            output.append(createStandardErrorMessage(output.clone(), subjectOutput, testDescriptionString, argsOutput)).nl()
-                .indentLines();
-            output.i().error('No matching assertion, did you mean:').nl();
-            var assertionDeclarations = Object.keys(handlers.reduce(function (result, handler) {
-                result[handler.declaration] = true;
-                return result;
-            }, {})).sort();
-            assertionDeclarations.forEach(function (declaration, i) {
-                output.nl(i > 0 ? 1 : 0).i().text(declaration);
-            });
-        }
-    });
 };
 
 function makeExpectFunction(unexpected) {
@@ -1019,6 +1011,25 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
 
     function executeExpect(subject, testDescriptionString, args) {
         var assertionRule = that.lookupAssertionRule(subject, testDescriptionString, args);
+
+        if (!assertionRule) {
+            var tokens = testDescriptionString.split(' ');
+            for (var n = tokens.length - 1; n > 0 ; n -= 1) {
+                var prefix = tokens.slice(0, n).join(' ');
+                var argsWithAssertionPrepended = [ tokens.slice(n).join(' ') ].concat(args);
+                assertionRule = that.assertions[prefix] && that.lookupAssertionRule(subject, prefix, argsWithAssertionPrepended, true);
+                if (assertionRule) {
+                    // Great, found the longest prefix of the string that yielded a suitable assertion for the given subject and args
+                    testDescriptionString = prefix;
+                    args = argsWithAssertionPrepended;
+                    break;
+                }
+            }
+            if (!assertionRule) {
+                that.throwAssertionNotFoundError(subject, testDescriptionString, args);
+            }
+        }
+
         var flags = extend({}, assertionRule.flags);
         var wrappedExpect = function () {
             var subject = arguments[0];
@@ -1051,7 +1062,7 @@ Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
         };
         wrappedExpect.argsOutput = args.map(function (arg, i) {
             var argRule = wrappedExpect.assertionRule.args[i];
-            if (typeof arg === 'string' && (argRule && (argRule.type === AssertionStringType) || wrappedExpect._getAssertionIndices().indexOf(i) >= 0)) {
+            if (typeof arg === 'string' && (argRule && argRule.type.is('assertion') || wrappedExpect._getAssertionIndices().indexOf(i) >= 0)) {
                 return new AssertionString(arg);
             }
 

--- a/lib/createWrappedExpectProto.js
+++ b/lib/createWrappedExpectProto.js
@@ -7,6 +7,10 @@ var testFrameworkPatch = require('./testFrameworkPatch');
 var makeAndMethod = require('./makeAndMethod');
 var utils = require('./utils');
 
+function isAssertionArg(arg) {
+    return arg.type.is('assertion');
+}
+
 module.exports = function createWrappedExpectProto(unexpected) {
     var wrappedExpectProto = {
         promise: makePromise,
@@ -162,12 +166,12 @@ module.exports = function createWrappedExpectProto(unexpected) {
                 var currentAssertionRule = this.assertionRule;
                 var offset = 0;
                 OUTER: while (true) {
-                    if (currentAssertionRule.args.length > 1 && currentAssertionRule.args[currentAssertionRule.args.length - 2].type.is('assertion')) {
+                    if (currentAssertionRule.args.length > 1 && isAssertionArg(currentAssertionRule.args[currentAssertionRule.args.length - 2])) {
                         assertionIndices.push(offset + currentAssertionRule.args.length - 2);
                         var assertions = unexpected.assertions[args[offset + currentAssertionRule.args.length - 2]];
                         if (assertions) {
                             for (var i = 0 ; i < assertions.length ; i += 1) {
-                                if (assertions[i].args.some(function (a) { return a.type.is('assertion'); })) {
+                                if (assertions[i].args.some(isAssertionArg)) {
                                     offset += currentAssertionRule.args.length - 1;
                                     currentAssertionRule = assertions[i];
                                     continue OUTER;

--- a/lib/createWrappedExpectProto.js
+++ b/lib/createWrappedExpectProto.js
@@ -83,7 +83,7 @@ module.exports = function createWrappedExpectProto(unexpected) {
                 }
                 assertionIndex = -1;
                 for (var i = 0 ; i < this.assertionRule.args.length ; i += 1) {
-                    if (this.assertionRule.args[i].isAssertion) {
+                    if (this.assertionRule.args[i].type.is('assertion')) {
                         assertionIndex = i;
                         break;
                     }
@@ -162,12 +162,12 @@ module.exports = function createWrappedExpectProto(unexpected) {
                 var currentAssertionRule = this.assertionRule;
                 var offset = 0;
                 OUTER: while (true) {
-                    if (currentAssertionRule.args.length > 1 && currentAssertionRule.args[currentAssertionRule.args.length - 2].isAssertion) {
+                    if (currentAssertionRule.args.length > 1 && currentAssertionRule.args[currentAssertionRule.args.length - 2].type.is('assertion')) {
                         assertionIndices.push(offset + currentAssertionRule.args.length - 2);
                         var assertions = unexpected.assertions[args[offset + currentAssertionRule.args.length - 2]];
                         if (assertions) {
                             for (var i = 0 ; i < assertions.length ; i += 1) {
-                                if (assertions[i].args.some(function (a) { return a.isAssertion; })) {
+                                if (assertions[i].args.some(function (a) { return a.type.is('assertion'); })) {
                                     offset += currentAssertionRule.args.length - 1;
                                     currentAssertionRule = assertions[i];
                                     continue OUTER;

--- a/lib/types.js
+++ b/lib/types.js
@@ -5,6 +5,7 @@ var arrayChanges = require('array-changes');
 var leven = require('leven');
 var detectIndent = require('detect-indent');
 var defaultDepth = require('./defaultDepth');
+var AssertionString = require('./AssertionString');
 
 module.exports = function (expect) {
     expect.addType({
@@ -969,6 +970,16 @@ module.exports = function (expect) {
         },
         inspect: function (value, depth, output) {
             output.jsPrimitive(value);
+        }
+    });
+
+    expect.addType({
+        name: 'assertion',
+        identify: function (value) {
+            return value instanceof AssertionString;
+        },
+        inspect: function (value, depth, output) {
+            output.error(value.text);
         }
     });
 };

--- a/lib/types.js
+++ b/lib/types.js
@@ -977,9 +977,6 @@ module.exports = function (expect) {
         name: 'assertion',
         identify: function (value) {
             return value instanceof AssertionString;
-        },
-        inspect: function (value, depth, output) {
-            output.error(value.text);
         }
     });
 };

--- a/test/assertionParser.spec.js
+++ b/test/assertionParser.spec.js
@@ -138,7 +138,7 @@ describe('parseAssertion', function () {
                     assertion: 'when decoded as',
                     args: [
                         { type: { name: 'string' }, minimum: 1, maximum: 1 },
-                        { type: { name: 'assertion-string' }, minimum: 1, maximum: 1 },
+                        { type: { name: 'assertion' }, minimum: 1, maximum: 1 },
                         { type: { name: 'any' }, minimum: 0, maximum: Infinity }
                     ]
                 },

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -8476,4 +8476,77 @@ describe('unexpected', function () {
             });
         });
     });
+
+    describe('with the next assertion as a continuation', function () {
+        describe('with "to have items satisfying" followed by another assertion', function () {
+            it('should succeed', function () {
+                return expect([ 123 ], 'to have items satisfying to be a number');
+            });
+
+            it('should fail', function () {
+                return expect(function () {
+                    return expect([ 123 ], 'to have items satisfying to be a boolean');
+                }, 'to error',
+                    "expected [ 123 ] to have items satisfying to be a boolean\n" +
+                    "\n" +
+                    "[\n" +
+                    "  123 // should be a boolean\n" +
+                    "]"
+                );
+            });
+        });
+
+        describe('with "to have items satisfying" twice followed by another assertion', function () {
+            it('should succeed', function () {
+                return expect([ [ 123 ] ], 'to have items satisfying to have items satisfying to be a number');
+            });
+
+            it('should fail', function () {
+                return expect(function () {
+                    return expect([ [ 123 ] ], 'to have items satisfying to have items satisfying to be a boolean');
+                }, 'to error',
+                    "expected [ [ 123 ] ]\n" +
+                    "to have items satisfying to have items satisfying to be a boolean\n" +
+                    "\n" +
+                    "[\n" +
+                    "  [\n" +
+                    "    123 // should be a boolean\n" +
+                    "  ]\n" +
+                    "]"
+                );
+            });
+        });
+
+        describe('with "when rejected" followed by another assertion', function () {
+            it('should succeed', function () {
+                return expect(expect.promise.reject(123), 'when rejected to satisfy', 123);
+            });
+
+            it('should fail', function () {
+                return expect(function () {
+                    return expect(expect.promise.reject(true), 'when rejected to be a number');
+                }, 'to error',
+                    "expected Promise (rejected) => true when rejected to be a number\n" +
+                    "  expected true to be a number"
+                );
+            });
+        });
+
+        describe('with "when rejected" twice followed by another assertion', function () {
+            it('should succeed', function () {
+                return expect(expect.promise.reject(expect.promise.reject(123)), 'when rejected when rejected to satisfy', 123);
+            });
+
+            it('should fail', function () {
+                return expect(function () {
+                    return expect(expect.promise.reject(expect.promise.reject(true)), 'when rejected when rejected to be a number');
+                }, 'to error',
+                    "expected Promise (rejected) => Promise (rejected) => true\n" +
+                    "when rejected when rejected to be a number\n" +
+                    "  expected Promise (rejected) => true when rejected to be a number\n" +
+                    "    expected true to be a number"
+                );
+            });
+        });
+    });
 });


### PR DESCRIPTION
@sunesimonsen Not totally happy with this yet, but it seems like it works at this point and I think it's ready for feedback when you get some time.

The next step would be to figure out a plan for removing `to satisfy assertion` and change the meaning of `expect(..., 'to have items satisfying', <string>)` so `<string>` is satisfied against rather than used as the name of an assertion.