### PR TITLE
Make unexpected errors more resilient to weird post processing of the stack

### DIFF
--- a/lib/UnexpectedError.js
+++ b/lib/UnexpectedError.js
@@ -22,7 +22,7 @@ function UnexpectedError(expect, parent) {
 
     this.expect = expect;
     this.parent = parent || null;
-    this.name = 'UnexpectedError';
+    this.name = 'Error';
 }
 
 UnexpectedError.prototype = Object.create(Error.prototype);
@@ -200,6 +200,16 @@ UnexpectedError.prototype.getErrorMessage = function (options) {
     }
 };
 
+function findStackStart(lines) {
+    for (var i = lines.length - 1; 0 <= i; i -= 1) {
+        if (lines[i] === '') {
+            return i + 1;
+        }
+    }
+
+    return -1;
+}
+
 UnexpectedError.prototype.serializeMessage = function (outputFormat) {
     if (!this._hasSerializedErrorMessage) {
         var htmlFormat = outputFormat === 'html';
@@ -211,14 +221,17 @@ UnexpectedError.prototype.serializeMessage = function (outputFormat) {
 
         this.message = '\n' + this.getErrorMessage({
             format: htmlFormat ? 'text' : outputFormat
-        }).toString();
+        }).toString() + '\n';
 
         if (!this.useFullStackTrace) {
             var newStack = [];
             var removedFrames = false;
             var lines = this.stack.split(/\n/);
+
+            var stackStart = findStackStart(lines);
+
             lines.forEach(function (line, i) {
-                if (i !== 0 && (/node_modules\/unexpected(?:-[^\/]+)?\//).test(line)) {
+                if (stackStart <= i && (/node_modules\/unexpected(?:-[^\/]+)?\//).test(line)) {
                     removedFrames = true;
                 } else {
                     newStack.push(line);
@@ -233,7 +246,6 @@ UnexpectedError.prototype.serializeMessage = function (outputFormat) {
                 } else {
                     newStack.push(indentation + 'set UNEXPECTED_FULL_TRACE=true to see the full stack trace');
                 }
-
             }
 
             this.stack = newStack.join('\n');

--- a/test/api/fail.spec.js
+++ b/test/api/fail.spec.js
@@ -65,7 +65,7 @@ describe('fail assertion', function () {
                     message: 'hey'
                 });
             }, 'to throw', {
-                message: '\nhey'
+                message: '\nhey\n'
             });
         });
 
@@ -75,7 +75,7 @@ describe('fail assertion', function () {
                     message: expect.output.clone().text('hey')
                 });
             }, 'to throw', {
-                message: '\nhey'
+                message: '\nhey\n'
             });
         });
     });

--- a/test/api/outputFormat.spec.js
+++ b/test/api/outputFormat.spec.js
@@ -16,7 +16,7 @@ describe('outputFormat', function () {
                 var clonedExpect = expect.clone().outputFormat('ansi');
                 clonedExpect(42, 'to equal', 24);
             }, 'to throw', {
-                message: '\n\x1b[31m\x1b[1mexpected\x1b[22m\x1b[39m 42 \x1b[31m\x1b[1mto equal\x1b[22m\x1b[39m 24'
+                message: '\n\x1b[31m\x1b[1mexpected\x1b[22m\x1b[39m 42 \x1b[31m\x1b[1mto equal\x1b[22m\x1b[39m 24\n'
             });
         });
     });


### PR DESCRIPTION
I have been running into several errors related to post processing of the stack by different test frameworks. 

* Karma-mocha will consider parts of error message as the stack if it looks like the stack. In this case it was unexpected-sinon that was conflicting with it. The result of this error is that you will not get the error message removed from the stack, so you'll get a double error.
* Jasmine html runner don't like the name of the error to be anything else than `Error`, otherwise it will cut the stack trace incorrectly.

All in all it seems like a good idea to separate the stack trace from the error message, for me that also works out well visually.

This PR also makes sure that we will only remove stack frames and not parts of the error message that looks like a stack trace.