### PR TITLE
Expose (almost) all of Bluebird's static methods.

### DIFF
--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -111,8 +111,12 @@ function extractPromisesFromObject(obj) {
     };
 });
 
-['resolve', 'reject'].forEach(function (staticMethodName) {
-    makePromise[staticMethodName] = Promise[staticMethodName];
+// Expose all of Bluebird's static methods, except the ones related to long stack traces,
+// unhandled rejections and the scheduler, which we need to manage ourselves:
+Object.keys(Promise).forEach(function (staticMethodName) {
+    if (!/^_|^on|^setScheduler|ongStackTraces/.test(staticMethodName) && typeof makePromise[staticMethodName] === 'undefined') {
+        makePromise[staticMethodName] = Promise[staticMethodName];
+    }
 });
 
 module.exports = makePromise;

--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -114,7 +114,7 @@ function extractPromisesFromObject(obj) {
 // Expose all of Bluebird's static methods, except the ones related to long stack traces,
 // unhandled rejections and the scheduler, which we need to manage ourselves:
 Object.keys(Promise).forEach(function (staticMethodName) {
-    if (!/^_|^on|^setScheduler|ongStackTraces/.test(staticMethodName) && typeof makePromise[staticMethodName] === 'undefined') {
+    if (!/^_|^on|^setScheduler|ongStackTraces/.test(staticMethodName) && typeof Promise[staticMethodName] === 'function' && typeof makePromise[staticMethodName] === 'undefined') {
         makePromise[staticMethodName] = Promise[staticMethodName];
     }
 });


### PR DESCRIPTION
//cc @alexjeffburke 