### PR TITLE
Don't inspect args for when called with as an array

### DIFF
--- a/documentation/assertions/function/when-called-with.md
+++ b/documentation/assertions/function/when-called-with.md
@@ -15,7 +15,7 @@ expect(add, 'when called with', [1, 2], 'to equal', 9);
 ```
 
 ```output
-expected function add(a, b) { return a + b; } when called with [ 1, 2 ] to equal 9
+expected function add(a, b) { return a + b; } when called with 1, 2 to equal 9
   expected 3 to equal 9
 ```
 

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1341,6 +1341,9 @@ module.exports = function (expect) {
 
     expect.addAssertion('<function> [when] called with <array-like> <assertion?>', function (expect, subject, args) { // ...
         expect.errorMode = 'nested';
+        expect.argsOutput[0] = function (output) {
+            output.appendItems(args, ', ');
+        };
         return expect.shift(subject.apply(subject, args));
     });
 

--- a/test/assertions/when-called-with.spec.js
+++ b/test/assertions/when-called-with.spec.js
@@ -12,7 +12,7 @@ describe('when called with assertion', function () {
         expect(function () {
             expect(add, 'when called with', [3, 4], 'to equal', 9);
         }, 'to throw',
-               'expected function add(a, b) { return a + b; } when called with [ 3, 4 ] to equal 9\n' +
+               'expected function add(a, b) { return a + b; } when called with 3, 4 to equal 9\n' +
                '  expected 7 to equal 9');
     });
 


### PR DESCRIPTION
This PR removed the parenthesis from the args in the error message for `when called with`.