### PR TITLE
Add 'when sorted' and 'when sorted by' assertions for arrays

### DIFF
--- a/documentation/assertions/array-like/when-sorted-by.md
+++ b/documentation/assertions/array-like/when-sorted-by.md
@@ -1,0 +1,27 @@
+Sort the subject array by a compare function that defines the sort order then
+delegate the return value to another assertion.
+
+```js
+expect([2, 1, 3], 'when sorted by', function (a, b) {
+    return a - b;
+}, 'to equal', [1, 2, 3]);
+```
+
+In case of a failing expectation you get the following output:
+
+```js
+expect([2, 1, 3], 'when sorted by', function (a, b) {
+    return a - b;
+}, 'to equal', [3, 2, 1]);
+```
+
+```output
+expected [ 1, 2, 3 ]
+when sorted by function (a, b) { return a - b; } to equal [ 3, 2, 1 ]
+
+[
+  1, // should equal 3
+  2,
+  3 // should equal 1
+]
+```

--- a/documentation/assertions/array-like/when-sorted-by.md
+++ b/documentation/assertions/array-like/when-sorted-by.md
@@ -16,7 +16,7 @@ expect([2, 1, 3], 'when sorted by', function (a, b) {
 ```
 
 ```output
-expected [ 1, 2, 3 ]
+expected [ 2, 1, 3 ]
 when sorted by function (a, b) { return a - b; } to equal [ 3, 2, 1 ]
 
 [

--- a/documentation/assertions/array-like/when-sorted.md
+++ b/documentation/assertions/array-like/when-sorted.md
@@ -12,7 +12,7 @@ expect(['c', 'a', 'b'], 'when sorted', 'to equal', ['c', 'b', 'a']);
 ```
 
 ```output
-expected [ 'a', 'b', 'c' ] when sorted to equal [ 'c', 'b', 'a' ]
+expected [ 'c', 'a', 'b' ] when sorted to equal [ 'c', 'b', 'a' ]
 
 [
   'a', // should equal 'c'

--- a/documentation/assertions/array-like/when-sorted.md
+++ b/documentation/assertions/array-like/when-sorted.md
@@ -1,0 +1,28 @@
+Sort the subject array by the [default compare function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
+then delegate the return value to another assertion.
+
+```js
+expect(['c', 'a', 'b'], 'when sorted', 'to equal', ['a', 'b', 'c']);
+```
+
+In case of a failing expectation you get the following output:
+
+```js
+expect(['c', 'a', 'b'], 'when sorted', 'to equal', ['c', 'b', 'a']);
+```
+
+```output
+expected [ 'a', 'b', 'c' ] when sorted to equal [ 'c', 'b', 'a' ]
+
+[
+  'a', // should equal 'c'
+       //
+       // -a
+       // +c
+  'b',
+  'c' // should equal 'a'
+      //
+      // -c
+      // +a
+]
+```

--- a/documentation/assertions/array-like/when-sorted.md
+++ b/documentation/assertions/array-like/when-sorted.md
@@ -5,6 +5,12 @@ then delegate the return value to another assertion.
 expect(['c', 'a', 'b'], 'when sorted', 'to equal', ['a', 'b', 'c']);
 ```
 
+To sort an array of numbers, use `when sorted numerically`:
+
+```js
+expect([3, 1, 2], 'when sorted numerically', 'to equal', [1, 2, 3]);
+```
+
 In case of a failing expectation you get the following output:
 
 ```js

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1403,6 +1403,13 @@ module.exports = function (expect) {
         }
     });
 
+    expect.addAssertion([
+        '<array-like> [when] sorted <assertion?>',
+        '<array-like> [when] sorted by <function> <assertion?>'
+    ], function (expect, subject, compareFunction) {
+        return expect.shift(subject.sort(compareFunction));
+    });
+
     expect.addAssertion('<Promise> to be rejected', function (expect, subject) {
         expect.errorMode = 'nested';
         return expect.promise(function () {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1407,7 +1407,7 @@ module.exports = function (expect) {
         '<array-like> [when] sorted <assertion?>',
         '<array-like> [when] sorted by <function> <assertion?>'
     ], function (expect, subject, compareFunction) {
-        return expect.shift(subject.sort(compareFunction));
+        return expect.shift([].concat(subject).sort(compareFunction));
     });
 
     expect.addAssertion('<Promise> to be rejected', function (expect, subject) {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1404,9 +1404,14 @@ module.exports = function (expect) {
     });
 
     expect.addAssertion([
-        '<array-like> [when] sorted <assertion?>',
+        '<array-like> [when] sorted [numerically] <assertion?>',
         '<array-like> [when] sorted by <function> <assertion?>'
     ], function (expect, subject, compareFunction) {
+        if (expect.flags.numerically) {
+            compareFunction = function (a, b) {
+                return a - b;
+            };
+        }
         return expect.shift([].concat(subject).sort(compareFunction));
     });
 

--- a/test/assertions/when-sorted-by.spec.js
+++ b/test/assertions/when-sorted-by.spec.js
@@ -1,0 +1,28 @@
+/*global expect*/
+describe('when sorted by assertion', function () {
+    it('should should sort an array (in place) using the provided compare function', function () {
+        expect(['c', 'b', 'a'], 'when sorted by', function (a, b) {
+            if (a < b) {
+                return 1;
+            }
+            if (a > b) {
+                return -1;
+            }
+            return 0;
+        }, 'to equal', ['c', 'b', 'a']);
+    });
+
+    it('should should provide the result as the fulfillment value if no assertion is provided', function () {
+        return expect([3, 1, 2], 'when sorted by', function (a, b) {
+            return a - b;
+        }).then(function (sortedArray) {
+            expect(sortedArray, 'to equal', [1, 2, 3]);
+        });
+    });
+
+    it('should also work without the \'when\'', function () {
+        expect([4, 10, 5], 'sorted by', function (a, b) {
+            return a - b;
+        }, 'to equal', [4, 5, 10]);
+    });
+});

--- a/test/assertions/when-sorted-by.spec.js
+++ b/test/assertions/when-sorted-by.spec.js
@@ -1,6 +1,6 @@
 /*global expect*/
 describe('when sorted by assertion', function () {
-    it('should should sort an array (in place) using the provided compare function', function () {
+    it('should sort an array using the provided compare function', function () {
         expect(['c', 'b', 'a'], 'when sorted by', function (a, b) {
             if (a < b) {
                 return 1;
@@ -12,7 +12,7 @@ describe('when sorted by assertion', function () {
         }, 'to equal', ['c', 'b', 'a']);
     });
 
-    it('should should provide the result as the fulfillment value if no assertion is provided', function () {
+    it('should provide the result as the fulfillment value if no assertion is provided', function () {
         return expect([3, 1, 2], 'when sorted by', function (a, b) {
             return a - b;
         }).then(function (sortedArray) {

--- a/test/assertions/when-sorted.spec.js
+++ b/test/assertions/when-sorted.spec.js
@@ -4,6 +4,10 @@ describe('when sorted assertion', function () {
         expect(['c', 'a', 'b'], 'when sorted', 'to equal', ['a', 'b', 'c']);
     });
 
+    it('should sort an array of numbers if the \'numerically\' flag is included', function () {
+        expect([5, 12, 20, 2], 'when sorted numerically', 'to equal', [2, 5, 12, 20]);
+    });
+
     it('should provide the result as the fulfillment value if no assertion is provided', function () {
         return expect(['c', 'b', 'a'], 'when sorted').then(function (sortedArray) {
             expect(sortedArray, 'to equal', ['a', 'b', 'c']);

--- a/test/assertions/when-sorted.spec.js
+++ b/test/assertions/when-sorted.spec.js
@@ -1,0 +1,16 @@
+/*global expect*/
+describe('when sorted assertion', function () {
+    it('should should sort an array (in place) using the default compare function', function () {
+        expect(['c', 'a', 'b'], 'when sorted', 'to equal', ['a', 'b', 'c']);
+    });
+
+    it('should should provide the result as the fulfillment value if no assertion is provided', function () {
+        return expect(['c', 'b', 'a'], 'when sorted').then(function (sortedArray) {
+            expect(sortedArray, 'to equal', ['a', 'b', 'c']);
+        });
+    });
+
+    it('should also work without the \'when\'', function () {
+        expect(['c', 'd', 'a'], 'sorted', 'to equal', ['a', 'c', 'd']);
+    });
+});

--- a/test/assertions/when-sorted.spec.js
+++ b/test/assertions/when-sorted.spec.js
@@ -1,10 +1,10 @@
 /*global expect*/
 describe('when sorted assertion', function () {
-    it('should should sort an array (in place) using the default compare function', function () {
+    it('should sort an array using the default compare function', function () {
         expect(['c', 'a', 'b'], 'when sorted', 'to equal', ['a', 'b', 'c']);
     });
 
-    it('should should provide the result as the fulfillment value if no assertion is provided', function () {
+    it('should provide the result as the fulfillment value if no assertion is provided', function () {
         return expect(['c', 'b', 'a'], 'when sorted').then(function (sortedArray) {
             expect(sortedArray, 'to equal', ['a', 'b', 'c']);
         });


### PR DESCRIPTION
Adds:
```
<array-like> when sorted [numerically] <assertion?>
<array-like> when sorted by <function> <assertion?>
```
Closes #311 