### PR TITLE
expect.it: Always fail when there's a misspelled assertion

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -221,16 +221,9 @@ function createExpectIt(expect, expectations) {
             }) && !groupEvaluations.some(function (groupEvaluation) {
                 // If one of the or groups has a bubbleThrough error as the
                 // first failing assertion, fail the whole expect.it:
-                for (var i = 0 ; i < groupEvaluation.length ; i += 1) {
-                    var evaluation = groupEvaluation[i];
-                    if (evaluation.promise.isRejected()) {
-                        if (evaluation.promise.reason().errorMode === 'bubbleThrough') {
-                            return true;
-                        } else {
-                            break;
-                        }
-                    }
-                }
+                return groupEvaluation.some(function (evaluation) {
+                    return evaluation.promise.isRejected() && evaluation.promise.reason().errorMode === 'bubbleThrough';
+                });
             });
 
             if (!isSuccessful) {
@@ -857,7 +850,6 @@ Unexpected.prototype.throwAssertionNotFoundError = function (subject, testDescri
     var candidateHandlers = this.assertions[testDescriptionString];
     if (candidateHandlers) {
         this.fail({
-            errorMode: 'bubbleThrough',
             message: function (output) {
                 var subjectOutput = function (output) {
                     output.appendInspected(subject);

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -214,19 +214,19 @@ function createExpectIt(expect, expectations) {
         });
 
         return oathbreaker(expect.promise.settle(promises).then(function () {
-            var isSuccessful = groupEvaluations.some(function (groupEvaluation) {
-                return groupEvaluation.every(function (evaluation) {
-                    return evaluation.promise.isFulfilled();
-                });
-            }) && !groupEvaluations.some(function (groupEvaluation) {
-                // If one of the or groups has a bubbleThrough error as the
-                // first failing assertion, fail the whole expect.it:
-                return groupEvaluation.some(function (evaluation) {
-                    return evaluation.promise.isRejected() && evaluation.promise.reason().errorMode === 'bubbleThrough';
+            groupEvaluations.forEach(function (groupEvaluation) {
+                groupEvaluation.forEach(function (evaluation) {
+                    if (evaluation.promise.isRejected() && evaluation.promise.reason().errorMode === 'bubbleThrough') {
+                        throw evaluation.promise.reason();
+                    }
                 });
             });
 
-            if (!isSuccessful) {
+            if (!groupEvaluations.some(function (groupEvaluation) {
+                return groupEvaluation.every(function (evaluation) {
+                    return evaluation.promise.isFulfilled();
+                });
+            })) {
                 expect.fail(function (output) {
                     writeGroupEvaluationsToOutput(expect, output, groupEvaluations);
                 });

--- a/test/api/it.spec.js
+++ b/test/api/it.spec.js
@@ -223,8 +223,7 @@ describe('expect.it', function () {
             "expect.it('this is misspelled', 1)\n" +
             "      .or('to be a string')\n" +
             "\n" +
-            "⨯ Unknown assertion 'this is misspelled', did you mean: 'to be fulfilled' or\n" +
-            "✓ expected 'foo' to be a string"
+            "Unknown assertion 'this is misspelled', did you mean: 'to be fulfilled'"
         );
     });
 
@@ -237,10 +236,7 @@ describe('expect.it', function () {
             "        .and('misspelled')\n" +
             "      .or('to be a string')\n" +
             "\n" +
-            "⨯ expected 'foo' to begin with 'bar' and\n" +
-            "⨯ expected 'foo' misspelled\n" +
-            "or\n" +
-            "✓ expected 'foo' to be a string"
+            "Unknown assertion 'misspelled', did you mean: 'called'"
         );
     });
 

--- a/test/api/it.spec.js
+++ b/test/api/it.spec.js
@@ -228,7 +228,23 @@ describe('expect.it', function () {
         );
     });
 
-    it('should not fail with a "missing assertion" error when it is not the first failing one in an "and" group', function () {
-        expect('foo', 'to satisfy', expect.it('to begin with', 'bar').and('misspelled').or('to be a string'));
+    it('should fail with a "missing assertion" error even when it is not the first failing one in an "and" group', function () {
+        expect(function () {
+            expect('foo', 'to satisfy', expect.it('to begin with', 'bar').and('misspelled').or('to be a string'));
+        }, 'to throw',
+            "expected 'foo' to satisfy\n" +
+            "expect.it('to begin with', 'bar')\n" +
+            "        .and('misspelled')\n" +
+            "      .or('to be a string')\n" +
+            "\n" +
+            "⨯ expected 'foo' to begin with 'bar' and\n" +
+            "⨯ expected 'foo' misspelled\n" +
+            "or\n" +
+            "✓ expected 'foo' to be a string"
+        );
+    });
+
+    it('should not fail when the first clause in an or group specifies an assertion that is not defined for the given arguments', function () {
+        expect([ false, 'foo', 'bar' ], 'to have items satisfying', expect.it('to be false').or('to be a string'));
     });
 });


### PR DESCRIPTION
This is partly accomplished by removing the "bubbleThrough" error mode from the missing assertion errors where the assertion isn't misspelled, but just isn't defined for the given arguments.

Fixes a problem introduced in #256 that causes the added test to fail. The problem debuted in 10.8.0.

// cc @gustavnikolaj @sunesimonsen