### PR TITLE
Refactor string diff code

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -358,6 +358,11 @@ module.exports = function (expect) {
                 this.alt({
                     text: function () {
                         this.text({added: '+', removed: '-'}[type] || ' ');
+                    },
+                    fallback: function () {
+                        if (line === '' && (type === 'added' || type === 'removed')) {
+                            this[specialCharStyle || baseStyle]('\\n');
+                        }
                     }
                 });
             }
@@ -421,8 +426,8 @@ module.exports = function (expect) {
                     } else if (part.removed) {
                         this.diffFragment('removed', part.value, 'diffRemovedHighlight', 'diffRemovedSpecialChar', options.markUpSpecialCharacters, true);
                     } else {
-                        newLine.diffFragment('added', part.value, 'diffAddedLine', undefined);
-                        this.diffFragment('removed', part.value, 'diffRemovedLine', undefined);
+                        newLine.diffFragment('added', part.value, 'diffAddedLine', 'diffAddedSpecialChar');
+                        this.diffFragment('removed', part.value, 'diffRemovedLine', 'diffRemovedSpecialChar');
                     }
                 }, this);
                 if (oldEndsWithNewline && !newEndsWithNewline) {
@@ -443,9 +448,9 @@ module.exports = function (expect) {
                     part.value.slice(0, -1) :
                     part.value;
                 if (part.added) {
-                    this.diffFragment('added', value, 'diffAddedLine', undefined, options.markUpSpecialCharacters);
+                    this.diffFragment('added', value, 'diffAddedLine', 'diffAddedSpecialChar', options.markUpSpecialCharacters);
                 } else if (part.removed) {
-                    this.diffFragment('removed', value, 'diffRemovedLine', undefined, options.markUpSpecialCharacters);
+                    this.diffFragment('removed', value, 'diffRemovedLine', 'diffRemovedSpecialChar', options.markUpSpecialCharacters);
                 } else {
                     var outer = this;
                     this.alt({

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -352,8 +352,7 @@ module.exports = function (expect) {
 
     expect.addStyle('stringDiffFragment', function (ch, text, baseStyle, specialCharStyle, markUpSpecialCharacters) {
         text.split(/\n/).forEach(function (line, i, lines) {
-            // Are we at the start of a line? (might want to add a magicpen method for this :)
-            if (this.output.length === 0 || this.output[this.output.length - 1].length === 0) {
+            if (this.isAtStartOfLine()) {
                 this.alt({
                     text: ch,
                     fallback: function () {

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -350,7 +350,7 @@ module.exports = function (expect) {
         }
     });
 
-    expect.addStyle('diffFragment', function (type, text, baseStyle, specialCharStyle, markUpSpecialCharacters) {
+    expect.addStyle('stringDiffFragment', function (type, text, baseStyle, specialCharStyle, markUpSpecialCharacters) {
         var lines = text.split(/\n/);
         lines.forEach(function (line, i) {
             // Are we at the start of a line? (might want to add a magicpen method for this :)
@@ -420,12 +420,12 @@ module.exports = function (expect) {
                 }
                 stringDiff['diff' + type](oldValue, newValue).forEach(function (part) {
                     if (part.added) {
-                        newLine.diffFragment('added', part.value, 'diffAddedHighlight', 'diffAddedSpecialChar', options.markUpSpecialCharacters, true);
+                        newLine.stringDiffFragment('added', part.value, 'diffAddedHighlight', 'diffAddedSpecialChar', options.markUpSpecialCharacters, true);
                     } else if (part.removed) {
-                        this.diffFragment('removed', part.value, 'diffRemovedHighlight', 'diffRemovedSpecialChar', options.markUpSpecialCharacters, true);
+                        this.stringDiffFragment('removed', part.value, 'diffRemovedHighlight', 'diffRemovedSpecialChar', options.markUpSpecialCharacters, true);
                     } else {
-                        newLine.diffFragment('added', part.value, 'diffAddedLine', 'diffAddedSpecialChar');
-                        this.diffFragment('removed', part.value, 'diffRemovedLine', 'diffRemovedSpecialChar');
+                        newLine.stringDiffFragment('added', part.value, 'diffAddedLine', 'diffAddedSpecialChar');
+                        this.stringDiffFragment('removed', part.value, 'diffRemovedLine', 'diffRemovedSpecialChar');
                     }
                 }, this);
                 if (newEndsWithNewline && !oldEndsWithNewline) {
@@ -442,11 +442,11 @@ module.exports = function (expect) {
                     part.value.slice(0, -1) :
                     part.value;
                 if (part.added) {
-                    this.diffFragment('added', value, 'diffAddedLine', 'diffAddedSpecialChar', options.markUpSpecialCharacters);
+                    this.stringDiffFragment('added', value, 'diffAddedLine', 'diffAddedSpecialChar', options.markUpSpecialCharacters);
                 } else if (part.removed) {
-                    this.diffFragment('removed', value, 'diffRemovedLine', 'diffRemovedSpecialChar', options.markUpSpecialCharacters);
+                    this.stringDiffFragment('removed', value, 'diffRemovedLine', 'diffRemovedSpecialChar', options.markUpSpecialCharacters);
                 } else {
-                    this.diffFragment('replaced', value, 'text');
+                    this.stringDiffFragment('replaced', value, 'text');
                 }
                 if (endsWithNewline) {
                     this.nl();

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -351,8 +351,7 @@ module.exports = function (expect) {
     });
 
     expect.addStyle('stringDiffFragment', function (type, text, baseStyle, specialCharStyle, markUpSpecialCharacters) {
-        var lines = text.split(/\n/);
-        lines.forEach(function (line, i) {
+        text.split(/\n/).forEach(function (line, i, lines) {
             // Are we at the start of a line? (might want to add a magicpen method for this :)
             if (this.output.length === 0 || this.output[this.output.length - 1].length === 0) {
                 this.alt({

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -356,9 +356,7 @@ module.exports = function (expect) {
             // Are we at the start of a line? (might want to add a magicpen method for this :)
             if (this.output.length === 0 || this.output[this.output.length - 1].length === 0) {
                 this.alt({
-                    text: function () {
-                        this.text({added: '+', removed: '-'}[type] || ' ');
-                    },
+                    text: {added: '+', removed: '-'}[type] || ' ',
                     fallback: function () {
                         if (line === '' && (type === 'added' || type === 'removed')) {
                             this[specialCharStyle || baseStyle]('\\n');

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -350,14 +350,14 @@ module.exports = function (expect) {
         }
     });
 
-    expect.addStyle('stringDiffFragment', function (type, text, baseStyle, specialCharStyle, markUpSpecialCharacters) {
+    expect.addStyle('stringDiffFragment', function (ch, text, baseStyle, specialCharStyle, markUpSpecialCharacters) {
         text.split(/\n/).forEach(function (line, i, lines) {
             // Are we at the start of a line? (might want to add a magicpen method for this :)
             if (this.output.length === 0 || this.output[this.output.length - 1].length === 0) {
                 this.alt({
-                    text: {added: '+', removed: '-'}[type] || ' ',
+                    text: ch,
                     fallback: function () {
-                        if (line === '' && (type === 'added' || type === 'removed')) {
+                        if (line === '' && ch !== ' ') {
                             this[specialCharStyle || baseStyle]('\\n');
                         }
                     }
@@ -419,12 +419,12 @@ module.exports = function (expect) {
                 }
                 stringDiff['diff' + type](oldValue, newValue).forEach(function (part) {
                     if (part.added) {
-                        newLine.stringDiffFragment('added', part.value, 'diffAddedHighlight', 'diffAddedSpecialChar', options.markUpSpecialCharacters, true);
+                        newLine.stringDiffFragment('+', part.value, 'diffAddedHighlight', 'diffAddedSpecialChar', options.markUpSpecialCharacters, true);
                     } else if (part.removed) {
-                        this.stringDiffFragment('removed', part.value, 'diffRemovedHighlight', 'diffRemovedSpecialChar', options.markUpSpecialCharacters, true);
+                        this.stringDiffFragment('-', part.value, 'diffRemovedHighlight', 'diffRemovedSpecialChar', options.markUpSpecialCharacters, true);
                     } else {
-                        newLine.stringDiffFragment('added', part.value, 'diffAddedLine', 'diffAddedSpecialChar');
-                        this.stringDiffFragment('removed', part.value, 'diffRemovedLine', 'diffRemovedSpecialChar');
+                        newLine.stringDiffFragment('+', part.value, 'diffAddedLine', 'diffAddedSpecialChar');
+                        this.stringDiffFragment('-', part.value, 'diffRemovedLine', 'diffRemovedSpecialChar');
                     }
                 }, this);
                 if (newEndsWithNewline && !oldEndsWithNewline) {
@@ -441,11 +441,11 @@ module.exports = function (expect) {
                     part.value.slice(0, -1) :
                     part.value;
                 if (part.added) {
-                    this.stringDiffFragment('added', value, 'diffAddedLine', 'diffAddedSpecialChar', options.markUpSpecialCharacters);
+                    this.stringDiffFragment('+', value, 'diffAddedLine', 'diffAddedSpecialChar', options.markUpSpecialCharacters);
                 } else if (part.removed) {
-                    this.stringDiffFragment('removed', value, 'diffRemovedLine', 'diffRemovedSpecialChar', options.markUpSpecialCharacters);
+                    this.stringDiffFragment('-', value, 'diffRemovedLine', 'diffRemovedSpecialChar', options.markUpSpecialCharacters);
                 } else {
-                    this.stringDiffFragment('replaced', value, 'text');
+                    this.stringDiffFragment(' ', value, 'text');
                 }
                 if (endsWithNewline) {
                     this.nl();

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -350,14 +350,14 @@ module.exports = function (expect) {
         }
     });
 
-    expect.addStyle('stringDiffFragment', function (ch, text, baseStyle, specialCharStyle, markUpSpecialCharacters) {
+    expect.addStyle('stringDiffFragment', function (ch, text, baseStyle, markUpSpecialCharacters) {
         text.split(/\n/).forEach(function (line, i, lines) {
             if (this.isAtStartOfLine()) {
                 this.alt({
                     text: ch,
                     fallback: function () {
                         if (line === '' && ch !== ' ') {
-                            this[specialCharStyle || baseStyle]('\\n');
+                            this[ch === '+' ? 'diffAddedSpecialChar' : 'diffRemovedSpecialChar']('\\n');
                         }
                     }
                 });
@@ -365,7 +365,7 @@ module.exports = function (expect) {
             if (markUpSpecialCharacters) {
                 line.split(specialCharRegExp).forEach(function (part) {
                     if (specialCharRegExp.test(part)) {
-                        this[specialCharStyle || baseStyle](utils.escapeChar(part));
+                        this[{'+': 'diffAddedSpecialChar', '-': 'diffRemovedSpecialChar'}[ch] || baseStyle](utils.escapeChar(part));
                     } else {
                         this[baseStyle](part);
                     }
@@ -418,12 +418,12 @@ module.exports = function (expect) {
                 }
                 stringDiff['diff' + type](oldValue, newValue).forEach(function (part) {
                     if (part.added) {
-                        newLine.stringDiffFragment('+', part.value, 'diffAddedHighlight', 'diffAddedSpecialChar', options.markUpSpecialCharacters, true);
+                        newLine.stringDiffFragment('+', part.value, 'diffAddedHighlight', options.markUpSpecialCharacters);
                     } else if (part.removed) {
-                        this.stringDiffFragment('-', part.value, 'diffRemovedHighlight', 'diffRemovedSpecialChar', options.markUpSpecialCharacters, true);
+                        this.stringDiffFragment('-', part.value, 'diffRemovedHighlight', options.markUpSpecialCharacters);
                     } else {
-                        newLine.stringDiffFragment('+', part.value, 'diffAddedLine', 'diffAddedSpecialChar');
-                        this.stringDiffFragment('-', part.value, 'diffRemovedLine', 'diffRemovedSpecialChar');
+                        newLine.stringDiffFragment('+', part.value, 'diffAddedLine');
+                        this.stringDiffFragment('-', part.value, 'diffRemovedLine');
                     }
                 }, this);
                 if (newEndsWithNewline && !oldEndsWithNewline) {
@@ -440,9 +440,9 @@ module.exports = function (expect) {
                     part.value.slice(0, -1) :
                     part.value;
                 if (part.added) {
-                    this.stringDiffFragment('+', value, 'diffAddedLine', 'diffAddedSpecialChar', options.markUpSpecialCharacters);
+                    this.stringDiffFragment('+', value, 'diffAddedLine', options.markUpSpecialCharacters);
                 } else if (part.removed) {
-                    this.stringDiffFragment('-', value, 'diffRemovedLine', 'diffRemovedSpecialChar', options.markUpSpecialCharacters);
+                    this.stringDiffFragment('-', value, 'diffRemovedLine', options.markUpSpecialCharacters);
                 } else {
                     this.stringDiffFragment(' ', value, 'text');
                 }

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -350,18 +350,32 @@ module.exports = function (expect) {
         }
     });
 
-    expect.addStyle('diffFragment', function (text, baseStyle, specialCharStyle, markUpSpecialCharacters) {
-        if (markUpSpecialCharacters) {
-            text.split(specialCharRegExp).forEach(function (part) {
-                if (specialCharRegExp.test(part)) {
-                    this[specialCharStyle || baseStyle](utils.escapeChar(part));
-                } else {
-                    this[baseStyle](part);
-                }
-            }, this);
-        } else {
-            this[baseStyle](text);
-        }
+    expect.addStyle('diffFragment', function (type, text, baseStyle, specialCharStyle, markUpSpecialCharacters) {
+        var lines = text.split(/\n/);
+        lines.forEach(function (line, i) {
+            // Are we at the start of a line? (might want to add a magicpen method for this :)
+            if (this.output.length === 0 || this.output[this.output.length - 1].length === 0) {
+                this.alt({
+                    text: function () {
+                        this.text({added: '+', removed: '-'}[type] || ' ');
+                    }
+                });
+            }
+            if (markUpSpecialCharacters) {
+                line.split(specialCharRegExp).forEach(function (part) {
+                    if (specialCharRegExp.test(part)) {
+                        this[specialCharStyle || baseStyle](utils.escapeChar(part));
+                    } else {
+                        this[baseStyle](part);
+                    }
+                }, this);
+            } else {
+                this[baseStyle](line);
+            }
+            if (i !== lines.length - 1) {
+                this.nl();
+            }
+        }, this);
     });
 
     expect.addStyle('stringDiff', function (actual, expected, options) {
@@ -392,7 +406,6 @@ module.exports = function (expect) {
             if (part.replaced) {
                 var oldValue = part.oldValue;
                 var newValue = part.newValue;
-                var oldLine = this.clone();
                 var newLine = this.clone();
                 var oldEndsWithNewline = oldValue.slice(-1) === '\n';
                 var newEndsWithNewline = newValue.slice(-1) === '\n';
@@ -402,33 +415,25 @@ module.exports = function (expect) {
                 if (newEndsWithNewline) {
                     newValue = newValue.slice(0, -1);
                 }
-
                 stringDiff['diff' + type](oldValue, newValue).forEach(function (part) {
                     if (part.added) {
-                        newLine.diffFragment(part.value, 'diffAddedHighlight', 'diffAddedSpecialChar', options.markUpSpecialCharacters);
+                        newLine.diffFragment('added', part.value, 'diffAddedHighlight', 'diffAddedSpecialChar', options.markUpSpecialCharacters, true);
                     } else if (part.removed) {
-                        oldLine.diffFragment(part.value, 'diffRemovedHighlight', 'diffRemovedSpecialChar', options.markUpSpecialCharacters);
+                        this.diffFragment('removed', part.value, 'diffRemovedHighlight', 'diffRemovedSpecialChar', options.markUpSpecialCharacters, true);
                     } else {
-                        newLine.diffAddedLine(part.value);
-                        oldLine.diffRemovedLine(part.value);
+                        newLine.diffFragment('added', part.value, 'diffAddedLine', undefined);
+                        this.diffFragment('removed', part.value, 'diffRemovedLine', undefined);
                     }
-                });
-                this.alt({
-                    text: function () {
-                        oldLine.prependLinesWith(this.clone().diffRemovedLine('-'));
-                        newLine.prependLinesWith(this.clone().diffAddedLine('+'));
-                    }
-                });
-
+                }, this);
                 if (oldEndsWithNewline && !newEndsWithNewline) {
-                    oldLine.diffRemovedSpecialChar('\\n');
+                    this.diffRemovedSpecialChar('\\n');
                 }
 
                 if (newEndsWithNewline && !oldEndsWithNewline) {
                     newLine.diffAddedSpecialChar('\\n');
                 }
 
-                this.append(oldLine).nl().append(newLine);
+                this.nl().append(newLine);
                 if (oldEndsWithNewline && index < diffLines.length - 1) {
                     this.nl();
                 }
@@ -438,29 +443,9 @@ module.exports = function (expect) {
                     part.value.slice(0, -1) :
                     part.value;
                 if (part.added) {
-                    this.append(function () {
-                        this.diffFragment(value, 'diffAddedLine', undefined, options.markUpSpecialCharacters);
-                        var outer = this;
-                        this.alt({
-                            text: function () {
-                                outer.prependLinesWith(function () {
-                                    this.diffAddedLine('+');
-                                });
-                            }
-                        });
-                    });
+                    this.diffFragment('added', value, 'diffAddedLine', undefined, options.markUpSpecialCharacters);
                 } else if (part.removed) {
-                    this.append(function () {
-                        this.diffFragment(value, 'diffRemovedLine', undefined, options.markUpSpecialCharacters);
-                        var outer = this;
-                        this.alt({
-                            text: function () {
-                                outer.prependLinesWith(function () {
-                                    this.diffRemovedLine('-');
-                                });
-                            }
-                        });
-                    });
+                    this.diffFragment('removed', value, 'diffRemovedLine', undefined, options.markUpSpecialCharacters);
                 } else {
                     var outer = this;
                     this.alt({

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -396,10 +396,10 @@ module.exports = function (expect) {
                     replaced: true
                 });
                 lastPart = null;
-            } else if (lastPart) {
-                diffLines.push(lastPart);
-                lastPart = part;
             } else {
+                if (lastPart) {
+                    diffLines.push(lastPart);
+                }
                 lastPart = part;
             }
         });
@@ -430,18 +430,14 @@ module.exports = function (expect) {
                         this.diffFragment('removed', part.value, 'diffRemovedLine', 'diffRemovedSpecialChar');
                     }
                 }, this);
-                if (oldEndsWithNewline && !newEndsWithNewline) {
-                    this.diffRemovedSpecialChar('\\n');
-                }
-
                 if (newEndsWithNewline && !oldEndsWithNewline) {
                     newLine.diffAddedSpecialChar('\\n');
                 }
 
-                this.nl().append(newLine);
-                if (oldEndsWithNewline && index < diffLines.length - 1) {
-                    this.nl();
+                if (oldEndsWithNewline && !newEndsWithNewline) {
+                    this.diffRemovedSpecialChar('\\n');
                 }
+                this.nl().append(newLine).nl(oldEndsWithNewline && index < diffLines.length - 1 ? 1 : 0);
             } else {
                 var endsWithNewline = /\n$/.test(part.value);
                 var value = endsWithNewline ?
@@ -452,15 +448,7 @@ module.exports = function (expect) {
                 } else if (part.removed) {
                     this.diffFragment('removed', value, 'diffRemovedLine', 'diffRemovedSpecialChar', options.markUpSpecialCharacters);
                 } else {
-                    var outer = this;
-                    this.alt({
-                        text: function () {
-                            outer.text(value.replace(/^(.)/gm, ' $1'));
-                        },
-                        fallback: function () {
-                            this.text(value);
-                        }
-                    });
+                    this.diffFragment('replaced', value, 'text');
                 }
                 if (endsWithNewline) {
                     this.nl();

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "detect-indent": "3.0.1",
     "diff": "1.1.0",
     "leven": "1.0.0",
-    "magicpen": "5.7.0",
+    "magicpen": "5.8.0",
     "unexpected-bluebird": "2.9.34"
   },
   "devDependencies": {

--- a/test/styles/stringDiff.spec.js
+++ b/test/styles/stringDiff.spec.js
@@ -3,60 +3,79 @@ describe('stringDiff', function () {
     var actual = 'abc\ndef\nghi\njkl\nmno';
     var expected = 'ghi\njkl\nmno\npqr\nstu\nvwx';
 
-    it('outputs leading + and - in text mode', function () {
-        expect(
-            expect.createOutput('text').stringDiff(actual, expected),
-            'to equal',
-            expect.createOutput('text')
-                .block(function () {
-                    this
-                      .diffRemovedLine('-').nl()
-                      .diffRemovedLine('-');
-                })
-                .block(function () {
-                    this
-                        .diffRemovedLine('abc').nl()
-                        .diffRemovedLine('def');
-                }).nl()
-                .text(' ghi').nl()
-                .text(' jkl').nl()
-                .block(function () {
-                    this.diffRemovedLine('-');
-                })
-                .block(function () {
-                    this.diffRemovedLine('mno');
-                }).nl()
-                .block(function () {
-                    this
-                        .diffAddedLine('+').nl()
-                        .diffAddedLine('+').nl()
-                        .diffAddedLine('+').nl()
-                        .diffAddedLine('+');
-                })
-                .block(function () {
-                    this
-                      .diffAddedLine('mno').nl()
-                      .diffAddedHighlight('pqr').nl()
-                      .diffAddedHighlight('stu').nl()
-                      .diffAddedHighlight('vwx');
-                })
-        );
+    describe('in text mode', function () {
+        it('outputs leading + and - in text mode', function () {
+            var pen = expect.createOutput('text').stringDiff(actual, expected);
+            expect(
+                pen.toString(),
+                'to equal',
+                '-abc\n' +
+                '-def\n' +
+                ' ghi\n' +
+                ' jkl\n' +
+                '-mno\n' +
+                '+mno\n' +
+                '+pqr\n' +
+                '+stu\n' +
+                '+vwx'
+            );
+
+            expect(
+                pen,
+                'to equal',
+                expect.createOutput('text')
+                    .block(function () {
+                        this
+                          .diffRemovedLine('-').nl()
+                          .diffRemovedLine('-');
+                    })
+                    .block(function () {
+                        this
+                            .diffRemovedLine('abc').nl()
+                            .diffRemovedLine('def');
+                    }).nl()
+                    .text(' ghi').nl()
+                    .text(' jkl').nl()
+                    .block(function () {
+                        this.diffRemovedLine('-');
+                    })
+                    .block(function () {
+                        this.diffRemovedLine('mno');
+                    }).nl()
+                    .block(function () {
+                        this
+                            .diffAddedLine('+').nl()
+                            .diffAddedLine('+').nl()
+                            .diffAddedLine('+').nl()
+                            .diffAddedLine('+');
+                    })
+                    .block(function () {
+                        this
+                          .diffAddedLine('mno').nl()
+                          .diffAddedHighlight('pqr').nl()
+                          .diffAddedHighlight('stu').nl()
+                          .diffAddedHighlight('vwx');
+                    })
+            );
+        });
     });
 
-    it('does not output leading + and - in ansi mode', function () {
-        expect(
-            expect.createOutput('ansi').stringDiff(actual, expected),
-            'to equal',
-            expect.createOutput('ansi')
-                .diffRemovedLine('abc').nl()
-                .diffRemovedLine('def').nl()
-                .text('ghi').nl()
-                .text('jkl').nl()
-                .diffRemovedLine('mno').nl()
-                .diffAddedLine('mno').nl()
-                .diffAddedHighlight('pqr').nl()
-                .diffAddedHighlight('stu').nl()
-                .diffAddedHighlight('vwx')
-        );
+    describe('in ansi mode', function () {
+        it('does not output leading + and -', function () {
+            expect(
+                expect.createOutput('ansi').stringDiff(actual, expected),
+                'to equal',
+                expect.createOutput('ansi')
+                    .diffRemovedLine('abc').nl()
+                    .diffRemovedLine('def').nl()
+                    .text('ghi').nl()
+                    .text('jkl').nl()
+                    .diffRemovedLine('mno').nl()
+                    .diffAddedLine('mno').nl()
+                    .diffAddedHighlight('pqr').nl()
+                    .diffAddedHighlight('stu').nl()
+                    .diffAddedHighlight('vwx')
+            );
+        });
     });
 });

--- a/test/styles/stringDiff.spec.js
+++ b/test/styles/stringDiff.spec.js
@@ -77,5 +77,23 @@ describe('stringDiff', function () {
                     .diffAddedHighlight('vwx')
             );
         });
+
+        it('renders escaped newlines when a line has been removed', function () {
+            expect(
+                expect.createOutput('ansi').stringDiff('\n', ''),
+                'to equal',
+                expect.createOutput('ansi')
+                    .diffRemovedSpecialChar('\\n').nl()
+            );
+        });
+
+        it('renders escaped newlines when a line has been added', function () {
+            expect(
+                expect.createOutput('ansi').stringDiff('', '\n'),
+                'to equal',
+                expect.createOutput('ansi')
+                    .diffAddedSpecialChar('\\n').nl()
+            );
+        });
     });
 });


### PR DESCRIPTION
As discussed in https://github.com/unexpectedjs/unexpected/issues/272

This gets rid of `prependLinesWith`, makes the output more efficient, and removes some duplication. Also, it makes removed/added empty lines recognizable in html and ansi modes.

It's not really done yet, but ready for feedback.