### PR TITLE
Avoid diff result

### DIFF
--- a/documentation/api/UnexpectedError.md
+++ b/documentation/api/UnexpectedError.md
@@ -41,19 +41,16 @@ expect.addAssertion("<array> to have item satisfying <any+>", function (expect, 
     if (failed) {
       expect.fail({
         diff: function (output, diff, inspect, equal) {
-          var result = {
-            inline: true,
-            diff: output
-          };
+          output.inline = true;
           promises.forEach(function (promise, index) {
-            if (index > 0) { result.diff.nl(2); }
+            if (index > 0) { output.nl(2); }
             var error = promise.reason();
             // the error is connected to the current scope
             // but we are just interested in the nested error
             error.errorMode = 'bubble';
-            result.diff.append(error.getErrorMessage(output));
+            output.append(error.getErrorMessage(output));
           });
-          return result;
+          return output;
         }
       });
     }
@@ -156,8 +153,7 @@ expect.addAssertion('<any> to be completely custom', function (expect, subject) 
     expect.fail({
       diff: function (output, diff, inspect, equal) {
         output.text('~~~~~~~~~~~~~~').sp().success('custom').sp().text('~~~~~~~~~~~~~~').nl();
-        var result = createDiff(output, diff, inspect, equal);
-        return result;
+        return createDiff(output, diff, inspect, equal);
       }
     });
   });

--- a/documentation/api/addType.md
+++ b/documentation/api/addType.md
@@ -238,6 +238,7 @@ expect.addType({
         return a === b || equal(a.name, b.name);
     },
     diff: function (actual, expected, output, diff, inspect) {
+        output.inline = inlineDiff;
         var nameDiff = diff(actual.name, expected.name);
 
         output.text('new Person(')
@@ -245,13 +246,13 @@ expect.addType({
               .indentLines();
 
         if (nameDiff && nameDiff.inline) {
-            output.append(nameDiff.diff);
+            output.append(nameDiff);
         } else {
             output.i().append(inspect(actual.name)).text(',').sp()
                   .annotationBlock(function () {
                       this.error('should be ').append(inspect(expected.name));
                       if (nameDiff) {
-                          this.nl().append(nameDiff.diff);
+                          this.nl().append(nameDiff);
                       }
                   })
                   .nl();
@@ -262,10 +263,7 @@ expect.addType({
               .nl()
               .text(')');
 
-        return {
-            inline: inlineDiff,
-            diff: output
-        };
+        return output;
     }
 });
 ```

--- a/documentation/api/withError.md
+++ b/documentation/api/withError.md
@@ -29,10 +29,7 @@ expect.addAssertion('to have same gender as', function (expect, subject, value) 
   }, function (e) {
     expect.fail({
       diff: function (output) {
-        return {
-          inline: false,
-          diff: output.bold(subject.genderSign()).text(' ≠ ').bold(value.genderSign())
-        };
+        return output.bold(subject.genderSign()).text(' ≠ ').bold(value.genderSign());
       }
     });
   });
@@ -59,10 +56,8 @@ expect.addAssertion('delegating to an asynchronous assertion', function (expect,
   }, function (e) {
     expect.fail({
       diff: function (output) {
-        return {
-          inline: true,
-          diff: output.text('Cool a diff attached to an asynchronous failure!')
-        };
+        output.inline = true;
+        return output.text('Cool a diff attached to an asynchronous failure!');
       }
     });
   });

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -69,7 +69,13 @@ function Unexpected(options) {
     this.assertions = options.assertions || {};
     this.typeByName = options.typeByName || {any: anyType};
     this.types = options.types || [anyType];
-    this.output = options.output || magicpen();
+    if (options.output) {
+        this.output = options.output;
+    } else {
+        this.output = magicpen();
+        this.output.inline = false;
+        this.output.diff = false;
+    }
     this._outputFormat = options.format || magicpen.defaultFormat;
     this.installedPlugins = options.installedPlugins || [];
 

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -13,6 +13,7 @@ var defaultDepth = require('./defaultDepth');
 var createWrappedExpectProto = require('./createWrappedExpectProto');
 var AssertionString = require('./AssertionString');
 var throwIfNonUnexpectedError = require('./throwIfNonUnexpectedError');
+var makeDiffResultBackwardsCompatible = require('./makeDiffResultBackwardsCompatible');
 
 function isAssertionArg(arg) {
     return arg.type.is('assertion');
@@ -673,7 +674,7 @@ Unexpected.prototype.addType = function (type) {
             throw new Error('You need to pass the output to baseType.diff() as the third parameter');
         }
 
-        return baseType.diff(actual, expected,
+        return makeDiffResultBackwardsCompatible(baseType.diff(actual, expected,
                       output.clone(),
                       function (actual, expected) {
                           return that.diff(actual, expected, output.clone());
@@ -681,7 +682,7 @@ Unexpected.prototype.addType = function (type) {
                       function (value, depth) {
                           return output.clone().appendInspected(value, depth);
                       },
-                      that.equal.bind(that));
+                      that.equal.bind(that)));
     };
 
     extendedBaseType.equal = function (actual, expected) {
@@ -1204,13 +1205,13 @@ Unexpected.prototype.diff = function (a, b, output, recursions, seen) {
         seen.push(a);
     }
 
-    return this.findCommonType(a, b).diff(a, b, output, function (actual, expected) {
+    return makeDiffResultBackwardsCompatible(this.findCommonType(a, b).diff(a, b, output, function (actual, expected) {
         return that.diff(actual, expected, output.clone(), recursions - 1, seen);
     }, function (v, depth) {
         return output.clone().appendInspected(v, depth);
     }, function (actual, expected) {
         return that.equal(actual, expected);
-    });
+    }));
 };
 
 Unexpected.prototype.toString = function () {

--- a/lib/UnexpectedError.js
+++ b/lib/UnexpectedError.js
@@ -84,7 +84,7 @@ UnexpectedError.prototype.getDefaultErrorMessage = function (options) {
     if (errorWithDiff && errorWithDiff.createDiff) {
         var comparison = errorWithDiff.buildDiff(options);
         if (comparison) {
-            output.nl(2).append(comparison.diff);
+            output.nl(2).append(comparison);
         }
     }
 
@@ -145,23 +145,14 @@ UnexpectedError.prototype.getDiff = function (options) {
         errorWithDiff = errorWithDiff.parent;
     }
 
-    if (errorWithDiff) {
-        var diffResult = errorWithDiff.buildDiff(options);
-        if (diffResult && diffResult.diff) {
-            return diffResult;
-        } else {
-            return null;
-        }
-    } else {
-        return null;
-    }
+    return errorWithDiff && errorWithDiff.buildDiff(options);
 };
 
 UnexpectedError.prototype.getDiffMessage = function (options) {
     var output = this.outputFromOptions(options);
     var comparison = this.getDiff(options);
     if (comparison) {
-        output.append(comparison.diff);
+        output.append(comparison);
     } else if (this.expect.testDescription) {
         output.append(this.expect.standardErrorMessage(output.clone(), options));
     } else if (typeof this.output === 'function') {

--- a/lib/UnexpectedError.js
+++ b/lib/UnexpectedError.js
@@ -1,6 +1,7 @@
 var utils = require('./utils');
 var defaultDepth = require('./defaultDepth');
 var useFullStackTrace = require('./useFullStackTrace');
+var makeDiffResultBackwardsCompatible = require('./makeDiffResultBackwardsCompatible');
 
 var errorMethodBlacklist = ['message', 'line', 'sourceId', 'sourceURL', 'stack', 'stackArray'].reduce(function (result, prop) {
     result[prop] = true;
@@ -59,13 +60,13 @@ UnexpectedError.prototype.isUnexpected = true;
 UnexpectedError.prototype.buildDiff = function (options) {
     var output = this.outputFromOptions(options);
     var expect = this.expect;
-    return this.createDiff && this.createDiff(output, function (actual, expected) {
+    return this.createDiff && makeDiffResultBackwardsCompatible(this.createDiff(output, function (actual, expected) {
         return expect.diff(actual, expected, output.clone());
     }, function (v, depth) {
         return output.clone().appendInspected(v, (depth || defaultDepth) - 1);
     }, function (actual, expected) {
         return expect.equal(actual, expected);
-    });
+    }));
 };
 
 UnexpectedError.prototype.getDefaultErrorMessage = function (options) {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -168,7 +168,7 @@ module.exports = function (expect) {
                         output.removedHighlight($0);
                     });
                     flushUntilIndex(subject.length);
-                    return {diff: output};
+                    return output;
                 }
             });
         });
@@ -230,9 +230,7 @@ module.exports = function (expect) {
                             actual[propertyName] = subject[propertyName];
                         }
                     });
-                    var result = diff(actual, expected);
-                    result.diff = utils.wrapConstructorNameAroundOutput(result.diff, subject);
-                    return result;
+                    return utils.wrapConstructorNameAroundOutput(diff(actual, expected), subject);
                 }
             });
         });
@@ -275,14 +273,11 @@ module.exports = function (expect) {
             }, function (err) {
                 expect.fail({
                     diff: !expect.flags.not && function (output, diff, inspect, equal) {
+                        output.inline = true;
                         var keyInValue = {};
                         keys.forEach(function (key) {
                             keyInValue[key] = true;
                         });
-                        var result = {
-                            diff: output,
-                            inline: true
-                        };
                         var subjectType = expect.findTypeOf(subject);
                         var subjectIsArrayLike = subjectType.is('array-like');
 
@@ -304,7 +299,7 @@ module.exports = function (expect) {
                         output.outdentLines();
                         subjectType.suffix(output, subject);
 
-                        return result;
+                        return output;
                     }
                 });
             });
@@ -415,7 +410,7 @@ module.exports = function (expect) {
                         });
                         flushUntilIndex(subject.length);
                     }
-                    return {diff: output};
+                    return output;
                 }
             });
         });
@@ -467,7 +462,7 @@ module.exports = function (expect) {
                                 .text(subject.substr(i));
                         }
                     }
-                    return {diff: output};
+                    return output;
                 }
             });
         });
@@ -497,7 +492,7 @@ module.exports = function (expect) {
                             .text(subject.substr(0, subject.length - i))
                             .partialMatch(subject.substr(subject.length - i, subject.length));
                     }
-                    return {diff: output};
+                    return output;
                 }
             });
         });
@@ -780,9 +775,9 @@ module.exports = function (expect) {
         if (subject.isUnexpected) {
             var subjectPen;
             if (useDiff) {
-                var diffResult = subject.getDiff({ format: format });
-                if (diffResult && diffResult.diff) {
-                    subjectPen = diffResult.diff;
+                var diff = subject.getDiff({ format: format });
+                if (diff) {
+                    subjectPen = diff;
                 } else {
                     expect.fail('The UnexpectedError instance does not have a diff');
                 }
@@ -845,10 +840,7 @@ module.exports = function (expect) {
         }, function (e) {
             expect.fail({
                 diff: function (output, diff, inspect, equal) {
-                    return {
-                        diff: output.appendErrorMessage(e),
-                        inline: false
-                    };
+                    return output.appendErrorMessage(e);
                 }
             });
         });
@@ -907,10 +899,7 @@ module.exports = function (expect) {
         }, function (e) {
             expect.fail({
                 diff: function (output) {
-                    return {
-                        diff: output.appendErrorMessage(e),
-                        inline: false
-                    };
+                    return output.appendErrorMessage(e);
                 }
             });
         });
@@ -1060,10 +1049,7 @@ module.exports = function (expect) {
                     expect.errorMode = 'default';
                     expect.fail({
                         diff: function (output, diff, inspect, equal) {
-                            var result = {
-                                diff: output,
-                                inline: true
-                            };
+                            output.inline = true;
                             var indexOfLastNonInsert = changes.reduce(function (previousValue, diffItem, index) {
                                 return (diffItem.type === 'insert') ? previousValue : index;
                             }, -1);
@@ -1107,7 +1093,7 @@ module.exports = function (expect) {
                                                 var toSatisfyResult = toSatisfyMatrix[diffItem.actualIndex][diffItem.expectedIndex];
                                                 var valueDiff = toSatisfyResult && toSatisfyResult !== true && toSatisfyResult.getDiff({ output: output.clone() });
                                                 if (valueDiff && valueDiff.inline) {
-                                                    this.append(valueDiff.diff.amend(delimiterOutput));
+                                                    this.append(valueDiff.amend(delimiterOutput));
                                                 } else {
                                                     this.append(inspect(diffItem.value).amend(delimiterOutput)).sp().annotationBlock(function () {
                                                         this.omitSubject = diffItem.value;
@@ -1116,7 +1102,7 @@ module.exports = function (expect) {
                                                             this.error(label).sp()
                                                                 .block(inspect(diffItem.expected));
                                                             if (valueDiff) {
-                                                                this.nl(2).append(valueDiff.diff);
+                                                                this.nl(2).append(valueDiff);
                                                             }
                                                         } else {
                                                             this.appendErrorMessage(toSatisfyResult);
@@ -1136,7 +1122,7 @@ module.exports = function (expect) {
                                 .nl(suffixOutput.isEmpty() ? 0 : 1)
                                 .append(suffixOutput);
 
-                            return result;
+                            return output;
                         }
                     });
                 }
@@ -1175,11 +1161,7 @@ module.exports = function (expect) {
             return expect.promise.settle(promiseByKey).then(function () {
                 expect.fail({
                     diff: function (output, diff, inspect, equal) {
-                        var result = {
-                            diff: output,
-                            inline: true
-                        };
-
+                        output.inline = true;
                         var subjectIsArrayLike = subjectType.is('array-like');
                         var subjectKeys = subjectType.getKeys(subject);
                         var keys = utils.uniqueStringsAndSymbols(subjectKeys, valueType.getKeys(value));
@@ -1226,8 +1208,8 @@ module.exports = function (expect) {
                                     if (missingArrayIndex) {
                                         output.error('// missing').sp();
                                     }
-                                    if (keyDiff && keyDiff.diff && keyDiff.inline) {
-                                        valueOutput = keyDiff.diff;
+                                    if (keyDiff && keyDiff.inline) {
+                                        valueOutput = keyDiff;
                                     } else if (typeof value[key] === 'function') {
                                         isInlineDiff = false;
                                         annotation.appendErrorMessage(conflicting);
@@ -1236,10 +1218,10 @@ module.exports = function (expect) {
                                             .block(inspect(value[key]));
 
                                         if (keyDiff) {
-                                            annotation.nl(2).append(keyDiff.diff);
+                                            annotation.nl(2).append(keyDiff);
                                         }
                                     } else {
-                                        valueOutput = keyDiff.diff;
+                                        valueOutput = keyDiff;
                                     }
                                 }
 
@@ -1288,11 +1270,9 @@ module.exports = function (expect) {
                             output.outdentLines();
                         }
                         var suffixOutput = subjectType.suffix(output.clone(), subject);
-                        output
+                        return output
                             .nl(suffixOutput.isEmpty() ? 0 : 1)
                             .append(suffixOutput);
-
-                        return result;
                     }
                 });
             });

--- a/lib/makeDiffResultBackwardsCompatible.js
+++ b/lib/makeDiffResultBackwardsCompatible.js
@@ -1,0 +1,19 @@
+module.exports = function makeDiffResultBackwardsCompatible(diff) {
+    if (diff) {
+        if (diff.isMagicPen) {
+            // New format: { [MagicPen], inline: <boolean> }
+            // Make backwards compatible by adding a 'diff' property that points
+            // to the instance itself.
+            diff.diff = diff;
+        } else {
+            // Old format: { inline: <boolean>, diff: <magicpen> }
+            // Upgrade to the new format by moving the inline property to
+            // the magicpen instance, and remain backwards compatibly by adding
+            // the diff property pointing to the instance itself.
+            diff.diff.inline = diff.inline;
+            diff = diff.diff;
+            diff.diff = diff;
+        }
+    }
+    return diff;
+};

--- a/lib/types.js
+++ b/lib/types.js
@@ -20,32 +20,28 @@ module.exports = function (expect) {
             output.append(this.suffix(output.clone(), value));
         },
         diff: function (actual, expected, output, diff, inspect) {
+            output.inline = true;
             actual = this.unwrap(actual);
             expected = this.unwrap(expected);
             var comparison = diff(actual, expected);
             var prefixOutput = this.prefix(output.clone(), actual);
             var suffixOutput = this.suffix(output.clone(), actual);
             if (comparison && comparison.inline) {
-                return {
-                    inline: true,
-                    diff: output.append(prefixOutput).append(comparison.diff).append(suffixOutput)
-                };
+                return output.append(prefixOutput).append(comparison).append(suffixOutput);
             } else {
-                return {
-                    inline: true,
-                    diff: output.append(prefixOutput).nl()
-                        .indentLines()
-                        .i().block(function () {
-                            this.append(inspect(actual)).sp().annotationBlock(function () {
-                                this.shouldEqualError(expected, inspect);
-                                if (comparison) {
-                                    this.nl(2).append(comparison.diff);
-                                }
-                            });
-                        }).nl()
-                        .outdentLines()
-                        .append(suffixOutput)
-                };
+                return output.append(prefixOutput).nl()
+                    .indentLines()
+                    .i().block(function () {
+                        this.append(inspect(actual)).sp().annotationBlock(function () {
+                            this.shouldEqualError(expected, inspect);
+                            if (comparison) {
+                                this.nl(2).append(comparison);
+                            }
+                        });
+
+                    }).nl()
+                    .outdentLines()
+                    .append(suffixOutput);
             }
         }
     });
@@ -285,18 +281,12 @@ module.exports = function (expect) {
         },
         diff: function (actual, expected, output, diff, inspect, equal) {
             if (actual.constructor !== expected.constructor) {
-                return {
-                    diff: output.text('Mismatching constructors ')
-                        .text(actual.constructor && utils.getFunctionName(actual.constructor) || actual.constructor)
-                        .text(' should be ').text(expected.constructor && utils.getFunctionName(expected.constructor) || expected.constructor),
-                    inline: false
-                };
+                return output.text('Mismatching constructors ')
+                    .text(actual.constructor && utils.getFunctionName(actual.constructor) || actual.constructor)
+                    .text(' should be ').text(expected.constructor && utils.getFunctionName(expected.constructor) || expected.constructor);
             }
 
-            var result = {
-                diff: output,
-                inline: true
-            };
+            output.inline = true;
             var actualKeys = this.getKeys(actual);
             var keys = utils.uniqueStringsAndSymbols(actualKeys, this.getKeys(expected));
             var prefixOutput = this.prefix(output.clone(), actual);
@@ -327,11 +317,11 @@ module.exports = function (expect) {
                             if (!keyDiff || (keyDiff && !keyDiff.inline)) {
                                 annotation.shouldEqualError(expected[key]);
                                 if (keyDiff) {
-                                    annotation.nl(2).append(keyDiff.diff);
+                                    annotation.nl(2).append(keyDiff);
                                 }
                             } else {
                                 isInlineDiff = true;
-                                valueOutput = keyDiff.diff;
+                                valueOutput = keyDiff;
                             }
                         }
                     } else {
@@ -357,11 +347,9 @@ module.exports = function (expect) {
                 output.outdentLines();
             }
             var suffixOutput = this.suffix(output.clone(), actual);
-            output
+            return output
                 .nl(suffixOutput.isEmpty() ? 0 : 1)
                 .append(suffixOutput);
-
-            return result;
         },
 
         similar: function (a, b) {
@@ -566,14 +554,11 @@ module.exports = function (expect) {
         },
         diffLimit: 512,
         diff: function (actual, expected, output, diff, inspect, equal) {
-            var result = {
-                diff: output,
-                inline: true
-            };
+            output.inline = true;
 
             if (Math.max(actual.length, expected.length) > this.diffLimit) {
-                result.diff.jsComment('Diff suppressed due to size > ' + this.diffLimit);
-                return result;
+                output.jsComment('Diff suppressed due to size > ' + this.diffLimit);
+                return output;
             }
 
             if (actual.constructor !== expected.constructor) {
@@ -623,10 +608,10 @@ module.exports = function (expect) {
                             var valueDiff = diff(diffItem.value, diffItem.expected);
                             this.property(diffItem.actualIndex, output.clone().block(function () {
                                 if (valueDiff && valueDiff.inline) {
-                                    this.append(valueDiff.diff.amend(delimiterOutput));
+                                    this.append(valueDiff.amend(delimiterOutput));
                                 } else if (valueDiff) {
                                     this.append(inspect(diffItem.value).amend(delimiterOutput.sp())).annotationBlock(function () {
-                                        this.shouldEqualError(diffItem.expected, inspect).nl(2).append(valueDiff.diff);
+                                        this.shouldEqualError(diffItem.expected, inspect).nl(2).append(valueDiff);
                                     });
                                 } else {
                                     this.append(inspect(diffItem.value).amend(delimiterOutput.sp())).annotationBlock(function () {
@@ -648,7 +633,7 @@ module.exports = function (expect) {
                 .nl(suffixOutput.isEmpty() ? 0 : 1)
                 .append(suffixOutput);
 
-            return result;
+            return output;
         }
     });
 
@@ -717,20 +702,17 @@ module.exports = function (expect) {
         },
         diff: function (actual, expected, output, diff) {
             if (actual.constructor !== expected.constructor) {
-                return {
-                    diff: output.text('Mismatching constructors ')
-                        .errorName(actual)
-                        .text(' should be ').errorName(expected),
-                    inline: false
-                };
+                return output.text('Mismatching constructors ')
+                    .errorName(actual)
+                    .text(' should be ').errorName(expected);
             }
 
-            var result = diff(this.unwrap(actual), this.unwrap(expected));
-            if (result && result.diff) {
-                result.diff = output.clone().errorName(actual).text('(').append(result.diff).text(')');
+            output = diff(this.unwrap(actual), this.unwrap(expected));
+            if (output) {
+                output = output.clone().errorName(actual).text('(').append(output).text(')');
 
             }
-            return result;
+            return output;
         }
     });
 
@@ -913,12 +895,7 @@ module.exports = function (expect) {
             output.jsRegexp(regExp);
         },
         diff: function (actual, expected, output, diff, inspect) {
-            var result = {
-                diff: output,
-                inline: false
-            };
-            output.stringDiff(String(actual), String(expected), {type: 'Chars', markUpSpecialCharacters: true});
-            return result;
+            return output.stringDiff(String(actual), String(expected), {type: 'Chars', markUpSpecialCharacters: true});
         }
     });
 
@@ -995,16 +972,15 @@ module.exports = function (expect) {
         },
         diffLimit: 512,
         diff: function (actual, expected, output, diff, inspect) {
-            var result = {diff: output};
             if (Math.max(actual.length, expected.length) > this.diffLimit) {
-                result.diff.jsComment('Diff suppressed due to size > ' + this.diffLimit);
+                output.jsComment('Diff suppressed due to size > ' + this.diffLimit);
             } else {
-                result.diff.stringDiff(this.hexDump(actual), this.hexDump(expected), {type: 'Chars', markUpSpecialCharacters: false})
+                output.stringDiff(this.hexDump(actual), this.hexDump(expected), {type: 'Chars', markUpSpecialCharacters: false})
                     .replaceText(/[\x00-\x1f\x7f-\xff␊␍]/g, '.').replaceText(/[│ ]/g, function (styles, content) {
                         this.text(content);
                     });
             }
-            return result;
+            return output;
         }
     });
 
@@ -1043,12 +1019,9 @@ module.exports = function (expect) {
             output.singleQuotedString(value);
         },
         diff: function (actual, expected, output, diff, inspect) {
-            var result = {
-                diff: output,
-                inline: false
-            };
-            output.stringDiff(actual, expected, {type: 'WordsWithSpace', markUpSpecialCharacters: true});
-            return result;
+            var d = output.stringDiff(actual, expected, {type: 'WordsWithSpace', markUpSpecialCharacters: true});
+            d.inline = false;
+            return d;
         }
     });
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "detect-indent": "3.0.1",
     "diff": "1.1.0",
     "leven": "1.0.0",
-    "magicpen": "5.6.0",
+    "magicpen": "5.7.0",
     "unexpected-bluebird": "2.9.34"
   },
   "devDependencies": {

--- a/test/api/addType.spec.js
+++ b/test/api/addType.spec.js
@@ -25,9 +25,9 @@ describe('addType', function () {
                     .text(')');
             },
             diff: function (actual, expected, output, diff) {
-                var comparison = diff({ value: actual.value }, { value: expected.value });
-                comparison.diff = output.text('box(').append(comparison.diff).text(')');
-                return comparison;
+                output = output.text('box(').append(diff({ value: actual.value }, { value: expected.value })).text(')');
+                output.inline = true;
+                return output;
             }
         });
     });

--- a/test/api/addType.spec.js
+++ b/test/api/addType.spec.js
@@ -1,35 +1,8 @@
 /*global expect*/
 describe('addType', function () {
-    function box(value) {
-        return {
-            isBox: true,
-            value: value
-        };
-    }
     var clonedExpect;
-
     beforeEach(function () {
         clonedExpect = expect.clone();
-        clonedExpect.addType({
-            name: 'box',
-            identify: function (obj) {
-                return obj && typeof obj === 'object' && obj.isBox;
-            },
-            equal: function (a, b, equal) {
-                return a === b || equal(a.value, b.value);
-            },
-            inspect: function (obj, depth, output, inspect) {
-                return output
-                    .text('box(')
-                    .append(inspect(obj.value))
-                    .text(')');
-            },
-            diff: function (actual, expected, output, diff) {
-                output = output.text('box(').append(diff({ value: actual.value }, { value: expected.value })).text(')');
-                output.inline = true;
-                return output;
-            }
-        });
     });
 
     it('throws an expection if the type has an empty or undefined name', function () {
@@ -82,72 +55,105 @@ describe('addType', function () {
         }, 'to throw', 'A type must be given a non-empty name and must match ^[a-z_](?:|[a-z0-9_.-]*[_a-z0-9])$');
     });
 
-    it('should use the equal defined by the type', function () {
-        clonedExpect(box(123), 'to equal', box(123));
-        clonedExpect(box(123), 'not to equal', box(321));
-    });
+    describe('with a custom box type', function () {
+        function box(value) {
+            return {
+                isBox: true,
+                value: value
+            };
+        }
 
-    it('shows a diff in case of a mismatch', function () {
-        expect(function () {
-            clonedExpect(box(box(123)), 'to equal', box(box(456)));
-        }, 'to throw', "expected box(box(123)) to equal box(box(456))\n" +
-               "\n" +
-               "box({\n" +
-               "  value: box({\n" +
-               "    value: 123 // should equal 456\n" +
-               "  })\n" +
-               "})");
-    });
+        describe('added with a base type of any', function () {
+            beforeEach(function () {
+                clonedExpect.addType({
+                    name: 'box',
+                    identify: function (obj) {
+                        return obj && typeof obj === 'object' && obj.isBox;
+                    },
+                    equal: function (a, b, equal) {
+                        return a === b || equal(a.value, b.value);
+                    },
+                    inspect: function (obj, depth, output, inspect) {
+                        return output
+                            .text('box(')
+                            .append(inspect(obj.value))
+                            .text(')');
+                    },
+                    diff: function (actual, expected, output, diff) {
+                        output = output.text('box(').append(diff({ value: actual.value }, { value: expected.value })).text(')');
+                        output.inline = true;
+                        return output;
+                    }
+                });
+            });
 
-    describe('with base type wrapperObject', function () {
-        beforeEach(function () {
-            clonedExpect = expect.clone();
-            clonedExpect.addType({
-                name: 'box',
-                base: 'wrapperObject',
-                identify: function (obj) {
-                    return obj && typeof obj === 'object' && obj.isBox;
-                },
-                unwrap: function (box) {
-                    return box.value;
-                },
-                prefix: function (output) {
-                    return output.text('box(');
-                },
-                suffix: function (output) {
-                    return output.text(')');
-                }
+            it('should use the equal defined by the type', function () {
+                clonedExpect(box(123), 'to equal', box(123));
+                clonedExpect(box(123), 'not to equal', box(321));
+            });
+
+            it('shows a diff in case of a mismatch', function () {
+                expect(function () {
+                    clonedExpect(box(box(123)), 'to equal', box(box(456)));
+                }, 'to throw', "expected box(box(123)) to equal box(box(456))\n" +
+                       "\n" +
+                       "box({\n" +
+                       "  value: box({\n" +
+                       "    value: 123 // should equal 456\n" +
+                       "  })\n" +
+                       "})");
             });
         });
 
-        it('should use the equal defined by the type', function () {
-            clonedExpect(box(123), 'to equal', box(123));
-            clonedExpect(box(123), 'not to equal', box(321));
-        });
+        describe('added with a base type of wrapperObject', function () {
+            beforeEach(function () {
+                clonedExpect.addType({
+                    name: 'box',
+                    base: 'wrapperObject',
+                    identify: function (obj) {
+                        return obj && typeof obj === 'object' && obj.isBox;
+                    },
+                    unwrap: function (box) {
+                        return box.value;
+                    },
+                    prefix: function (output) {
+                        return output.text('box(');
+                    },
+                    suffix: function (output) {
+                        return output.text(')');
+                    }
+                });
+            });
 
-        it('shows a diff in case of a mismatch', function () {
-            expect(function () {
-                clonedExpect(box(box(123)), 'to equal', box(box(456)));
-            }, 'to throw', "expected box(box(123)) to equal box(box(456))\n" +
-                   "\n" +
-                   "box(box(\n" +
-                   "  123 // should equal 456\n" +
-                   "))");
-        });
+            it('should use the equal defined by the type', function () {
+                clonedExpect(box(123), 'to equal', box(123));
+                clonedExpect(box(123), 'not to equal', box(321));
+            });
 
-        it('should include the diff when one is available', function () {
-            expect(function () {
-                clonedExpect(box('abc'), 'to equal', box('abe'));
-            }, 'to throw',
-                   "expected box('abc') to equal box('abe')\n" +
-                   "\n" +
-                   "box(\n" +
-                   "  'abc' // should equal 'abe'\n" +
-                   "        //\n" +
-                   "        // -abc\n" +
-                   "        // +abe\n" +
-                   ")"
-                  );
+            it('shows a diff in case of a mismatch', function () {
+                expect(function () {
+                    clonedExpect(box(box(123)), 'to equal', box(box(456)));
+                }, 'to throw', "expected box(box(123)) to equal box(box(456))\n" +
+                       "\n" +
+                       "box(box(\n" +
+                       "  123 // should equal 456\n" +
+                       "))");
+            });
+
+            it('should include the diff when one is available', function () {
+                expect(function () {
+                    clonedExpect(box('abc'), 'to equal', box('abe'));
+                }, 'to throw',
+                       "expected box('abc') to equal box('abe')\n" +
+                       "\n" +
+                       "box(\n" +
+                       "  'abc' // should equal 'abe'\n" +
+                       "        //\n" +
+                       "        // -abc\n" +
+                       "        // +abe\n" +
+                       ")"
+                      );
+            });
         });
     });
 });

--- a/test/api/fail.spec.js
+++ b/test/api/fail.spec.js
@@ -79,4 +79,45 @@ describe('fail assertion', function () {
             });
         });
     });
+
+    describe('with a diff function', function () {
+        it('should generate the diff', function () {
+            var clonedExpect = expect.clone();
+            clonedExpect.addAssertion('<any> to foo', function (expect, subject, value) {
+                expect.fail({
+                    diff: function (output, diff, inspect, equal) {
+                        return output.text('custom');
+                    }
+                });
+            });
+            expect(function () {
+                clonedExpect('bar', 'to foo');
+            }, 'to throw',
+                "expected 'bar' to foo\n" +
+                "\n" +
+                "custom"
+            );
+        });
+
+        it('should support a diff function that uses the old API', function () {
+            var clonedExpect = expect.clone();
+            clonedExpect.addAssertion('<any> to foo', function (expect, subject, value) {
+                expect.fail({
+                    diff: function (output, diff, inspect, equal) {
+                        return {
+                            inline: false,
+                            diff: output.text('custom')
+                        };
+                    }
+                });
+            });
+            expect(function () {
+                clonedExpect('bar', 'to foo');
+            }, 'to throw',
+                "expected 'bar' to foo\n" +
+                "\n" +
+                "custom"
+            );
+        });
+    });
 });

--- a/test/types/array-like-type.spec.js
+++ b/test/types/array-like-type.spec.js
@@ -26,7 +26,7 @@ describe('array-like type', function () {
 
         it('should not render the indentation when an instance is diffed', function () {
             expect(
-                clonedExpect.diff(['a', 'b'], ['aa', 'bb']).diff.toString(),
+                clonedExpect.diff(['a', 'b'], ['aa', 'bb']).toString(),
                 'to equal',
                 "[\n" +
                 "'a', // should equal 'aa'\n" +
@@ -87,7 +87,7 @@ describe('array-like type', function () {
 
         it('should not render the prefix, suffix, and the newlines when an instance is diffed', function () {
             expect(
-                clonedExpect.diff(['a', 'b'], ['aa', 'bb']).diff.toString(),
+                clonedExpect.diff(['a', 'b'], ['aa', 'bb']).toString(),
                 'to equal',
                 "  'a', // should equal 'aa'\n" +
                 "       //\n" +

--- a/test/types/object-type.spec.js
+++ b/test/types/object-type.spec.js
@@ -66,7 +66,7 @@ describe('object type', function () {
 
         it('should not render the indentation when an instance is diffed', function () {
             expect(
-                clonedExpect.diff({a: 'a', b: 'b'}, {a: 'aa', b: 'bb'}).diff.toString(),
+                clonedExpect.diff({a: 'a', b: 'b'}, {a: 'aa', b: 'bb'}).toString(),
                 'to equal',
                 "{\n" +
                 "a: 'a', // should equal 'aa'\n" +
@@ -129,7 +129,7 @@ describe('object type', function () {
 
         it('should not render the prefix, suffix, and the newlines when an instance is diffed', function () {
             expect(
-                clonedExpect.diff({a: 'a', b: 'b'}, {a: 'aa', b: 'bb'}).diff.toString(),
+                clonedExpect.diff({a: 'a', b: 'b'}, {a: 'aa', b: 'bb'}).toString(),
                 'to equal',
                 "  a: 'a', // should equal 'aa'\n" +
                 "          //\n" +

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -775,4 +775,24 @@ describe('unexpected', function () {
             });
         });
     });
+
+    describe('#output', function () {
+        it('does not allow the creation of a style named "inline"', function () {
+            expect(function () {
+                expect.output.addStyle('inline', function () {});
+            }, 'to throw', '"inline" style cannot be defined, it clashes with a built-in attribute');
+        });
+
+        it('does not allow the creation of a style named "inline" on a clone', function () {
+            expect(function () {
+                expect.output.clone().addStyle('inline', function () {});
+            }, 'to throw', '"inline" style cannot be defined, it clashes with a built-in attribute');
+        });
+
+        it('does not allow the creation of a style named "diff"', function () {
+            expect(function () {
+                expect.output.addStyle('diff', function () {});
+            }, 'to throw', '"diff" style cannot be defined, it clashes with a built-in attribute');
+        });
+    });
 });


### PR DESCRIPTION
I've been a bit annoyed with the intermediate `{ inline: <boolean>, diff: <magicpen> }` object returned by diffing functions and wanted to try to get rid of it. I think it adds boilerplate, makes it harder to grasp the API and name variables (is it a "diffResult"?)

My idea is to move the `inline` attribute to the MagicPen instance and just return that. In order to remain backwards compatible, a `diff` property is mounted on the MagicPen instance pointing to the instance itself. The compatibility layer can of course be removed later.

At some point we discussed the `inline` property and concluded that it might not so much be a property of the diff itself, but a mode that the caller picks. If we make a change like that later, I suppose we'll also want to get rid of the `diffResult` object, so this change will help out with that.

This change would also make it possible to not require diffing functions to return the `output` that was passed in, just like `inspect`. I can quickly add that feature if there's any interest :)

Drawbacks to merging this:

* We would sort of reserve the `inline` and `diff` property names on magicpen instances, at least for a while
* The backwards compatibility code adds complexity
* It might be a matter of taste. I suppose there was a good reason why it was originally implemented in this way.