### PR TITLE
Add jspm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,9 @@
     "serve": "*",
     "unexpected-documentation-site-generator": "^4.0.0",
     "unexpected-markdown": "1.3.1"
+  },
+  "jspm": {
+    "dependencies": {},
+    "main": "unexpected.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "jspm": {
     "dependencies": {},
-    "main": "unexpected.js"
+    "main": "unexpected.js",
+    "jspmPackage": true
   }
 }


### PR DESCRIPTION
This gets it working through jspm. It's nicer to use the built version directly in jspm to avoid all the additional dependencies.