### PR TITLE
Implement <function> to be (rejected|fulfilled) [with]

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1418,6 +1418,13 @@ module.exports = function (expect) {
         });
     });
 
+    expect.addAssertion('<function> to be rejected', function (expect, subject) {
+        expect.errorMode = 'nested';
+        return expect(expect.promise(function () {
+            return subject();
+        }), 'to be rejected');
+    });
+
     expect.addAssertion('<Promise> to be rejected with <any>', function (expect, subject, value) {
         expect.errorMode = 'nested';
         return expect(subject, 'to be rejected').then(function (err) {
@@ -1431,6 +1438,13 @@ module.exports = function (expect) {
                 });
             }
         });
+    });
+
+    expect.addAssertion('<function> to be rejected with <any>', function (expect, subject, value) {
+        expect.errorMode = 'nested';
+        return expect(expect.promise(function () {
+            return subject();
+        }), 'to be rejected with', value);
     });
 
     expect.addAssertion('<Promise> to be fulfilled', function (expect, subject) {
@@ -1449,6 +1463,13 @@ module.exports = function (expect) {
         });
     });
 
+    expect.addAssertion('<function> to be fulfilled', function (expect, subject) {
+        expect.errorMode = 'nested';
+        return expect(expect.promise(function () {
+            return subject();
+        }), 'to be fulfilled');
+    });
+
     expect.addAssertion('<Promise> to be fulfilled with <any>', function (expect, subject, value) {
         expect.errorMode = 'nested';
         return expect(subject, 'to be fulfilled').then(function (fulfillmentValue) {
@@ -1456,6 +1477,13 @@ module.exports = function (expect) {
                 return fulfillmentValue;
             });
         });
+    });
+
+    expect.addAssertion('<function> to be fulfilled with <any>', function (expect, subject, value) {
+        expect.errorMode = 'nested';
+        return expect(expect.promise(function () {
+            return subject();
+        }), 'to be fulfilled with', value);
     });
 
     expect.addAssertion('<Promise> when rejected <assertion>', function (expect, subject, nextAssertion) {

--- a/test/assertions/to-be-fulfilled.spec.js
+++ b/test/assertions/to-be-fulfilled.spec.js
@@ -75,4 +75,52 @@ describe('to be fulfilled assertion', function () {
             );
         });
     });
+
+    describe('when passed a function', function () {
+        it('should succeed if the function returns a promise that succeeds', function () {
+            return expect(function () {
+                return expect.promise(function () {
+                    return 123;
+                });
+            }, 'to be fulfilled');
+        });
+
+        it('should forward the fulfillment value', function () {
+            return expect(function () {
+                return expect.promise(function () {
+                    return 123;
+                });
+            }, 'to be fulfilled').then(function (value) {
+                expect(value, 'to equal', 123);
+            });
+        });
+
+        it('should fail if the function returns a promise that fails', function () {
+            expect(function () {
+                return expect(function () {
+                    return expect.promise.reject(new Error('foo'));
+                }, 'to be fulfilled');
+            }, 'to throw',
+                "expected\n" +
+                "function () {\n" +
+                "  return expect.promise.reject(new Error('foo'));\n" +
+                "}\n" +
+                "to be fulfilled\n" +
+                "  expected Promise (rejected) => Error('foo') to be fulfilled\n" +
+                "    Promise (rejected) => Error('foo') unexpectedly rejected with Error('foo')"
+            );
+        });
+
+        it('should fail if the function throws synchronously', function () {
+            expect(function () {
+                return expect(function () {
+                    throw new Error('foo');
+                }, 'to be fulfilled');
+            }, 'to throw',
+                "expected function () { throw new Error('foo'); } to be fulfilled\n" +
+                "  expected Promise (rejected) => Error('foo') to be fulfilled\n" +
+                "    Promise (rejected) => Error('foo') unexpectedly rejected with Error('foo')"
+            );
+        });
+    });
 });

--- a/test/assertions/to-be-fulfilled.spec.js
+++ b/test/assertions/to-be-fulfilled.spec.js
@@ -111,6 +111,22 @@ describe('to be fulfilled assertion', function () {
             );
         });
 
+        it('should fail if the function returns a promise that is fulfilled with the wrong value', function () {
+            expect(function () {
+                return expect(function () {
+                    return expect.promise.resolve(123);
+                }, 'to be fulfilled with', 456);
+            }, 'to throw',
+                "expected\n" +
+                "function () {\n" +
+                "  return expect.promise.resolve(123);\n" +
+                "}\n" +
+                "to be fulfilled with 456\n" +
+                "  expected Promise (fulfilled) => 123 to be fulfilled with 456\n" +
+                "    expected 123 to equal 456"
+            );
+        });
+
         it('should fail if the function throws synchronously', function () {
             expect(function () {
                 return expect(function () {

--- a/test/assertions/to-be-rejected.spec.js
+++ b/test/assertions/to-be-rejected.spec.js
@@ -112,4 +112,44 @@ describe('to be rejected assertion', function () {
             );
         });
     });
+
+    describe('when passed a function', function () {
+        it('should succeed if the function returns a promise that is rejected', function () {
+            return expect(function () {
+                return expect.promise.reject(new Error('foo'));
+            }, 'to be rejected');
+        });
+
+        it('should forward the rejection reason', function () {
+            return expect(function () {
+                return expect.promise(function () {
+                    return expect.promise.reject(new Error('foo'));
+                });
+            }, 'to be rejected').then(function (err) {
+                expect(err, 'to have message', 'foo');
+            });
+        });
+
+        it('should fail if the function returns a promise that is fulfilled', function () {
+            expect(function () {
+                return expect(function () {
+                    return expect.promise.resolve(123);
+                }, 'to be rejected');
+            }, 'to throw',
+                "expected\n" +
+                "function () {\n" +
+                "  return expect.promise.resolve(123);\n" +
+                "}\n" +
+                "to be rejected\n" +
+                "  expected Promise (fulfilled) => 123 to be rejected\n" +
+                "    Promise (fulfilled) => 123 unexpectedly fulfilled with 123"
+            );
+        });
+
+        it('should succeed if the function throws synchronously', function () {
+            return expect(function () {
+                throw new Error('foo');
+            }, 'to be rejected');
+        });
+    });
 });

--- a/test/assertions/to-be-rejected.spec.js
+++ b/test/assertions/to-be-rejected.spec.js
@@ -146,6 +146,29 @@ describe('to be rejected assertion', function () {
             );
         });
 
+        it('should fail if the function returns a promise that is fulfilled with the wrong value', function () {
+            expect(function () {
+                return expect(function () {
+                    return expect.promise.reject(new Error('foo'));
+                }, 'to be rejected with', new Error('bar'));
+            }, 'to throw',
+                "expected\n" +
+                "function () {\n" +
+                "  return expect.promise.reject(new Error('foo'));\n" +
+                "}\n" +
+                "to be rejected with Error('bar')\n" +
+                "  expected Promise (rejected) => Error('foo') to be rejected with Error('bar')\n" +
+                "    expected Error('foo') to satisfy Error('bar')\n" +
+                "\n" +
+                "    Error({\n" +
+                "      message: 'foo' // should equal 'bar'\n" +
+                "                     //\n" +
+                "                     // -foo\n" +
+                "                     // +bar\n" +
+                "    })"
+            );
+        });
+
         it('should succeed if the function throws synchronously', function () {
             return expect(function () {
                 throw new Error('foo');

--- a/test/assertions/when-rejected.spec.js
+++ b/test/assertions/when-rejected.spec.js
@@ -39,7 +39,7 @@ describe('when rejected adverbial assertion', function () {
             }), 'when rejected', 'to equal', new Error('unhappy times')),
             'to be rejected with',
             "expected Promise when rejected to equal Error('unhappy times')\n" +
-                "  Promise unexpectedly fulfilled"
+            "  Promise unexpectedly fulfilled"
         );
     });
 


### PR DESCRIPTION
Promise libraries tend to support passing a function wherever a promise is expected.

@mwoc and I ran into a case where it'd be really nice to do the same for `to be rejected [with]` and `to be fulfilled [with]` because of the way the subject interacted with a `with http mocked out` assertion.

Discussion items:

* Should the assertion fail if the function does not return a promise? I think it should not, for symmetry with how `new Promise() {return nonPromise;}` works.
* Should the assertion fail if the function throws synchronously? I think it should not, for symmetry with how `new Promise() {throw new Error('foo');}` works.
* What about `<Promise> when rejected` and `<Promise> when fulfilled`? For consistency these two should also support functions. On the other hand I don't think anyone is or should be using those assertions now that `to be fulfilled [with]` forwards the fulfillment value and `to be rejected [with]` forwards the rejection reason -- so I'd actually rather deprecate them.

Thoughts? 