### PR TITLE
Fix UNEXPECTED_FULL_TRACE env variable for emulated DOM

### DIFF
--- a/lib/useFullStackTrace.js
+++ b/lib/useFullStackTrace.js
@@ -2,7 +2,9 @@
 var useFullStackTrace = false;
 if (typeof window !== 'undefined' && typeof window.location !== 'undefined') {
     useFullStackTrace = !!window.location.search.match(/[?&]full-trace=true(?:$|&)/);
-} else if (typeof process !== 'undefined' && process.env.UNEXPECTED_FULL_TRACE) {
+}
+
+if (typeof process !== 'undefined' && process.env && process.env.UNEXPECTED_FULL_TRACE) {
     useFullStackTrace = true;
 }
 module.exports = useFullStackTrace;


### PR DESCRIPTION
If the DOM is emulated, and the tests are running under node, then the
environment variable UNEXPECTED_FULL_TRACE was ignored. This change
treats the variable equally - i.e. if `process` is also defined
globally, and `process.env.UNEXPECTED_FULL_TRACE` too, then the full
trace should be used.