### PR TITLE
Allow subtypes of object and array-like more fine-grained control over newlines and indentation

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1071,10 +1071,16 @@ module.exports = function (expect) {
                             var indexOfLastNonInsert = changes.reduce(function (previousValue, diffItem, index) {
                                 return (diffItem.type === 'insert') ? previousValue : index;
                             }, -1);
-                            output.append(subjectType.prefix(output.clone(), subject)).nl().indentLines();
+                            output.append(subjectType.prefix(output.clone(), subject));
+                            if (subjectType.leadingNewline) {
+                                output.nl();
+                            }
+                            if (subjectType.indent) {
+                                output.indentLines();
+                            }
                             changes.forEach(function (diffItem, index) {
                                 var delimiterOutput = subjectType.delimiter(output.clone(), index, indexOfLastNonInsert + 1);
-                                output.i().block(function () {
+                                output.nl(index > 0 ? 1 : 0).i().block(function () {
                                     var type = diffItem.type;
                                     if (type === 'insert') {
                                         this.annotationBlock(function () {
@@ -1112,9 +1118,15 @@ module.exports = function (expect) {
                                             });
                                         }
                                     }
-                                }).nl();
+                                });
                             });
-                            output.outdentLines().append(subjectType.suffix(output.clone(), subject));
+                            if (subjectType.indent) {
+                                output.outdentLines();
+                            }
+                            if (subjectType.trailingNewline) {
+                                output.nl();
+                            }
+                            output.append(subjectType.suffix(output.clone(), subject));
                             return result;
                         }
                     });
@@ -1171,10 +1183,14 @@ module.exports = function (expect) {
                         var keys = Object.keys(keyIndex);
 
                         subjectType.prefix(output, subject);
-                        output.nl().indentLines();
-
+                        if (subjectType.leadingNewline) {
+                            output.nl();
+                        }
+                        if (subjectType.indent) {
+                            output.indentLines();
+                        }
                         keys.forEach(function (key, index) {
-                            output.i().block(function () {
+                            output.nl(index > 0 ? 1 : 0).i().block(function () {
                                 var valueOutput;
                                 var annotation = output.clone();
                                 var conflicting;
@@ -1276,10 +1292,15 @@ module.exports = function (expect) {
                                 } else {
                                     this.block(valueOutput);
                                 }
-                            }).nl();
+                            });
                         });
 
-                        output.outdentLines();
+                        if (subjectType.indent) {
+                            output.outdentLines();
+                        }
+                        if (subjectType.trailingNewline) {
+                            output.nl();
+                        }
                         subjectType.suffix(output, subject);
 
                         return result;

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1071,10 +1071,11 @@ module.exports = function (expect) {
                             var indexOfLastNonInsert = changes.reduce(function (previousValue, diffItem, index) {
                                 return (diffItem.type === 'insert') ? previousValue : index;
                             }, -1);
-                            output.append(subjectType.prefix(output.clone(), subject));
-                            if (subjectType.leadingNewline) {
-                                output.nl();
-                            }
+                            var prefixOutput = subjectType.prefix(output.clone(), subject);
+                            output
+                                .append(prefixOutput)
+                                .nl(prefixOutput.isEmpty() ? 0 : 1);
+
                             if (subjectType.indent) {
                                 output.indentLines();
                             }
@@ -1123,10 +1124,11 @@ module.exports = function (expect) {
                             if (subjectType.indent) {
                                 output.outdentLines();
                             }
-                            if (subjectType.trailingNewline) {
-                                output.nl();
-                            }
-                            output.append(subjectType.suffix(output.clone(), subject));
+                            var suffixOutput = subjectType.suffix(output.clone(), subject);
+                            output
+                                .nl(suffixOutput.isEmpty() ? 0 : 1)
+                                .append(suffixOutput);
+
                             return result;
                         }
                     });
@@ -1182,10 +1184,11 @@ module.exports = function (expect) {
 
                         var keys = Object.keys(keyIndex);
 
-                        subjectType.prefix(output, subject);
-                        if (subjectType.leadingNewline) {
-                            output.nl();
-                        }
+                        var prefixOutput = subjectType.prefix(output.clone(), subject);
+                        output
+                            .append(prefixOutput)
+                            .nl(prefixOutput.isEmpty() ? 0 : 1);
+
                         if (subjectType.indent) {
                             output.indentLines();
                         }
@@ -1298,10 +1301,10 @@ module.exports = function (expect) {
                         if (subjectType.indent) {
                             output.outdentLines();
                         }
-                        if (subjectType.trailingNewline) {
-                            output.nl();
-                        }
-                        subjectType.suffix(output, subject);
+                        var suffixOutput = subjectType.suffix(output.clone(), subject);
+                        output
+                            .nl(suffixOutput.isEmpty() ? 0 : 1)
+                            .append(suffixOutput);
 
                         return result;
                     }

--- a/lib/types.js
+++ b/lib/types.js
@@ -52,6 +52,9 @@ module.exports = function (expect) {
 
     expect.addType({
         name: 'object',
+        indent: true,
+        leadingNewline: true,
+        trailingNewline: true,
         identify: function (obj) {
             return obj && typeof obj === 'object';
         },
@@ -206,12 +209,20 @@ module.exports = function (expect) {
             }
 
             this.prefix(output, obj);
-            if (itemsOutput.isMultiline()) {
-                output.nl()
-                      .indentLines()
-                      .i().block(itemsOutput)
-                      .outdentLines()
-                      .nl();
+            if (this.multipleLines || itemsOutput.isMultiline()) {
+                if (this.leadingNewline) {
+                    output.nl();
+                }
+                if (this.indent) {
+                    output.indentLines().i();
+                }
+                output.block(itemsOutput);
+                if (this.indent) {
+                    output.outdentLines();
+                }
+                if (this.trailingNewline) {
+                    output.nl();
+                }
             } else {
                 output.sp().append(itemsOutput).sp();
             }
@@ -243,11 +254,16 @@ module.exports = function (expect) {
             var keys = Object.keys(keyIndex);
 
             this.prefix(output, actual);
-            output.nl().indentLines();
+            if (this.leadingNewline) {
+                output.nl();
+            }
 
+            if (this.indent) {
+                output.indentLines();
+            }
             var type = this;
             keys.forEach(function (key, index) {
-                output.i().block(function () {
+                output.nl(index > 0 ? 1 : 0).i().block(function () {
                     var valueOutput;
                     var annotation = output.clone();
                     var conflicting = !equal(actual[key], expected[key]);
@@ -298,10 +314,15 @@ module.exports = function (expect) {
                     if (!annotation.isEmpty()) {
                         this.sp().annotationBlock(annotation);
                     }
-                }).nl();
+                });
             });
 
-            output.outdentLines();
+            if (this.indent) {
+                output.outdentLines();
+            }
+            if (this.trailingNewline) {
+                output.nl();
+            }
             this.suffix(output, actual);
 
             return result;
@@ -425,29 +446,46 @@ module.exports = function (expect) {
             var currentDepth = defaultDepth - Math.min(defaultDepth, depth);
             var maxLineLength = (output.preferredWidth - 20) - currentDepth * output.indentationWidth - 2;
             var width = 0;
-            var multipleLines = inspectedItems.some(function (o) {
-                if (o.isMultiline()) {
-                    return true;
-                }
+            var multipleLines = this.multipleLines;
+            if (typeof multipleLines === 'undefined') {
+                // The type does not specify whether to inspect on multiple lines.
+                // Auto-detect based on the size of the inspected items:
+                multipleLines = inspectedItems.some(function (o) {
+                    if (o.isMultiline()) {
+                        return true;
+                    }
 
-                var size = o.size();
-                width += size.width;
-                return width > maxLineLength;
-            });
-
+                    var size = o.size();
+                    width += size.width;
+                    return width > maxLineLength;
+                });
+            }
             var type = this;
             inspectedItems.forEach(function (inspectedItem, index) {
                 inspectedItem.amend(type.delimiter(output.clone(), index, keys.length));
             });
 
             if (multipleLines) {
-                output.append(prefixOutput).nl().indentLines();
-
+                output.append(prefixOutput);
+                if (this.leadingNewline) {
+                    output.nl();
+                }
+                if (this.indent) {
+                    output.indentLines();
+                }
                 inspectedItems.forEach(function (inspectedItem, index) {
-                    output.i().block(inspectedItem).nl();
+                    output.nl(index > 0 ? 1 : 0).i().block(inspectedItem);
                 });
 
-                output.outdentLines().append(suffixOutput);
+                if (this.indent) {
+                    output.outdentLines();
+                }
+
+                if (this.trailingNewline) {
+                    output.nl();
+                }
+
+                output.append(suffixOutput);
             } else {
                 output.append(prefixOutput).sp();
                 inspectedItems.forEach(function (inspectedItem, index) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -514,7 +514,15 @@ module.exports = function (expect) {
                 return this.baseType.diff(actual, expected, output);
             }
 
-            output.append(this.prefix(output.clone(), actual)).nl().indentLines();
+            output.append(this.prefix(output.clone(), actual));
+
+            if (this.leadingNewline) {
+                output.nl();
+            }
+
+            if (this.indent) {
+                output.indentLines();
+            }
 
             var type = this;
             var changes = arrayChanges(actual, expected, equal, function (a, b) {
@@ -525,7 +533,7 @@ module.exports = function (expect) {
             }, -1);
             changes.forEach(function (diffItem, index) {
                 var delimiterOutput = type.delimiter(output.clone(), index, indexOfLastNonInsert + 1);
-                output.i().block(function () {
+                output.nl(index > 0 ? 1 : 0).i().block(function () {
                     var type = diffItem.type;
                     if (type === 'insert') {
                         this.annotationBlock(function () {
@@ -549,10 +557,18 @@ module.exports = function (expect) {
                             });
                         }
                     }
-                }).nl();
+                });
             });
 
-            output.outdentLines().append(this.suffix(output.clone(), actual));
+            if (this.indent) {
+                output.outdentLines();
+            }
+
+            if (this.trailingNewline) {
+                output.nl();
+            }
+
+            output.append(this.suffix(output.clone(), actual));
 
             return result;
         }

--- a/lib/types.js
+++ b/lib/types.js
@@ -55,6 +55,7 @@ module.exports = function (expect) {
         indent: true,
         leadingNewline: true,
         trailingNewline: true,
+        forceMultipleLines: false,
         identify: function (obj) {
             return obj && typeof obj === 'object';
         },
@@ -209,7 +210,7 @@ module.exports = function (expect) {
             }
 
             this.prefix(output, obj);
-            if (this.multipleLines || itemsOutput.isMultiline()) {
+            if (this.forceMultipleLines || itemsOutput.isMultiline()) {
                 if (this.leadingNewline) {
                     output.nl();
                 }
@@ -446,25 +447,19 @@ module.exports = function (expect) {
             var currentDepth = defaultDepth - Math.min(defaultDepth, depth);
             var maxLineLength = (output.preferredWidth - 20) - currentDepth * output.indentationWidth - 2;
             var width = 0;
-            var multipleLines = this.multipleLines;
-            if (typeof multipleLines === 'undefined') {
-                // The type does not specify whether to inspect on multiple lines.
-                // Auto-detect based on the size of the inspected items:
-                multipleLines = inspectedItems.some(function (o) {
-                    if (o.isMultiline()) {
-                        return true;
-                    }
+            var multipleLines = this.forceMultipleLines || inspectedItems.some(function (o) {
+                if (o.isMultiline()) {
+                    return true;
+                }
 
-                    var size = o.size();
-                    width += size.width;
-                    return width > maxLineLength;
-                });
-            }
+                var size = o.size();
+                width += size.width;
+                return width > maxLineLength;
+            });
             var type = this;
             inspectedItems.forEach(function (inspectedItem, index) {
                 inspectedItem.amend(type.delimiter(output.clone(), index, keys.length));
             });
-
             if (multipleLines) {
                 output.append(prefixOutput);
                 if (this.leadingNewline) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -53,8 +53,6 @@ module.exports = function (expect) {
     expect.addType({
         name: 'object',
         indent: true,
-        leadingNewline: true,
-        trailingNewline: true,
         forceMultipleLines: false,
         identify: function (obj) {
             return obj && typeof obj === 'object';
@@ -209,9 +207,11 @@ module.exports = function (expect) {
                 });
             }
 
-            this.prefix(output, obj);
+            var prefixOutput = this.prefix(output.clone(), obj);
+            var suffixOutput = this.suffix(output.clone(), obj);
+            output.append(prefixOutput);
             if (this.forceMultipleLines || itemsOutput.isMultiline()) {
-                if (this.leadingNewline) {
+                if (!prefixOutput.isEmpty()) {
                     output.nl();
                 }
                 if (this.indent) {
@@ -221,13 +221,16 @@ module.exports = function (expect) {
                 if (this.indent) {
                     output.outdentLines();
                 }
-                if (this.trailingNewline) {
+                if (!suffixOutput.isEmpty()) {
                     output.nl();
                 }
             } else {
-                output.sp().append(itemsOutput).sp();
+                output
+                    .sp(prefixOutput.isEmpty() ? 0 : 1)
+                    .append(itemsOutput)
+                    .sp(suffixOutput.isEmpty() ? 0 : 1);
             }
-            this.suffix(output, obj);
+            output.append(suffixOutput);
         },
         diff: function (actual, expected, output, diff, inspect, equal) {
             if (actual.constructor !== expected.constructor) {
@@ -254,10 +257,10 @@ module.exports = function (expect) {
 
             var keys = Object.keys(keyIndex);
 
-            this.prefix(output, actual);
-            if (this.leadingNewline) {
-                output.nl();
-            }
+            var prefixOutput = this.prefix(output.clone(), actual);
+            output
+                .append(prefixOutput)
+                .nl(prefixOutput.isEmpty() ? 0 : 1);
 
             if (this.indent) {
                 output.indentLines();
@@ -321,10 +324,10 @@ module.exports = function (expect) {
             if (this.indent) {
                 output.outdentLines();
             }
-            if (this.trailingNewline) {
-                output.nl();
-            }
-            this.suffix(output, actual);
+            var suffixOutput = this.suffix(output.clone(), actual);
+            output
+                .nl(suffixOutput.isEmpty() ? 0 : 1)
+                .append(suffixOutput);
 
             return result;
         },
@@ -462,7 +465,7 @@ module.exports = function (expect) {
             });
             if (multipleLines) {
                 output.append(prefixOutput);
-                if (this.leadingNewline) {
+                if (!prefixOutput.isEmpty()) {
                     output.nl();
                 }
                 if (this.indent) {
@@ -476,13 +479,15 @@ module.exports = function (expect) {
                     output.outdentLines();
                 }
 
-                if (this.trailingNewline) {
+                if (!suffixOutput.isEmpty()) {
                     output.nl();
                 }
 
                 output.append(suffixOutput);
             } else {
-                output.append(prefixOutput).sp();
+                output
+                    .append(prefixOutput)
+                    .sp(prefixOutput.isEmpty() ? 0 : 1);
                 inspectedItems.forEach(function (inspectedItem, index) {
                     output.append(inspectedItem);
                     var lastIndex = index === inspectedItems.length - 1;
@@ -490,7 +495,9 @@ module.exports = function (expect) {
                         output.sp();
                     }
                 });
-                output.sp().append(suffixOutput);
+                output
+                    .sp(suffixOutput.isEmpty() ? 0 : 1)
+                    .append(suffixOutput);
             }
         },
         diffLimit: 512,
@@ -509,11 +516,11 @@ module.exports = function (expect) {
                 return this.baseType.diff(actual, expected, output);
             }
 
-            output.append(this.prefix(output.clone(), actual));
+            var prefixOutput = this.prefix(output.clone(), actual);
+            output
+                .append(prefixOutput)
+                .nl(prefixOutput.isEmpty() ? 0 : 1);
 
-            if (this.leadingNewline) {
-                output.nl();
-            }
 
             if (this.indent) {
                 output.indentLines();
@@ -559,11 +566,10 @@ module.exports = function (expect) {
                 output.outdentLines();
             }
 
-            if (this.trailingNewline) {
-                output.nl();
-            }
-
-            output.append(this.suffix(output.clone(), actual));
+            var suffixOutput = this.suffix(output.clone(), actual);
+            output
+                .nl(suffixOutput.isEmpty() ? 0 : 1)
+                .append(suffixOutput);
 
             return result;
         }

--- a/test/types/array-like-type.spec.js
+++ b/test/types/array-like-type.spec.js
@@ -1,0 +1,113 @@
+/*global expect*/
+describe('array-like type', function () {
+    describe('with a subtype that disables indentation', function () {
+        var clonedExpect = expect.clone();
+
+        clonedExpect.addType({
+            base: 'array-like',
+            name: 'bogusarray',
+            identify: Array.isArray,
+            indent: false
+        });
+
+        it('should not render the indentation when an instance is inspected in a multi-line context', function () {
+            expect(
+                clonedExpect.inspect([
+                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+                ]).toString(),
+                'to equal',
+                "[\n" +
+                "'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',\n" +
+                "'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'\n" +
+                "]"
+            );
+        });
+
+        it('should not render the indentation when an instance is diffed', function () {
+            expect(
+                clonedExpect.diff(['a', 'b'], ['aa', 'bb']).diff.toString(),
+                'to equal',
+                "[\n" +
+                "'a', // should equal 'aa'\n" +
+                "     // -a\n" +
+                "     // +aa\n" +
+                "'b' // should equal 'bb'\n" +
+                "    // -b\n" +
+                "    // +bb\n" +
+                "]"
+            );
+        });
+
+        it('should not render the indentation when an instance participates in a "to satisfy" diff', function () {
+            expect(function () {
+                clonedExpect(['aaa', 'bbb'], 'to satisfy', { 0: 'foo' });
+            }, 'to throw',
+                "expected [ 'aaa', 'bbb' ] to satisfy { 0: 'foo' }\n" +
+                "\n" +
+                "[\n" +
+                "'aaa', // should equal 'foo'\n" +
+                "       // -aaa\n" +
+                "       // +foo\n" +
+                "'bbb'\n" +
+                "]"
+            );
+        });
+    });
+
+    describe('with a subtype that disables prefix, suffix, leading and trailing newline', function () {
+        var clonedExpect = expect.clone();
+
+        clonedExpect.addType({
+            base: 'array-like',
+            name: 'bogusarray',
+            identify: Array.isArray,
+            prefix: function (output) {
+                return output;
+            },
+            suffix: function (output) {
+                return output;
+            },
+            leadingNewline: false,
+            trailingNewline: false
+        });
+
+        it('should not render the newlines when an instance is inspected in a multi-line context', function () {
+            expect(
+                clonedExpect.inspect([
+                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+                ]).toString(),
+                'to equal',
+                "  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',\n" +
+                "  'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'"
+            );
+        });
+
+        it('should not render the newlines when an instance is diffed', function () {
+            expect(
+                clonedExpect.diff(['a', 'b'], ['aa', 'bb']).diff.toString(),
+                'to equal',
+                "  'a', // should equal 'aa'\n" +
+                "       // -a\n" +
+                "       // +aa\n" +
+                "  'b' // should equal 'bb'\n" +
+                "      // -b\n" +
+                "      // +bb"
+            );
+        });
+
+        it('should not render the indentation when an instance participates in a "to satisfy" diff', function () {
+            expect(function () {
+                clonedExpect(['aaa', 'bbb'], 'to satisfy', { 0: 'foo' });
+            }, 'to throw',
+                "expected  'aaa', 'bbb'  to satisfy { 0: 'foo' }\n" +
+                "\n" +
+                "  'aaa', // should equal 'foo'\n" +
+                "         // -aaa\n" +
+                "         // +foo\n" +
+                "  'bbb'"
+            );
+        });
+    });
+});

--- a/test/types/array-like-type.spec.js
+++ b/test/types/array-like-type.spec.js
@@ -67,9 +67,7 @@ describe('array-like type', function () {
             },
             suffix: function (output) {
                 return output;
-            },
-            leadingNewline: false,
-            trailingNewline: false
+            }
         });
 
         it('should not render the prefix, suffix, and the newlines when an instance is inspected in a multi-line context', function () {
@@ -101,7 +99,7 @@ describe('array-like type', function () {
             expect(function () {
                 clonedExpect(['aaa', 'bbb'], 'to satisfy', {0: 'foo'});
             }, 'to throw',
-                "expected  'aaa', 'bbb'  to satisfy { 0: 'foo' }\n" +
+                "expected 'aaa', 'bbb' to satisfy { 0: 'foo' }\n" +
                 "\n" +
                 "  'aaa', // should equal 'foo'\n" +
                 "         // -aaa\n" +

--- a/test/types/array-like-type.spec.js
+++ b/test/types/array-like-type.spec.js
@@ -41,7 +41,7 @@ describe('array-like type', function () {
 
         it('should not render the indentation when an instance participates in a "to satisfy" diff', function () {
             expect(function () {
-                clonedExpect(['aaa', 'bbb'], 'to satisfy', { 0: 'foo' });
+                clonedExpect(['aaa', 'bbb'], 'to satisfy', {0: 'foo'});
             }, 'to throw',
                 "expected [ 'aaa', 'bbb' ] to satisfy { 0: 'foo' }\n" +
                 "\n" +
@@ -72,7 +72,7 @@ describe('array-like type', function () {
             trailingNewline: false
         });
 
-        it('should not render the newlines when an instance is inspected in a multi-line context', function () {
+        it('should not render the prefix, suffix, and the newlines when an instance is inspected in a multi-line context', function () {
             expect(
                 clonedExpect.inspect([
                     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -84,7 +84,7 @@ describe('array-like type', function () {
             );
         });
 
-        it('should not render the newlines when an instance is diffed', function () {
+        it('should not render the prefix, suffix, and the newlines when an instance is diffed', function () {
             expect(
                 clonedExpect.diff(['a', 'b'], ['aa', 'bb']).diff.toString(),
                 'to equal',
@@ -97,9 +97,9 @@ describe('array-like type', function () {
             );
         });
 
-        it('should not render the indentation when an instance participates in a "to satisfy" diff', function () {
+        it('should not render the prefix, suffix, and the newlines when an instance participates in a "to satisfy" diff', function () {
             expect(function () {
-                clonedExpect(['aaa', 'bbb'], 'to satisfy', { 0: 'foo' });
+                clonedExpect(['aaa', 'bbb'], 'to satisfy', {0: 'foo'});
             }, 'to throw',
                 "expected  'aaa', 'bbb'  to satisfy { 0: 'foo' }\n" +
                 "\n" +
@@ -107,6 +107,28 @@ describe('array-like type', function () {
                 "         // -aaa\n" +
                 "         // +foo\n" +
                 "  'bbb'"
+            );
+        });
+    });
+
+    describe('with a subtype that forces forceMultipleLines mode', function () {
+        var clonedExpect = expect.clone();
+
+        clonedExpect.addType({
+            base: 'array-like',
+            name: 'bogusarray',
+            identify: Array.isArray,
+            forceMultipleLines: true
+        });
+
+        it('should inspect in forceMultipleLines mode despite being able to render on one line', function () {
+            expect(
+                clonedExpect.inspect(['a', 'b']).toString(),
+                'to equal',
+                "[\n" +
+                "  'a',\n" +
+                "  'b'\n" +
+                "]"
             );
         });
     });

--- a/test/types/array-like-type.spec.js
+++ b/test/types/array-like-type.spec.js
@@ -55,7 +55,7 @@ describe('array-like type', function () {
         });
     });
 
-    describe('with a subtype that disables prefix, suffix, leading and trailing newline', function () {
+    describe('with a subtype that renders an empty prefix and an empty suffix', function () {
         var clonedExpect = expect.clone();
 
         clonedExpect.addType({

--- a/test/types/object-type.spec.js
+++ b/test/types/object-type.spec.js
@@ -40,4 +40,142 @@ describe('object type', function () {
                   );
         });
     });
+
+    describe('with a subtype that disables indentation', function () {
+        var clonedExpect = expect.clone();
+
+        clonedExpect.addType({
+            base: 'object',
+            name: 'bogusobject',
+            identify: function (obj) {
+                return obj && typeof obj === 'object' && !Array.isArray(obj);
+            },
+            indent: false
+        });
+
+        it('should not render the indentation when an instance is inspected in a multi-line context', function () {
+            expect(
+                clonedExpect.inspect({
+                    a: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                    b: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+                }).toString(),
+                'to equal',
+                "{\n" +
+                "a: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',\n" +
+                "b: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'\n" +
+                "}"
+            );
+        });
+
+        it('should not render the indentation when an instance is diffed', function () {
+            expect(
+                clonedExpect.diff({a: 'a', b: 'b'}, {a: 'aa', b: 'bb'}).diff.toString(),
+                'to equal',
+                "{\n" +
+                "a: 'a', // should equal 'aa'\n" +
+                "        // -a\n" +
+                "        // +aa\n" +
+                "b: 'b' // should equal 'bb'\n" +
+                "       // -b\n" +
+                "       // +bb\n" +
+                "}"
+            );
+        });
+
+        it('should not render the indentation when an instance participates in a "to satisfy" diff', function () {
+            expect(function () {
+                clonedExpect({a: 'aaa', b: 'bbb'}, 'to satisfy', {a: 'foo'});
+            }, 'to throw',
+                "expected { a: 'aaa', b: 'bbb' } to satisfy { a: 'foo' }\n" +
+                "\n" +
+                "{\n" +
+                "a: 'aaa', // should equal 'foo'\n" +
+                "          // -aaa\n" +
+                "          // +foo\n" +
+                "b: 'bbb'\n" +
+                "}"
+            );
+        });
+    });
+
+    describe('with a subtype that disables prefix, suffix, leading and trailing newline', function () {
+        var clonedExpect = expect.clone();
+
+        clonedExpect.addType({
+            base: 'object',
+            name: 'bogusobject',
+            identify: function (obj) {
+                return obj && typeof obj === 'object' && !Array.isArray(obj);
+            },
+            prefix: function (output) {
+                return output;
+            },
+            suffix: function (output) {
+                return output;
+            },
+            leadingNewline: false,
+            trailingNewline: false
+        });
+
+        it('should not render the prefix, suffix, and the newlines when an instance is inspected in a multi-line context', function () {
+            expect(
+                clonedExpect.inspect({
+                    a: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                    b: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+                }).toString(),
+                'to equal',
+                "  a: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',\n" +
+                "  b: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'"
+            );
+        });
+
+        it('should not render the prefix, suffix, and the newlines when an instance is diffed', function () {
+            expect(
+                clonedExpect.diff({a: 'a', b: 'b'}, {a: 'aa', b: 'bb'}).diff.toString(),
+                'to equal',
+                "  a: 'a', // should equal 'aa'\n" +
+                "          // -a\n" +
+                "          // +aa\n" +
+                "  b: 'b' // should equal 'bb'\n" +
+                "         // -b\n" +
+                "         // +bb"
+            );
+        });
+
+        it('should not render the prefix, suffix, and the newlines when an instance participates in a "to satisfy" diff', function () {
+            expect(function () {
+                clonedExpect({a: 'aaa', b: 'bbb'}, 'to satisfy', {a: 'foo'});
+            }, 'to throw',
+                "expected  a: 'aaa', b: 'bbb'  to satisfy  a: 'foo' \n" +
+                "\n" +
+                "  a: 'aaa', // should equal 'foo'\n" +
+                "            // -aaa\n" +
+                "            // +foo\n" +
+                "  b: 'bbb'"
+            );
+        });
+    });
+
+    describe('with a subtype that forces forceMultipleLines mode', function () {
+        var clonedExpect = expect.clone();
+
+        clonedExpect.addType({
+            base: 'object',
+            name: 'bogusobject',
+            identify: function (obj) {
+                return obj && typeof obj === 'object' && !Array.isArray(obj);
+            },
+            forceMultipleLines: true
+        });
+
+        it('should inspect in forceMultipleLines mode despite being able to render on one line', function () {
+            expect(
+                clonedExpect.inspect({a: 'a', b: 'b'}).toString(),
+                'to equal',
+                "{\n" +
+                "  a: 'a', b: 'b'\n" + // This is the 'compact' feature kicking in
+                "}"
+            );
+        });
+    });
 });

--- a/test/types/object-type.spec.js
+++ b/test/types/object-type.spec.js
@@ -112,9 +112,7 @@ describe('object type', function () {
             },
             suffix: function (output) {
                 return output;
-            },
-            leadingNewline: false,
-            trailingNewline: false
+            }
         });
 
         it('should not render the prefix, suffix, and the newlines when an instance is inspected in a multi-line context', function () {
@@ -146,7 +144,7 @@ describe('object type', function () {
             expect(function () {
                 clonedExpect({a: 'aaa', b: 'bbb'}, 'to satisfy', {a: 'foo'});
             }, 'to throw',
-                "expected  a: 'aaa', b: 'bbb'  to satisfy  a: 'foo' \n" +
+                "expected a: 'aaa', b: 'bbb' to satisfy a: 'foo'\n" +
                 "\n" +
                 "  a: 'aaa', // should equal 'foo'\n" +
                 "            // -aaa\n" +

--- a/test/types/object-type.spec.js
+++ b/test/types/object-type.spec.js
@@ -98,7 +98,7 @@ describe('object type', function () {
         });
     });
 
-    describe('with a subtype that disables prefix, suffix, leading and trailing newline', function () {
+    describe('with a subtype that renders an empty prefix and an empty suffix', function () {
         var clonedExpect = expect.clone();
 
         clonedExpect.addType({


### PR DESCRIPTION
See discussion here: https://github.com/unexpectedjs/unexpected-sinon/pull/19