### PR TITLE
Don't consider two different functions equal even if their toString() methods return the same value

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -780,7 +780,7 @@ module.exports = function (expect) {
         },
         getKeys: Object.keys,
         equal: function (a, b) {
-            return a === b || a.toString() === b.toString();
+            return a === b;
         },
         inspect: function (f, depth, output, inspect) {
             var source = f.toString();


### PR DESCRIPTION
They could be defined in different scopes and close over different vars.