### PR TITLE
Allow assertions to succeed without settling all promises

### DIFF
--- a/lib/createWrappedExpectProto.js
+++ b/lib/createWrappedExpectProto.js
@@ -3,7 +3,6 @@ var makePromise = require('./makePromise');
 var isPendingPromise = require('./isPendingPromise');
 var oathbreaker = require('./oathbreaker');
 var UnexpectedError = require('./UnexpectedError');
-var notifyPendingPromise = require('./notifyPendingPromise');
 var addAdditionalPromiseMethods = require('./addAdditionalPromiseMethods');
 var utils = require('./utils');
 
@@ -74,7 +73,6 @@ module.exports = function createWrappedExpectProto(unexpected) {
             try {
                 var result = oathbreaker(callback());
                 if (isPendingPromise(result)) {
-                    notifyPendingPromise(result);
                     result = result.then(undefined, function (e) {
                         if (e && e._isUnexpected) {
                             throw new UnexpectedError(that, e);

--- a/test/external.spec.js
+++ b/test/external.spec.js
@@ -90,6 +90,16 @@ if (typeof process === 'object') {
                     });
                 });
             });
+
+            describe('with an assertion that succeeds, but creates a promise that remains pending', function () {
+                it('should pass', function () {
+                    return expect('assertionSucceedsWhilePromiseIsPending', 'executed through mocha').spread(function (err, stdout, stderr) {
+                        expect(stdout, 'not to contain', 'Error: should call the callback: You have created a promise that was not returned from the it block');
+                        expect(err, 'to be falsy');
+                    });
+                });
+            });
+
         });
 
         describe('executed through jasmine', function () {

--- a/test/external/assertionSucceedsWhilePromiseIsPending.externaljs
+++ b/test/external/assertionSucceedsWhilePromiseIsPending.externaljs
@@ -1,0 +1,14 @@
+var expect = require('../../');
+
+expect.addAssertion('<any> to bar', function (expect, subject) {
+    expect(subject, 'to equal', 'bar');
+    return expect.promise(function (resolve, reject) {});
+});
+
+expect.addAssertion('<any> to foo', function (expect) {
+    expect('bar', 'to bar');
+});
+
+it('should call the callback', function () {
+    expect('foo', 'to foo');
+});


### PR DESCRIPTION
In other words, disable the afterEach-based footgun protection for all but the top level expect.

We've run into a case in unexpected-mitm where we need to fail the assertion due to the wrong HTTP request being made, but in that case we cannot guarantee that the delegated-to assertion is ever settled.

Relaxing the footgun protection fixes that, and will in general allow assertions a greater degree of freedom, while still protecting the end user from forgetting a `return`.