### PR TITLE
Truncate subject within begin and end with assertions

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -547,7 +547,6 @@ module.exports = function (expect) {
             } else {
                 outputSubject = subject.substring(contextLength, subject.length);
             }
-            outputSubject = outputSubject;
             isTruncated = true;
         } else {
             outputSubject = subject;

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -483,6 +483,7 @@ module.exports = function (expect) {
         if (value === '') {
             throw new Error("The '" + expect.testDescription + "' assertion does not support a prefix of the empty string");
         }
+        var isTruncated;
         var outputSubject;
         var contextLength = value.length + 25;
         if (subject.length > contextLength) {
@@ -492,12 +493,13 @@ module.exports = function (expect) {
             } else {
                 outputSubject = subject.substring(0, contextLength);
             }
-            outputSubject += '...';
+            isTruncated = true;
         } else {
             outputSubject = subject;
+            isTruncated = false;
         }
         expect.subjectOutput = function (output) {
-            output.jsString("'" + outputSubject.replace(/\n/g, '\\n') + "'");
+            output.jsString("'" + outputSubject.replace(/\n/g, '\\n') + "'" + (isTruncated ? '...' : ''));
         };
         expect.withError(function () {
             expect(subject.substr(0, value.length), '[not] to equal', value);
@@ -518,7 +520,8 @@ module.exports = function (expect) {
                         } else {
                             output
                                 .partialMatch(subject.substr(0, i))
-                                .text(outputSubject.substr(i));
+                                .text(outputSubject.substr(i))
+                                .jsComment(isTruncated ? '...' : '');
                         }
                     }
                     return output;

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -534,6 +534,7 @@ module.exports = function (expect) {
         if (value === '') {
             throw new Error("The '" + expect.testDescription + "' assertion does not support a suffix of the empty string");
         }
+        var isTruncated;
         var outputSubject;
         var contextLength = subject.length - value.length - 25;
         if (contextLength > 0) {
@@ -543,12 +544,14 @@ module.exports = function (expect) {
             } else {
                 outputSubject = subject.substring(contextLength, subject.length);
             }
-            outputSubject = '...' + outputSubject;
+            outputSubject = outputSubject;
+            isTruncated = true;
         } else {
             outputSubject = subject;
+            isTruncated = false;
         }
         expect.subjectOutput = function (output) {
-            output.jsString("'" + outputSubject.replace(/\n/g, '\\n') + "'");
+            output.jsString((isTruncated ? '...' : '') + "'" + outputSubject.replace(/\n/g, '\\n') + "'");
         };
         expect.withError(function () {
             expect(subject.substr(-value.length), '[not] to equal', value);
@@ -568,6 +571,7 @@ module.exports = function (expect) {
                             return null;
                         }
                         output
+                            .jsComment(isTruncated ? '...' : '')
                             .text(outputSubject.substr(0, outputSubject.length - i))
                             .partialMatch(outputSubject.substr(outputSubject.length - i, outputSubject.length));
                     }

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -483,6 +483,22 @@ module.exports = function (expect) {
         if (value === '') {
             throw new Error("The '" + expect.testDescription + "' assertion does not support a prefix of the empty string");
         }
+        var outputSubject;
+        var contextLength = value.length + 25;
+        if (subject.length > contextLength) {
+            var truncationIndex = subject.indexOf(' ', value.length + 1);
+            if (truncationIndex > -1 && truncationIndex < contextLength) {
+                outputSubject = subject.substring(0, truncationIndex);
+            } else {
+                outputSubject = subject.substring(0, contextLength);
+            }
+            outputSubject += '...';
+        } else {
+            outputSubject = subject;
+        }
+        expect.subjectOutput = function (output) {
+            output.jsString("'" + outputSubject.replace(/\n/g, '\\n') + "'");
+        };
         expect.withError(function () {
             expect(subject.substr(0, value.length), '[not] to equal', value);
         }, function (err) {
@@ -502,7 +518,7 @@ module.exports = function (expect) {
                         } else {
                             output
                                 .partialMatch(subject.substr(0, i))
-                                .text(subject.substr(i));
+                                .text(outputSubject.substr(i));
                         }
                     }
                     return output;

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -483,20 +483,12 @@ module.exports = function (expect) {
         if (value === '') {
             throw new Error("The '" + expect.testDescription + "' assertion does not support a prefix of the empty string");
         }
-        var isTruncated;
-        var outputSubject;
-        var contextLength = value.length + 25;
-        if (subject.length > contextLength) {
-            var truncationIndex = subject.indexOf(' ', value.length + 1);
-            if (truncationIndex > -1 && truncationIndex < contextLength) {
-                outputSubject = subject.substring(0, truncationIndex);
-            } else {
-                outputSubject = subject.substring(0, contextLength);
-            }
-            isTruncated = true;
-        } else {
+        var isTruncated = false;
+        var outputSubject = utils.truncateSubjectStringForBegin(subject, value);
+        if (outputSubject === null) {
             outputSubject = subject;
-            isTruncated = false;
+        } else {
+            isTruncated = true;
         }
         expect.subjectOutput = function (output) {
             output = output.jsString("'" + outputSubject.replace(/\n/g, '\\n') + "'");
@@ -537,20 +529,12 @@ module.exports = function (expect) {
         if (value === '') {
             throw new Error("The '" + expect.testDescription + "' assertion does not support a suffix of the empty string");
         }
-        var isTruncated;
-        var outputSubject;
-        var contextLength = subject.length - value.length - 25;
-        if (contextLength > 0) {
-            var truncationIndex = subject.lastIndexOf(' ', value.length + 1);
-            if (truncationIndex > -1 && truncationIndex >= contextLength) {
-                outputSubject = subject.substring(truncationIndex + 1, subject.length);
-            } else {
-                outputSubject = subject.substring(contextLength, subject.length);
-            }
-            isTruncated = true;
-        } else {
+        var isTruncated = false;
+        var outputSubject = utils.truncateSubjectStringForEnd(subject, value);
+        if (outputSubject === null) {
             outputSubject = subject;
-            isTruncated = false;
+        } else {
+            isTruncated = true;
         }
         expect.subjectOutput = function (output) {
             if (isTruncated) {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -499,7 +499,10 @@ module.exports = function (expect) {
             isTruncated = false;
         }
         expect.subjectOutput = function (output) {
-            output.jsString("'" + outputSubject.replace(/\n/g, '\\n') + "'" + (isTruncated ? '...' : ''));
+            output = output.jsString("'" + outputSubject.replace(/\n/g, '\\n') + "'");
+            if (isTruncated) {
+                output.jsComment('...');
+            }
         };
         expect.withError(function () {
             expect(subject.substr(0, value.length), '[not] to equal', value);
@@ -551,7 +554,10 @@ module.exports = function (expect) {
             isTruncated = false;
         }
         expect.subjectOutput = function (output) {
-            output.jsString((isTruncated ? '...' : '') + "'" + outputSubject.replace(/\n/g, '\\n') + "'");
+            if (isTruncated) {
+                output = output.jsComment('...');
+            }
+            output.jsString("'" + outputSubject.replace(/\n/g, '\\n') + "'");
         };
         expect.withError(function () {
             expect(subject.substr(-value.length), '[not] to equal', value);

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -531,6 +531,22 @@ module.exports = function (expect) {
         if (value === '') {
             throw new Error("The '" + expect.testDescription + "' assertion does not support a suffix of the empty string");
         }
+        var outputSubject;
+        var contextLength = subject.length - value.length - 25;
+        if (contextLength > 0) {
+            var truncationIndex = subject.lastIndexOf(' ', value.length + 1);
+            if (truncationIndex > -1 && truncationIndex >= contextLength) {
+                outputSubject = subject.substring(truncationIndex + 1, subject.length);
+            } else {
+                outputSubject = subject.substring(contextLength, subject.length);
+            }
+            outputSubject = '...' + outputSubject;
+        } else {
+            outputSubject = subject;
+        }
+        expect.subjectOutput = function (output) {
+            output.jsString("'" + outputSubject.replace(/\n/g, '\\n') + "'");
+        };
         expect.withError(function () {
             expect(subject.substr(-value.length), '[not] to equal', value);
         }, function (err) {
@@ -541,7 +557,7 @@ module.exports = function (expect) {
                         output.text(subject.substr(0, subject.length - value.length)).removedHighlight(value);
                     } else {
                         var i = 0;
-                        while (subject[subject.length - 1 - i] === value[value.length - 1 - i]) {
+                        while (outputSubject[outputSubject.length - 1 - i] === value[value.length - 1 - i]) {
                             i += 1;
                         }
                         if (i === 0) {
@@ -549,8 +565,8 @@ module.exports = function (expect) {
                             return null;
                         }
                         output
-                            .text(subject.substr(0, subject.length - i))
-                            .partialMatch(subject.substr(subject.length - i, subject.length));
+                            .text(outputSubject.substr(0, outputSubject.length - i))
+                            .partialMatch(outputSubject.substr(outputSubject.length - i, outputSubject.length));
                     }
                     return output;
                 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -194,5 +194,31 @@ var utils = module.exports = {
             }
             return packing;
         }
+    },
+
+    truncateSubjectStringForBegin: function (subject, value) {
+        var contextLength = value.length + 25;
+        if (subject.length <= contextLength) {
+            return null;
+        }
+        var truncationIndex = subject.indexOf(' ', value.length + 1);
+        if (truncationIndex > -1 && truncationIndex < contextLength) {
+            return subject.substring(0, truncationIndex);
+        } else {
+            return subject.substring(0, contextLength);
+        }
+    },
+
+    truncateSubjectStringForEnd: function (subject, value) {
+        var contextLength = subject.length - value.length - 25;
+        if (contextLength <= 0) {
+            return null;
+        }
+        var truncationIndex = subject.lastIndexOf(' ', value.length + 1);
+        if (truncationIndex > -1 && truncationIndex >= contextLength) {
+            return subject.substring(truncationIndex + 1, subject.length);
+        } else {
+            return subject.substring(contextLength, subject.length);
+        }
     }
 };

--- a/test/assertions/to-begin-with.spec.js
+++ b/test/assertions/to-begin-with.spec.js
@@ -70,7 +70,7 @@ describe('to begin with assertion', function () {
                         'barbazquux'
                     );
                 }, 'to throw exception',
-                       "expected 'foobarbaz-AtSomePointThisStringWill...' to begin with 'barbazquux'"
+                       "expected 'foobarbaz-AtSomePointThisStringWill'... to begin with 'barbazquux'"
                       );
             });
 
@@ -82,7 +82,7 @@ describe('to begin with assertion', function () {
                         'barbazquux'
                     );
                 }, 'to throw exception',
-                       "expected 'foobarbaz-StringTruncates...' to begin with 'barbazquux'"
+                       "expected 'foobarbaz-StringTruncates'... to begin with 'barbazquux'"
                       );
             });
 
@@ -94,7 +94,7 @@ describe('to begin with assertion', function () {
                         'foobarquux'
                     );
                 }, 'to throw exception',
-                       "expected 'foobarbaz-ButAtSomePointThisStringW...' to begin with 'foobarquux'\n" +
+                       "expected 'foobarbaz-ButAtSomePointThisStringW'... to begin with 'foobarquux'\n" +
                        "\n" +
                        "foobarbaz-ButAtSomePointThisStringW...\n" +
                        "^^^^^^"

--- a/test/assertions/to-begin-with.spec.js
+++ b/test/assertions/to-begin-with.spec.js
@@ -61,6 +61,45 @@ describe('to begin with assertion', function () {
                        "^^^"
                       );
             });
+
+            it('builds the diff correctly when the string is truncated with no common prefix', function () {
+                expect(function () {
+                    expect(
+                        'foobarbaz-AtSomePointThisStringWillBeTruncated',
+                        'to begin with',
+                        'barbazquux'
+                    );
+                }, 'to throw exception',
+                       "expected 'foobarbaz-AtSomePointThisStringWill...' to begin with 'barbazquux'"
+                      );
+            });
+
+            it('builds the diff correctly when the string contains a space and is truncated', function () {
+                expect(function () {
+                    expect(
+                        'foobarbaz-StringTruncates AtTheSpace',
+                        'to begin with',
+                        'barbazquux'
+                    );
+                }, 'to throw exception',
+                       "expected 'foobarbaz-StringTruncates...' to begin with 'barbazquux'"
+                      );
+            });
+
+            it('builds the diff correctly when the string is truncated after a partial match', function () {
+                expect(function () {
+                    expect(
+                        'foobarbaz-ButAtSomePointThisStringWillBeTruncated',
+                        'to begin with',
+                        'foobarquux'
+                    );
+                }, 'to throw exception',
+                       "expected 'foobarbaz-ButAtSomePointThisStringW...' to begin with 'foobarquux'\n" +
+                       "\n" +
+                       "foobarbaz-ButAtSomePointThisStringW...\n" +
+                       "^^^^^^"
+                      );
+            });
         });
     });
 

--- a/test/assertions/to-end-with.spec.js
+++ b/test/assertions/to-end-with.spec.js
@@ -70,7 +70,7 @@ describe('to end with assertion', function () {
                         'barbazquux'
                     );
                 }, 'to throw exception',
-                       "expected '...ThisStringWillBeTruncated-foobarbaz' to end with 'barbazquux'"
+                       "expected ...'ThisStringWillBeTruncated-foobarbaz' to end with 'barbazquux'"
                       );
             });
 
@@ -82,7 +82,7 @@ describe('to end with assertion', function () {
                         'barbazquux'
                     );
                 }, 'to throw exception',
-                       "expected '...ThenPleaseTruncateString-foobarbaz' to end with 'barbazquux'"
+                       "expected ...'ThenPleaseTruncateString-foobarbaz' to end with 'barbazquux'"
                       );
             });
 
@@ -94,7 +94,7 @@ describe('to end with assertion', function () {
                         'quuxbarfoo'
                     );
                 }, 'to throw exception',
-                       "expected '...ThisStringWillBeTruncated-bazbarfoo' to end with 'quuxbarfoo'\n" +
+                       "expected ...'ThisStringWillBeTruncated-bazbarfoo' to end with 'quuxbarfoo'\n" +
                        "\n" +
                        "...ThisStringWillBeTruncated-bazbarfoo\n" +
                        "                                ^^^^^^"

--- a/test/assertions/to-end-with.spec.js
+++ b/test/assertions/to-end-with.spec.js
@@ -61,6 +61,45 @@ describe('to end with assertion', function () {
                        "^^^"
                       );
             });
+
+            it('builds the diff correctly when the string is truncated with no common prefix', function () {
+                expect(function () {
+                    expect(
+                        'AtSomePointThisStringWillBeTruncated-foobarbaz',
+                        'to end with',
+                        'barbazquux'
+                    );
+                }, 'to throw exception',
+                       "expected '...ThisStringWillBeTruncated-foobarbaz' to end with 'barbazquux'"
+                      );
+            });
+
+            it('builds the diff correctly when the string contains a space and is truncated', function () {
+                expect(function () {
+                    expect(
+                        'a ThenPleaseTruncateString-foobarbaz',
+                        'to end with',
+                        'barbazquux'
+                    );
+                }, 'to throw exception',
+                       "expected '...ThenPleaseTruncateString-foobarbaz' to end with 'barbazquux'"
+                      );
+            });
+
+            it('builds the diff correctly when the string is truncated after a partial match', function () {
+                expect(function () {
+                    expect(
+                        'ButAtSomePointThisStringWillBeTruncated-bazbarfoo',
+                        'to end with',
+                        'quuxbarfoo'
+                    );
+                }, 'to throw exception',
+                       "expected '...ThisStringWillBeTruncated-bazbarfoo' to end with 'quuxbarfoo'\n" +
+                       "\n" +
+                       "...ThisStringWillBeTruncated-bazbarfoo\n" +
+                       "                                ^^^^^^"
+                      );
+            });
         });
     });
 


### PR DESCRIPTION
Hey,

This is my first attempt at doing this - feedback both requested and very welcome.

I might have gone a little overboard, the the current implementation details are as follows:
This commit uses 25 characters of context beyond the length of the prefix/suffix respectively. Should the subject be longer than the needle + 25, it is shortened. I implemented a slightly more intelligent truncation where it searches those additional 25 characters for a space and breaks there if found. The partialMatch is also updated to show a truncated version of the subject.

I'm conscious this is my first submission to a core assertion and am more than willing to rework this. Looking forward to your thoughts.

AJB
