### PR TITLE
Added '<object> not to have keys' assertion

### DIFF
--- a/documentation/assertions/object/to-be-empty.md
+++ b/documentation/assertions/object/to-be-empty.md
@@ -1,0 +1,36 @@
+Asserts that an object is empty.
+
+```javascript
+expect({}, 'to be empty');
+```
+
+In case of a failing expectation you get the following output:
+
+```javascript
+expect({ a: 'a', b: 'b' }, 'to be empty');
+```
+
+```output
+expected { a: 'a', b: 'b' } to be empty
+
+{
+  a: 'a', // should be removed
+  b: 'b' // should be removed
+}
+```
+
+This assertion can be negated using the `not` flag:
+
+```javascript
+expect({ a: 'a', b: 'b' }, 'not to be empty');
+```
+
+In case of a failing expectation you get the following output:
+
+```javascript
+expect({}, 'not to be empty');
+```
+
+```output
+expected {} not to be empty
+```

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -321,6 +321,13 @@ module.exports = function (expect) {
         }
     });
 
+    expect.addAssertion('<object> [not] to be empty', function (expect, subject) {
+        if (expect.flags.not && !expect.findTypeOf(subject).getKeys(subject).length) {
+            return expect.fail();
+        }
+        expect(subject, 'to [not] only have keys', []);
+    });
+
     expect.addAssertion('<object> not to have keys <array>', function (expect, subject, keys) {
         expect(subject, 'to not have keys', keys);
     });
@@ -339,10 +346,6 @@ module.exports = function (expect) {
 
     expect.addAssertion('<object> to [not] [only] have keys <string+>', function (expect, subject) {
         expect(subject, 'to [not] [only] have keys', Array.prototype.slice.call(arguments, 2));
-    });
-
-    expect.addAssertion('<object> not to have keys', function (expect, subject) {
-        expect(subject, 'to only have keys', []);
     });
 
     expect.addAssertion('<string> [not] to contain <string+>', function (expect, subject) {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -341,6 +341,10 @@ module.exports = function (expect) {
         expect(subject, 'to [not] [only] have keys', Array.prototype.slice.call(arguments, 2));
     });
 
+    expect.addAssertion('<object> not to have keys', function (expect, subject) {
+        expect(subject, 'to only have keys', []);
+    });
+
     expect.addAssertion('<string> [not] to contain <string+>', function (expect, subject) {
         var args = Array.prototype.slice.call(arguments, 2);
         args.forEach(function (arg) {

--- a/test/assertions/to-be-empty.spec.js
+++ b/test/assertions/to-be-empty.spec.js
@@ -8,6 +8,11 @@ describe('empty assertion', function () {
         expect([1, 2, 3], 'to be non-empty');
     });
 
+    it('asserts that objects (i.e. {}) are empty', function () {
+        expect({}, 'to be empty');
+        expect({ a: 'b' }, 'not to be empty');
+    });
+
     it('throws when the assertion fails', function () {
         expect(function () {
             expect([1, 2, 3], 'to be empty');
@@ -22,6 +27,21 @@ describe('empty assertion', function () {
         }, 'to throw exception',
                "expected null to be empty\n" +
                "  No matching assertion, did you mean:\n" +
+               "  <object> [not] to be empty\n" +
                "  <string|array-like> [not] to be empty");
+
+        expect(function () {
+            expect({ a: 'b' }, 'to be empty');
+        }, 'to throw exception',
+                "expected { a: 'b' } to be empty" +
+                "\n" +
+                "\n" +
+                "{\n" +
+                "  a: \'b\' // should be removed\n" +
+                "}");
+
+        expect(function () {
+             expect({}, 'not to be empty');
+         }, 'to throw exception', "expected {} not to be empty");
     });
 });

--- a/test/assertions/to-have-keys.spec.js
+++ b/test/assertions/to-have-keys.spec.js
@@ -7,6 +7,10 @@ describe('to have keys assertion', function () {
         expect({ a: 'b', c: 'd', e: 'f' }, 'to not only have keys', ['a', 'c']);
     });
 
+    it('asserts the absence of any keys on an object', function () {
+        expect({}, 'not to have keys');
+    });
+
     it('throws when the assertion fails', function () {
         expect(function () {
             expect({ a: 'b', c: 'd' }, 'to not only have keys', ['a', 'c']);
@@ -19,6 +23,17 @@ describe('to have keys assertion', function () {
         expect(function () {
             expect({ a: 'b', c: 'd' }, 'to not only have keys', 'a', 'c');
         }, 'to throw exception', "expected { a: 'b', c: 'd' } to not only have keys 'a', 'c'");
+
+        expect(function () {
+            expect({ a: 'b' }, 'not to have keys');
+        }, 'to throw exception',
+                "expected { a: 'b' } not to have keys" +
+                "\n" +
+                "\n" +
+                "{\n" +
+                "  a: \'b\' // should be removed\n" +
+                "}"
+                );
     });
 
     it('should fail with a diff when the only flag is used', function () {

--- a/test/assertions/to-have-keys.spec.js
+++ b/test/assertions/to-have-keys.spec.js
@@ -7,10 +7,6 @@ describe('to have keys assertion', function () {
         expect({ a: 'b', c: 'd', e: 'f' }, 'to not only have keys', ['a', 'c']);
     });
 
-    it('asserts the absence of any keys on an object', function () {
-        expect({}, 'not to have keys');
-    });
-
     it('throws when the assertion fails', function () {
         expect(function () {
             expect({ a: 'b', c: 'd' }, 'to not only have keys', ['a', 'c']);
@@ -23,17 +19,6 @@ describe('to have keys assertion', function () {
         expect(function () {
             expect({ a: 'b', c: 'd' }, 'to not only have keys', 'a', 'c');
         }, 'to throw exception', "expected { a: 'b', c: 'd' } to not only have keys 'a', 'c'");
-
-        expect(function () {
-            expect({ a: 'b' }, 'not to have keys');
-        }, 'to throw exception',
-                "expected { a: 'b' } not to have keys" +
-                "\n" +
-                "\n" +
-                "{\n" +
-                "  a: \'b\' // should be removed\n" +
-                "}"
-                );
     });
 
     it('should fail with a diff when the only flag is used', function () {


### PR DESCRIPTION
This should be a nicer way to check if an object is "empty" rather than the `<object> to be empty` assertion which was removed in v6.

It simply delegates to `<object> to only have keys` on an empty array of keys.

However, this PR does not add `<object> to have keys` which doesn't seem useful.