### PR TITLE
Remove all unexpected lines from the stack unless UNEXPECTED_FULL_TRACE is set

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -226,6 +226,31 @@ The source for Unexpected can be found on
 * Changed style names and added theming support (mostly internal).
 * Removed grammatically incorrect assertions.
 
+## Configure the error output
+
+### Disable stack trace trimming
+
+You can disable stack trace trimming the following way:
+
+```
+UNEXPECTED_FULL_TRACE=true mocha
+```
+
+You can achieve the same in the browser by setting the query parameter
+`full-trace` to `true`.
+
+### Controlling the inspection depth
+
+To change the level subtrees gets dotted out, you can set the inspection depth
+the following way:
+
+```
+UNEXPECTED_DEPTH=9 mocha
+```
+
+You can achieve the same in the browser by setting the query parameter `depth`
+to the inspection depth you want.
+
 ## MIT License
 
 Copyright (c) 2013 Sune Simonsen <sune@we-knowhow.dk>

--- a/lib/UnexpectedError.js
+++ b/lib/UnexpectedError.js
@@ -1,5 +1,6 @@
 var utils = require('./utils');
 var defaultDepth = require('./defaultDepth');
+var useFullStackTrace = require('./useFullStackTrace');
 
 var errorMethodBlacklist = ['message', 'line', 'sourceId', 'sourceURL', 'stack', 'stackArray'].reduce(function (result, prop) {
     result[prop] = true;
@@ -214,6 +215,26 @@ UnexpectedError.prototype.serializeMessage = function (outputFormat) {
             }
         }
         this.message = '\n' + this.getErrorMessage({format: outputFormat}).toString();
+
+        if (!useFullStackTrace) {
+            var newStack = [];
+            var removedFrames = false;
+            var lines = this.stack.split(/\n/);
+            lines.forEach(function (line, i) {
+                if (i !== 0 && (/node_modules\/unexpected(?:-[^\/]+)?\//).test(line)) {
+                    removedFrames = true;
+                } else {
+                    newStack.push(line);
+                }
+            });
+
+            if (removedFrames) {
+                var indentation = (/^(\s*)/).exec(lines[lines.length - 1])[1];
+                newStack.push(indentation + 'set UNEXPECTED_FULL_TRACE=true to see the full stack trace');
+            }
+
+            this.stack = newStack.join('\n');
+        }
 
         this._hasSerializedErrorMessage = true;
     }

--- a/lib/UnexpectedError.js
+++ b/lib/UnexpectedError.js
@@ -210,13 +210,16 @@ UnexpectedError.prototype.getErrorMessage = function (options) {
 
 UnexpectedError.prototype.serializeMessage = function (outputFormat) {
     if (!this._hasSerializedErrorMessage) {
-        if (outputFormat === 'html') {
-            outputFormat = 'text';
+        var htmlFormat = outputFormat === 'html';
+        if (htmlFormat) {
             if (!('htmlMessage' in this)) {
                 this.htmlMessage = this.getErrorMessage({format: 'html'}).toString();
             }
         }
-        this.message = '\n' + this.getErrorMessage({format: outputFormat}).toString();
+
+        this.message = '\n' + this.getErrorMessage({
+            format: htmlFormat ? 'text' : outputFormat
+        }).toString();
 
         if (!this.useFullStackTrace) {
             var newStack = [];
@@ -232,7 +235,13 @@ UnexpectedError.prototype.serializeMessage = function (outputFormat) {
 
             if (removedFrames) {
                 var indentation = (/^(\s*)/).exec(lines[lines.length - 1])[1];
-                newStack.push(indentation + 'set UNEXPECTED_FULL_TRACE=true to see the full stack trace');
+
+                if (outputFormat === 'html') {
+                    newStack.push(indentation + 'set the query parameter full-trace=true to see the full stack trace');
+                } else {
+                    newStack.push(indentation + 'set UNEXPECTED_FULL_TRACE=true to see the full stack trace');
+                }
+
             }
 
             this.stack = newStack.join('\n');

--- a/lib/UnexpectedError.js
+++ b/lib/UnexpectedError.js
@@ -26,6 +26,8 @@ function UnexpectedError(expect, parent) {
 
 UnexpectedError.prototype = Object.create(Error.prototype);
 
+UnexpectedError.prototype.useFullStackTrace = useFullStackTrace;
+
 var missingOutputMessage = 'You must either provide a format or a magicpen instance';
 UnexpectedError.prototype.outputFromOptions = function (options) {
     if (!options) {
@@ -216,7 +218,7 @@ UnexpectedError.prototype.serializeMessage = function (outputFormat) {
         }
         this.message = '\n' + this.getErrorMessage({format: outputFormat}).toString();
 
-        if (!useFullStackTrace) {
+        if (!this.useFullStackTrace) {
             var newStack = [];
             var removedFrames = false;
             var lines = this.stack.split(/\n/);

--- a/lib/useFullStackTrace.js
+++ b/lib/useFullStackTrace.js
@@ -1,0 +1,8 @@
+/*global window*/
+var useFullStackTrace = false;
+if (typeof window !== 'undefined' && typeof window.location !== 'undefined') {
+    useFullStackTrace = !!window.location.search.match(/[?&]full-trace=true(?:$|&)/);
+} else if (typeof process !== 'undefined' && process.env.UNEXPECTED_FULL_TRACE) {
+    useFullStackTrace = true;
+}
+module.exports = useFullStackTrace;

--- a/test/api/UnexpectedError.spec.js
+++ b/test/api/UnexpectedError.spec.js
@@ -36,4 +36,69 @@ describe('UnexpectedError', function () {
             expect(expect.findTypeOf(err).getKeys(err), 'to equal', [ 'message', 'errorMode', 'parent' ]);
         });
     });
+
+    describe('when full stack traces is disabled', function () {
+        it('trims the stack for node_module/unexpected/ and node_module/unexpected-<plugin-name>/', function () {
+            expect(function () {
+                expect.fail('wat');
+            }, 'to throw', function (err) {
+                err.useFullStackTrace = false;
+                err._hasSerializedErrorMessage = false;
+                err.stack =
+                    'UnexpectedError:\n' +
+                    'wat\n' +
+                    '      at oathbreaker (node_modules/unexpected/lib/oathbreaker.js:46:19)\n' +
+                    '      at Function.Unexpected.withError (node_modules/unexpected-sinon/lib/unexpected-sinon.js:123:1)\n' +
+                    '      at Function.Unexpected.withError (node_modules/unexpected/lib/Unexpected.js:792:12)\n' +
+                    '      at Function.<anonymous> (node_modules/unexpected/lib/assertions.js:569:16)\n' +
+                    '      at executeExpect (node_modules/unexpected/lib/Unexpected.js:1103:50)\n' +
+                    '      at Unexpected.expect (node_modules/unexpected/lib/Unexpected.js:1111:22)\n' +
+                    '      at Context.<anonymous> (test/Insection.spec.js:48:17)';
+
+                err.serializeMessage('text');
+
+                expect(err, 'to satisfy', {
+                    stack: 'UnexpectedError:\n' +
+                        'wat\n' +
+                        '      at Context.<anonymous> (test/Insection.spec.js:48:17)\n' +
+                        '      set UNEXPECTED_FULL_TRACE=true to see the full stack trace'
+                });
+            });
+        });
+    });
+
+    describe('when full stack traces is enabled', function () {
+        it('the initial stack is preserved', function () {
+            expect(function () {
+                expect.fail('wat');
+            }, 'to throw', function (err) {
+                err.useFullStackTrace = true;
+                err._hasSerializedErrorMessage = false;
+                err.stack =
+                    'UnexpectedError:\n' +
+                    'wat\n' +
+                    '      at oathbreaker (node_modules/unexpected/lib/oathbreaker.js:46:19)\n' +
+                    '      at Function.Unexpected.withError (node_modules/unexpected-sinon/lib/unexpected-sinon.js:123:1)\n' +
+                    '      at Function.Unexpected.withError (node_modules/unexpected/lib/Unexpected.js:792:12)\n' +
+                    '      at Function.<anonymous> (node_modules/unexpected/lib/assertions.js:569:16)\n' +
+                    '      at executeExpect (node_modules/unexpected/lib/Unexpected.js:1103:50)\n' +
+                    '      at Unexpected.expect (node_modules/unexpected/lib/Unexpected.js:1111:22)\n' +
+                    '      at Context.<anonymous> (test/Insection.spec.js:48:17)';
+
+                err.serializeMessage('text');
+
+                expect(err, 'to satisfy', {
+                    stack: 'UnexpectedError:\n' +
+                        'wat\n' +
+                        '      at oathbreaker (node_modules/unexpected/lib/oathbreaker.js:46:19)\n' +
+                        '      at Function.Unexpected.withError (node_modules/unexpected-sinon/lib/unexpected-sinon.js:123:1)\n' +
+                        '      at Function.Unexpected.withError (node_modules/unexpected/lib/Unexpected.js:792:12)\n' +
+                        '      at Function.<anonymous> (node_modules/unexpected/lib/assertions.js:569:16)\n' +
+                        '      at executeExpect (node_modules/unexpected/lib/Unexpected.js:1103:50)\n' +
+                        '      at Unexpected.expect (node_modules/unexpected/lib/Unexpected.js:1111:22)\n' +
+                        '      at Context.<anonymous> (test/Insection.spec.js:48:17)'
+                });
+            });
+        });
+    });
 });

--- a/test/api/UnexpectedError.spec.js
+++ b/test/api/UnexpectedError.spec.js
@@ -65,6 +65,36 @@ describe('UnexpectedError', function () {
                 });
             });
         });
+
+        describe('and the output format is set to html', function () {
+            it('shows a helping message about how to turn of stack trace trimming', function () {
+                expect(function () {
+                    expect.fail('wat');
+                }, 'to throw', function (err) {
+                    err.useFullStackTrace = false;
+                    err._hasSerializedErrorMessage = false;
+                    err.stack =
+                        'UnexpectedError:\n' +
+                        'wat\n' +
+                        '      at oathbreaker (node_modules/unexpected/lib/oathbreaker.js:46:19)\n' +
+                        '      at Function.Unexpected.withError (node_modules/unexpected-sinon/lib/unexpected-sinon.js:123:1)\n' +
+                        '      at Function.Unexpected.withError (node_modules/unexpected/lib/Unexpected.js:792:12)\n' +
+                        '      at Function.<anonymous> (node_modules/unexpected/lib/assertions.js:569:16)\n' +
+                        '      at executeExpect (node_modules/unexpected/lib/Unexpected.js:1103:50)\n' +
+                        '      at Unexpected.expect (node_modules/unexpected/lib/Unexpected.js:1111:22)\n' +
+                        '      at Context.<anonymous> (test/Insection.spec.js:48:17)';
+
+                    err.serializeMessage('html');
+
+                    expect(err, 'to satisfy', {
+                        stack: 'UnexpectedError:\n' +
+                            'wat\n' +
+                            '      at Context.<anonymous> (test/Insection.spec.js:48:17)\n' +
+                            '      set the query parameter full-trace=true to see the full stack trace'
+                    });
+                });
+            });
+        });
     });
 
     describe('when full stack traces is enabled', function () {


### PR DESCRIPTION
This PR removes all lines from the stack trace that points to `node_modules/unexpected` or `node_modules/unexpected-<plugin-name>/`. You can turn off this behaviour by settings the environment variable UNEXPECTED_FULL_TRACE or the query param `full-trace`. When lines are removed from the stack we display a message stating how to disable the behavior. The stack looks something like this with the feature turned on:

```
  2) Insection interval Insection.interval('[',4,335,']') returns the interval [4;3345]:
     UnexpectedError:
expected '[4;335]' to equal '[4;3345]'

-[4;335]
+[4;3345]
      at Context.<anonymous> (test/Insection.spec.js:48:17)
      set UNEXPECTED_FULL_TRACE=true to see the full stack trace
```

TODO:
* [x] display a different message in the browser.
* [x] update the documentation with information about this feature.

cc: @papandreou 