### PR TITLE
Implement 'to have (items|values) exhaustively satisfying'.

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -685,10 +685,10 @@ module.exports = function (expect) {
     });
 
     expect.addAssertion([
-        '<object> to have values satisfying <any+>',
-        '<object> to have values satisfying <assertion>',
-        '<object> to be (a map|a hash|an object) whose values satisfy <any+>',
-        '<object> to be (a map|a hash|an object) whose values satisfy <assertion>'
+        '<object> to have values [exhaustively] satisfying <any+>',
+        '<object> to have values [exhaustively] satisfying <assertion>',
+        '<object> to be (a map|a hash|an object) whose values [exhaustively] satisfy <any+>',
+        '<object> to be (a map|a hash|an object) whose values [exhaustively] satisfy <assertion>'
     ], function (expect, subject, nextArg) {
         expect.errorMode = 'nested';
         expect(subject, 'not to equal', {});
@@ -710,7 +710,7 @@ module.exports = function (expect) {
             }
         });
         return expect.withError(function () {
-            return expect(subject, 'to satisfy', expected);
+            return expect(subject, 'to [exhaustively] satisfy', expected);
         }, function (err) {
             expect.fail({
                 message: function (output) {
@@ -726,10 +726,10 @@ module.exports = function (expect) {
     });
 
     expect.addAssertion([
-        '<array-like> to have items satisfying <any+>',
-        '<array-like> to have items satisfying <assertion>',
-        '<array-like> to be an array whose items satisfy <any+>',
-        '<array-like> to be an array whose items satisfy <assertion>'
+        '<array-like> to have items [exhaustively] satisfying <any+>',
+        '<array-like> to have items [exhaustively] satisfying <assertion>',
+        '<array-like> to be an array whose items [exhaustively] satisfy <any+>',
+        '<array-like> to be an array whose items [exhaustively] satisfy <assertion>'
     ], function (expect, subject) { // ...
         var extraArgs = Array.prototype.slice.call(arguments, 2);
         expect.errorMode = 'nested';
@@ -737,7 +737,7 @@ module.exports = function (expect) {
         expect.errorMode = 'bubble';
 
         return expect.withError(function () {
-            return expect.apply(expect, [subject, 'to have values satisfying'].concat(extraArgs));
+            return expect.apply(expect, [subject, 'to have values [exhaustively] satisfying'].concat(extraArgs));
         }, function (err) {
             expect.fail({
                 message: function (output) {

--- a/test/assertions/to-have-items-satisfying.spec.js
+++ b/test/assertions/to-have-items-satisfying.spec.js
@@ -6,8 +6,8 @@ describe('to have items satisfying assertion', function () {
         }, 'to throw',
                "expected [ 1, 2, 3 ] to have items satisfying\n" +
                "  No matching assertion, did you mean:\n" +
-               "  <array-like> to have items satisfying <any+>\n" +
-               "  <array-like> to have items satisfying <assertion>");
+               "  <array-like> to have items [exhaustively] satisfying <any+>\n" +
+               "  <array-like> to have items [exhaustively] satisfying <assertion>");
     });
 
     it('only accepts arrays as the target object', function () {
@@ -16,8 +16,8 @@ describe('to have items satisfying assertion', function () {
         }, 'to throw',
                "expected 42 to have items satisfying function (item) {}\n" +
                "  No matching assertion, did you mean:\n" +
-               "  <array-like> to have items satisfying <any+>\n" +
-               "  <array-like> to have items satisfying <assertion>");
+               "  <array-like> to have items [exhaustively] satisfying <any+>\n" +
+               "  <array-like> to have items [exhaustively] satisfying <assertion>");
     });
 
     it('fails if the given array is empty', function () {
@@ -178,6 +178,28 @@ describe('to have items satisfying assertion', function () {
                     "  'abc' // should be a number after a short delay\n" +
                     "        //   should be a number\n" +
                     "]");
+        });
+    });
+
+    describe('with the exhaustively flag', function () {
+        it('should succeed', function () {
+            expect([{foo: 'bar', quux: 'baz'}], 'to have items exhaustively satisfying', {foo: 'bar', quux: 'baz'});
+        });
+
+        it('should fail when the spec is not met only because of the "exhaustively" semantics', function () {
+            expect(function () {
+                expect([{foo: 'bar', quux: 'baz'}], 'to have items exhaustively satisfying', {foo: 'bar'});
+            }, 'to throw',
+                "expected [ { foo: 'bar', quux: 'baz' } ]\n" +
+                "to have items exhaustively satisfying { foo: 'bar' }\n" +
+                "\n" +
+                "[\n" +
+                "  {\n" +
+                "    foo: 'bar',\n" +
+                "    quux: 'baz' // should be removed\n" +
+                "  }\n" +
+                "]"
+            );
         });
     });
 });

--- a/test/assertions/to-have-values-satisfying.spec.js
+++ b/test/assertions/to-have-values-satisfying.spec.js
@@ -6,8 +6,8 @@ describe('to have values satisfying assertion', function () {
         }, 'to throw',
                "expected [ 1, 2, 3 ] to have values satisfying\n" +
                "  No matching assertion, did you mean:\n" +
-               "  <object> to have values satisfying <any+>\n" +
-               "  <object> to have values satisfying <assertion>");
+               "  <object> to have values [exhaustively] satisfying <any+>\n" +
+               "  <object> to have values [exhaustively] satisfying <assertion>");
     });
 
     it('only accepts objects and arrays as the target', function () {
@@ -16,8 +16,8 @@ describe('to have values satisfying assertion', function () {
         }, 'to throw',
                "expected 42 to have values satisfying function (value) {}\n" +
                "  No matching assertion, did you mean:\n" +
-               "  <object> to have values satisfying <any+>\n" +
-               "  <object> to have values satisfying <assertion>");
+               "  <object> to have values [exhaustively] satisfying <any+>\n" +
+               "  <object> to have values [exhaustively] satisfying <assertion>");
     });
 
     it('asserts that the given callback does not throw for any values in the map', function () {
@@ -164,6 +164,28 @@ describe('to have values satisfying assertion', function () {
                     "  2: 'abc' // should be a number after a short delay\n" +
                     "           //   should be a number\n" +
                     "}");
+        });
+    });
+
+    describe('with the exhaustively flag', function () {
+        it('should succeed', function () {
+            expect([{foo: 'bar', quux: 'baz'}], 'to have values exhaustively satisfying', {foo: 'bar', quux: 'baz'});
+        });
+
+        it('should fail when the spec is not met only because of the "exhaustively" semantics', function () {
+            expect(function () {
+                expect([{foo: 'bar', quux: 'baz'}], 'to have values exhaustively satisfying', {foo: 'bar'});
+            }, 'to throw',
+                "expected [ { foo: 'bar', quux: 'baz' } ]\n" +
+                "to have values exhaustively satisfying { foo: 'bar' }\n" +
+                "\n" +
+                "[\n" +
+                "  {\n" +
+                "    foo: 'bar',\n" +
+                "    quux: 'baz' // should be removed\n" +
+                "  }\n" +
+                "]"
+            );
         });
     });
 });


### PR DESCRIPTION
Not sure why this wasn't implemented originally.

Needed for the `exhaustively` mode of: https://github.com/unexpectedjs/unexpected-sinon/pull/31