### PR TITLE
Feature/cheaper long stack trace

### DIFF
--- a/lib/oathbreaker.js
+++ b/lib/oathbreaker.js
@@ -1,5 +1,7 @@
 var workQueue = require('./workQueue');
 var Promise = require('unexpected-bluebird');
+var useFullStackTrace = require('./useFullStackTrace');
+
 module.exports = function oathbreaker(value) {
     if (!value || typeof value.then !== 'function') {
         return value;
@@ -46,7 +48,7 @@ module.exports = function oathbreaker(value) {
         throw error;
     } else if (evaluated) {
         return value;
-    } else if (value._captureStackTrace) {
+    } else if (value._captureStackTrace && !useFullStackTrace) {
         value._captureStackTrace(true);
     }
 

--- a/lib/oathbreaker.js
+++ b/lib/oathbreaker.js
@@ -46,6 +46,8 @@ module.exports = function oathbreaker(value) {
         throw error;
     } else if (evaluated) {
         return value;
+    } else {
+        value._captureStackTrace(true);
     }
 
     return new Promise(function (resolve, reject) {

--- a/lib/oathbreaker.js
+++ b/lib/oathbreaker.js
@@ -46,7 +46,7 @@ module.exports = function oathbreaker(value) {
         throw error;
     } else if (evaluated) {
         return value;
-    } else {
+    } else if (value._captureStackTrace) {
         value._captureStackTrace(true);
     }
 

--- a/lib/useFullStackTrace.js
+++ b/lib/useFullStackTrace.js
@@ -1,10 +1,12 @@
 /*global window*/
+var Promise = require('unexpected-bluebird');
 var useFullStackTrace = false;
 if (typeof window !== 'undefined' && typeof window.location !== 'undefined') {
     useFullStackTrace = !!window.location.search.match(/[?&]full-trace=true(?:$|&)/);
 }
 
 if (typeof process !== 'undefined' && process.env && process.env.UNEXPECTED_FULL_TRACE) {
+    Promise.longStackTraces();
     useFullStackTrace = true;
 }
 module.exports = useFullStackTrace;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "diff": "1.1.0",
     "leven": "2.0.0",
     "magicpen": "5.9.0",
-    "unexpected-bluebird": "2.9.34"
+    "unexpected-bluebird": "2.9.34-longstack"
   },
   "devDependencies": {
     "browserify": "5.9.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "diff": "1.1.0",
     "leven": "2.0.0",
     "magicpen": "5.9.0",
-    "unexpected-bluebird": "2.9.34-longstack"
+    "unexpected-bluebird": "2.9.34-longstack2"
   },
   "devDependencies": {
     "browserify": "5.9.1",

--- a/test/external.spec.js
+++ b/test/external.spec.js
@@ -55,6 +55,13 @@ if (typeof process === 'object') {
                     expect(err, 'to be falsy');
                 });
             });
+
+            it('should render a long stack trace for an async test', function () {
+                return expect('failingAsync', 'executed through mocha').spread(function (err, stdout, stderr) {
+                    expect(err, 'to be an', Error);
+                    expect(stdout, 'to contain', 'From previous event:');
+                });
+            });
         });
 
         describe('executed through jasmine', function () {

--- a/test/external/failingAsync.externaljs
+++ b/test/external/failingAsync.externaljs
@@ -1,0 +1,13 @@
+var expect = require('../../');
+
+expect.addAssertion('<any> when delayed a little bit <assertion?>', function (expect, subject) {
+    return expect.promise(function (run) {
+        setTimeout(run(function () {
+            return expect.shift();
+        }), 1);
+    });
+});
+
+it('should magically change', function () {
+    return expect('abc', 'when delayed a little bit', 'to equal', 'def');
+});


### PR DESCRIPTION
Attach a stack to all non-oathbreakable promises so that (a patched) Bluebird will render a long stack trace.

Perf. penalty seems to be about 3-4% according to chewbacca, whereas always forcing `BLUEBIRD_DEBUG=yes` regresses 22-25%.