### PR TITLE
Implement Symbol type when the Symbol global is available.

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1195,6 +1195,12 @@ module.exports = function (expect) {
                         });
 
                         var keys = Object.keys(keyIndex);
+                        if (Object.getOwnPropertySymbols) {
+                            var symbols = Object.getOwnPropertySymbols(keyIndex);
+                            if (symbols.length > 0) {
+                                Array.prototype.push.apply(keys, symbols);
+                            }
+                        }
 
                         var prefixOutput = subjectType.prefix(output.clone(), subject);
                         output

--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -1,4 +1,3 @@
-/*global Promise:true*/
 var Promise = require('bluebird');
 var oathbreaker = require('./oathbreaker');
 var throwIfNonUnexpectedError = require('./throwIfNonUnexpectedError');

--- a/lib/oathbreaker.js
+++ b/lib/oathbreaker.js
@@ -1,4 +1,3 @@
-/*global Promise:true*/
 var workQueue = require('./workQueue');
 var Promise = require('bluebird');
 module.exports = function oathbreaker(value) {

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -90,13 +90,21 @@ module.exports = function (expect) {
     });
 
     expect.addStyle('key', function (content) {
-        content = String(content);
-        if (/^[a-z\$\_][a-z0-9\$\_]*$/i.test(content)) {
-            this.text(content, 'jsKey');
-        } else if (/^(?:0|[1-9][0-9]*)$/.test(content)) {
-            this.jsNumber(content);
+        var isSymbol;
+        /*jshint ignore:start*/
+        isSymbol = typeof content === 'symbol';
+        /*jshint ignore:end*/
+        if (isSymbol) {
+            this.text('[').sp().appendInspected(content).sp().text(']');
         } else {
-            this.singleQuotedString(content);
+            content = String(content);
+            if (/^[a-z\$\_][a-z0-9\$\_]*$/i.test(content)) {
+                this.text(content, 'jsKey');
+            } else if (/^(?:0|[1-9][0-9]*)$/.test(content)) {
+                this.jsNumber(content);
+            } else {
+                this.singleQuotedString(content);
+            }
         }
     });
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -69,6 +69,40 @@ module.exports = function (expect) {
         });
     }
 
+    // If Symbol support is not detected, default to passing undefined to
+    // Array.prototype.sort, which means "natural" (asciibetical) sort.
+    var keyComparator;
+    if (typeof Symbol === 'function') {
+        // Comparator that puts symbols last:
+        keyComparator = function (a, b) {
+            var aString,
+                bString,
+                aIsSymbol,
+                bIsSymbol;
+            // jshint ignore:start
+            aIsSymbol = typeof a === 'symbol';
+            bIsSymbol = typeof b === 'symbol';
+            // jshint ignore:end
+            if (aIsSymbol) {
+                if (bIsSymbol) {
+                    aString = a.toString();
+                    bString = b.toString();
+                } else {
+                    return 1;
+                }
+            } else if (bIsSymbol) {
+                return -1;
+            }
+            if (aString < bString) {
+                return -1;
+            } else if (bString > aString) {
+                return 1;
+            } else {
+                return 0;
+            }
+        };
+    }
+
     expect.addType({
         name: 'object',
         indent: true,
@@ -99,7 +133,15 @@ module.exports = function (expect) {
             }
             return output;
         },
-        getKeys: Object.keys,
+        getKeys: Object.getOwnPropertySymbols ? function (obj) {
+            var keys = Object.keys(obj);
+            var symbols = Object.getOwnPropertySymbols(obj);
+            if (symbols.length > 0) {
+                return keys.concat(symbols);
+            } else {
+                return keys;
+            }
+        } : Object.keys,
         equal: function (a, b, equal) {
             if (a === b) {
                 return true;
@@ -121,8 +163,8 @@ module.exports = function (expect) {
                 return false;
             }
             //the same set of keys (although not necessarily the same order),
-            actualKeys.sort();
-            expectedKeys.sort();
+            actualKeys.sort(keyComparator);
+            expectedKeys.sort(keyComparator);
             // cheap key test
             for (var i = 0; i < actualKeys.length; i += 1) {
                 if (actualKeys[i] !== expectedKeys[i]) {
@@ -265,7 +307,6 @@ module.exports = function (expect) {
                 diff: output,
                 inline: true
             };
-
             var keyIndex = {};
             var actualKeys = expect.findTypeOf(actual).getKeys(actual);
             actualKeys.concat(expect.findTypeOf(expected).getKeys(expected)).forEach(function (key) {
@@ -275,6 +316,12 @@ module.exports = function (expect) {
             });
 
             var keys = Object.keys(keyIndex);
+            if (Object.getOwnPropertySymbols) {
+                var symbols = Object.getOwnPropertySymbols(keyIndex);
+                if (symbols.length > 0) {
+                    Array.prototype.push.apply(keys, symbols);
+                }
+            }
 
             var prefixOutput = this.prefix(output.clone(), actual);
             output

--- a/lib/types.js
+++ b/lib/types.js
@@ -54,7 +54,10 @@ module.exports = function (expect) {
         expect.addType({
             name: 'Symbol',
             identify: function (obj) {
-                return typeof obj === String('symbol'); // stupid jshint in es3 mode
+                // We're running jshint in es3 mode so it does not accept typeof x === 'symbol':
+                // jshint ignore:start
+                return typeof obj === 'symbol';
+                // jshint ignore:end
             },
             inspect: function (obj, depth, output, inspect) {
                 output

--- a/lib/types.js
+++ b/lib/types.js
@@ -50,6 +50,22 @@ module.exports = function (expect) {
         }
     });
 
+    if (typeof Symbol === 'function') {
+        expect.addType({
+            name: 'Symbol',
+            identify: function (obj) {
+                return typeof obj === String('symbol'); // stupid jshint in es3 mode
+            },
+            inspect: function (obj, depth, output, inspect) {
+                output
+                    .jsKeyword('Symbol')
+                    .text('(')
+                    .singleQuotedString(obj.toString().replace(/^Symbol\(|\)$/g, ''))
+                    .text(')');
+            }
+        });
+    }
+
     expect.addType({
         name: 'object',
         indent: true,

--- a/lib/workQueue.js
+++ b/lib/workQueue.js
@@ -1,4 +1,3 @@
-/*global Promise:true*/
 var Promise = require('bluebird');
 
 var workQueue = {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "istanbul": "0.3.16",
     "jasmine": "2.2.1",
     "jscs": "2.1.1",
-    "jshint": "2.5.6",
+    "jshint": "2.9.1",
     "minimist": "1.1.1",
     "mocha": "2.4.5",
     "mocha-phantomjs-papandreou": "4.0.2-patch1",

--- a/test/types/Symbol-type.spec.js
+++ b/test/types/Symbol-type.spec.js
@@ -9,6 +9,12 @@ if (typeof Symbol === 'function') {
             expect(symbolA, 'to inspect as', "Symbol('a')");
         });
 
+        it('inspects correctly when used as a key in an object', function () {
+            var obj = {};
+            obj[symbolA] = 123;
+            expect(obj, 'to inspect as', "{ [ Symbol('a') ]: 123 }");
+        });
+
         describe('when compared for equality', function () {
             it('considers a symbol equal to itself', function () {
                 expect(symbolA, 'to equal', symbolA);
@@ -22,6 +28,29 @@ if (typeof Symbol === 'function') {
                 expect(function () {
                     expect(symbolA, 'to equal', symbolB);
                 }, 'to throw', "expected Symbol('a') to equal Symbol('b')");
+            });
+
+            it('should include Symbol properties in the "to equal" diff of objects', function () {
+                var a = { foo: 123 };
+                a[symbolA] = 'foo';
+                a[symbolB] = 123;
+                var b = { foo: 456 };
+                b[symbolA] = 'bar';
+                b[symbolB] = 123;
+                expect(function () {
+                    expect(a, 'to equal', b);
+                }, 'to throw',
+                    "expected { foo: 123, [ Symbol('a') ]: 'foo', [ Symbol('b') ]: 123 }\n" +
+                    "to equal { foo: 456, [ Symbol('a') ]: 'bar', [ Symbol('b') ]: 123 }\n" +
+                    "\n" +
+                    "{\n" +
+                    "  foo: 123, // should equal 456\n" +
+                    "  [ Symbol('a') ]: 'foo', // should equal 'bar'\n" +
+                    "                          // -foo\n" +
+                    "                          // +bar\n" +
+                    "  [ Symbol('b') ]: 123\n" +
+                    "}"
+                );
             });
         });
 
@@ -42,6 +71,29 @@ if (typeof Symbol === 'function') {
                     "\n" +
                     "{\n" +
                     "  foo: Symbol('a') // should equal Symbol('a')\n" +
+                    "}"
+                );
+            });
+
+            it('should include the Symbol properties in the diff', function () {
+                var a = { foo: 123 };
+                a[symbolA] = 'foo';
+                a[symbolB] = 123;
+                var b = { foo: 456 };
+                b[symbolA] = 'bar';
+                b[symbolB] = 123;
+                expect(function () {
+                    expect(a, 'to satisfy', b);
+                }, 'to throw',
+                    "expected { foo: 123, [ Symbol('a') ]: 'foo', [ Symbol('b') ]: 123 }\n" +
+                    "to satisfy { foo: 456, [ Symbol('a') ]: 'bar', [ Symbol('b') ]: 123 }\n" +
+                    "\n" +
+                    "{\n" +
+                    "  foo: 123, // should equal 456\n" +
+                    "  [ Symbol('a') ]: 'foo', // should equal 'bar'\n" +
+                    "                          // -foo\n" +
+                    "                          // +bar\n" +
+                    "  [ Symbol('b') ]: 123\n" +
                     "}"
                 );
             });

--- a/test/types/Symbol-type.spec.js
+++ b/test/types/Symbol-type.spec.js
@@ -1,40 +1,42 @@
 /*global expect, Symbol*/
 if (typeof Symbol === 'function') {
     describe('Symbol type', function () {
+        var symbolA = Symbol('a');
+        var anotherSymbolA = Symbol('a');
+        var symbolB = Symbol('b');
+
         it('inspects correctly', function () {
-            expect(Symbol('foo'), 'to inspect as', "Symbol('foo')");
+            expect(symbolA, 'to inspect as', "Symbol('a')");
         });
 
         describe('when compared for equality', function () {
             it('considers a symbol equal to itself', function () {
-                var symbol = Symbol('a');
-                expect(symbol, 'to equal', symbol);
+                expect(symbolA, 'to equal', symbolA);
             });
 
             it('considers two symbols with the same name different', function () {
-                expect(Symbol('a'), 'not to equal', Symbol('a'));
+                expect(symbolA, 'not to equal', anotherSymbolA);
             });
 
             it('does not render a diff', function () {
                 expect(function () {
-                    expect(Symbol('a'), 'to equal', Symbol('b'));
+                    expect(symbolA, 'to equal', symbolB);
                 }, 'to throw', "expected Symbol('a') to equal Symbol('b')");
             });
         });
 
         describe('with to satisfy', function () {
             it('satisfies itself', function () {
-                var symbol = Symbol('a');
-                expect(symbol, 'to satisfy', symbol);
+                expect(symbolA, 'to satisfy', symbolA);
             });
 
             it('does not satisfy another symbol, even with the same name', function () {
-                expect(Symbol('a'), 'not to satisfy', Symbol('a'));
+                expect(symbolA, 'not to satisfy', anotherSymbolA);
             });
 
             it('does not render a diff', function () {
                 expect(function () {
-                    expect({ foo: Symbol('a') }, 'to satisfy', { foo: Symbol('a') });
+                    expect({ foo: symbolA }, 'to satisfy', { foo: anotherSymbolA });
                 }, 'to throw',
                     "expected { foo: Symbol('a') } to satisfy { foo: Symbol('a') }\n" +
                     "\n" +

--- a/test/types/Symbol-type.spec.js
+++ b/test/types/Symbol-type.spec.js
@@ -1,0 +1,48 @@
+/*global expect, Symbol*/
+if (typeof Symbol === 'function') {
+    describe('Symbol type', function () {
+        it('inspects correctly', function () {
+            expect(Symbol('foo'), 'to inspect as', "Symbol('foo')");
+        });
+
+        describe('when compared for equality', function () {
+            it('considers a symbol equal to itself', function () {
+                var symbol = Symbol('a');
+                expect(symbol, 'to equal', symbol);
+            });
+
+            it('considers two symbols with the same name different', function () {
+                expect(Symbol('a'), 'not to equal', Symbol('a'));
+            });
+
+            it('does not render a diff', function () {
+                expect(function () {
+                    expect(Symbol('a'), 'to equal', Symbol('b'));
+                }, 'to throw', "expected Symbol('a') to equal Symbol('b')");
+            });
+        });
+
+        describe('with to satisfy', function () {
+            it('satisfies itself', function () {
+                var symbol = Symbol('a');
+                expect(symbol, 'to satisfy', symbol);
+            });
+
+            it('does not satisfy another symbol, even with the same name', function () {
+                expect(Symbol('a'), 'not to satisfy', Symbol('a'));
+            });
+
+            it('does not render a diff', function () {
+                expect(function () {
+                    expect({ foo: Symbol('a') }, 'to satisfy', { foo: Symbol('a') });
+                }, 'to throw',
+                    "expected { foo: Symbol('a') } to satisfy { foo: Symbol('a') }\n" +
+                    "\n" +
+                    "{\n" +
+                    "  foo: Symbol('a') // should equal Symbol('a')\n" +
+                    "}"
+                );
+            });
+        });
+    });
+}


### PR DESCRIPTION
Fixes #261.

Symbols can also be used as keys in objects -- that's not implemented yet.
