### PR TITLE
to satisfy: compare functions by value

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -234,6 +234,16 @@ function createExpectIt(unexpected, expectations) {
         ? context
         : new Context(unexpected);
 
+    if (
+      orGroups.length === 1 &&
+      orGroups[0].length === 1 &&
+      orGroups[0][0].length === 1 &&
+      typeof orGroups[0][0][0] === 'function'
+    ) {
+      // expect.it(subject => ...)
+      return oathbreaker(orGroups[0][0][0](subject));
+    }
+
     const groupEvaluations = [];
     const promises = [];
     orGroups.forEach(orGroup => {

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -1326,7 +1326,7 @@ Unexpected.prototype._expect = function expect(context, args) {
 
   if (args.length < 2) {
     throw new Error('The expect function requires at least two parameters.');
-  } else if (testDescriptionString && testDescriptionString._expectIt) {
+  } else if (typeof testDescriptionString === 'function') {
     return that.expect.withError(
       () => testDescriptionString(subject),
       err => {
@@ -1401,7 +1401,7 @@ Unexpected.prototype._expect = function expect(context, args) {
           wrappedExpect,
           subject
         );
-      } else if (testDescriptionString && testDescriptionString._expectIt) {
+      } else if (typeof testDescriptionString === 'function') {
         wrappedExpect.errorMode = 'nested';
         return wrappedExpect.withError(
           () => testDescriptionString(subject),

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1096,12 +1096,9 @@ module.exports = expect => {
         if (typeof nextArg === 'string') {
           expected[key] = expect.it(s => expect.shift(s));
         } else if (typeof nextArg === 'function') {
-          expected[key] = expect.it(
-            (s, context) =>
-              nextArg._expectIt
-                ? nextArg(s, context)
-                : expect.it(s => nextArg(s, index))(s)
-          );
+          expected[key] = nextArg._expectIt
+            ? nextArg
+            : expect.it(s => nextArg(s, index));
         } else {
           expected[key] = nextArg;
         }

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1094,10 +1094,14 @@ module.exports = expect => {
       const expected = {};
       keys.forEach((key, index) => {
         if (typeof nextArg === 'string') {
-          expected[key] = s => expect.shift(s);
+          expected[key] = expect.it(s => expect.shift(s));
         } else if (typeof nextArg === 'function') {
-          expected[key] = s =>
-            nextArg._expectIt ? nextArg(s, expect.context) : nextArg(s, index);
+          expected[key] = expect.it(
+            (s, context) =>
+              nextArg._expectIt
+                ? nextArg(s, context)
+                : expect.it(s => nextArg(s, index))(s)
+          );
         } else {
           expected[key] = nextArg;
         }
@@ -1504,7 +1508,7 @@ module.exports = expect => {
           const valueKey = valueType.valueForKey(value, keyInValue);
           const valueKeyType = expect.findTypeOf(valueKey);
 
-          if (valueKeyType.is('function')) {
+          if (valueKeyType.is('expect.it')) {
             return valueKey(subjectKey);
           } else {
             return expect(subjectKey, 'to [exhaustively] satisfy', valueKey);
@@ -1715,7 +1719,9 @@ module.exports = expect => {
                           } else if (type === 'insert') {
                             this.annotationBlock(function() {
                               if (
-                                expect.findTypeOf(diffItem.value).is('function')
+                                expect
+                                  .findTypeOf(diffItem.value)
+                                  .is('expect.it')
                               ) {
                                 this.error('missing: ').block(function() {
                                   this.omitSubject = undefined;
@@ -1867,8 +1873,6 @@ module.exports = expect => {
           if (valueKeyType.is('expect.it')) {
             expect.context.thisObject = subject;
             return valueKey(subjectKey, expect.context);
-          } else if (valueKeyType.is('function')) {
-            return valueKey(subjectKey);
           } else {
             return expect(subjectKey, 'to [exhaustively] satisfy', valueKey);
           }
@@ -1941,7 +1945,7 @@ module.exports = expect => {
                           conflicting = null;
                         }
                       } else if (!subjectType.hasKey(subject, key)) {
-                        if (expect.findTypeOf(valueKey).is('function')) {
+                        if (expect.findTypeOf(valueKey).is('expect.it')) {
                           if (promiseByKey[key].isRejected()) {
                             output.error('// missing:').sp();
                             valueOutput = output

--- a/test/api/it.spec.js
+++ b/test/api/it.spec.js
@@ -363,6 +363,19 @@ describe('expect.it', () => {
       );
     });
 
+    it('supports returning a promise from the function', () => {
+      return expect(
+        () =>
+          expect.it(value =>
+            expect.promise(run => {
+              setTimeout(run(() => expect(value, 'to equal', 'bar')));
+            })
+          )('foo'),
+        'to be rejected with',
+        "expected 'foo' to equal 'bar'\n" + '\n' + '-foo\n' + '+bar'
+      );
+    });
+
     it('should fail when passed more than two arguments', () => {
       expect(
         function() {
@@ -373,6 +386,46 @@ describe('expect.it', () => {
         'to throw',
         'expect.it(<function>) does not accept additional arguments'
       );
+    });
+
+    describe('and chained the expression is chained', () => {
+      describe('and the first expression is a function', () => {
+        it('fails with a diff including all items in the chain', () => {
+          expect(
+            function() {
+              expect
+                .it(function(value) {
+                  expect(value, 'to equal', 'bar');
+                })
+                .and('to be a string')('foo');
+            },
+            'to throw',
+            "⨯ expected 'foo' to equal 'bar' and\n" +
+              '\n' +
+              '  -foo\n' +
+              '  +bar\n' +
+              "✓ expected 'foo' to be a string"
+          );
+        });
+      });
+
+      describe('and the second expression is a function', () => {
+        it('fails with a diff including all items in the chain', () => {
+          expect(
+            function() {
+              expect.it('to be a string').and(function(value) {
+                expect(value, 'to equal', 'bar');
+              })('foo');
+            },
+            'to throw',
+            "✓ expected 'foo' to be a string and\n" +
+              "⨯ expected 'foo' to equal 'bar'\n" +
+              '\n' +
+              '  -foo\n' +
+              '  +bar'
+          );
+        });
+      });
     });
   });
 });

--- a/test/api/it.spec.js
+++ b/test/api/it.spec.js
@@ -346,14 +346,14 @@ describe('expect.it', () => {
 
   describe('when passed a function', () => {
     it('should succeed', () => {
-      expect.it(function(value) {
+      expect.it(value => {
         expect(value, 'to equal', 'foo');
       })('foo');
     });
 
     it('should fail with a diff', () => {
       expect(
-        function() {
+        () => {
           expect.it(function(value) {
             expect(value, 'to equal', 'bar');
           })('foo');
@@ -378,7 +378,7 @@ describe('expect.it', () => {
 
     it('should fail when passed more than two arguments', () => {
       expect(
-        function() {
+        () => {
           expect.it(function(value) {
             expect(value, 'to equal', 'bar');
           }, 'yadda')('foo');
@@ -392,7 +392,7 @@ describe('expect.it', () => {
       describe('and the first expression is a function', () => {
         it('fails with a diff including all items in the chain', () => {
           expect(
-            function() {
+            () => {
               expect
                 .it(function(value) {
                   expect(value, 'to equal', 'bar');
@@ -412,7 +412,7 @@ describe('expect.it', () => {
       describe('and the second expression is a function', () => {
         it('fails with a diff including all items in the chain', () => {
           expect(
-            function() {
+            () => {
               expect.it('to be a string').and(function(value) {
                 expect(value, 'to equal', 'bar');
               })('foo');

--- a/test/assertions/to-satisfy.spec.js
+++ b/test/assertions/to-satisfy.spec.js
@@ -689,7 +689,7 @@ describe('to satisfy assertion', () => {
 
     it('should fail with an diff if the function fails', () => {
       expect(
-        function() {
+        () => {
           expect({ foo: 3 }, 'to satisfy', {
             foo: expect.it(function(v) {
               expect(v, 'to equal', 2);
@@ -2316,7 +2316,7 @@ describe('to satisfy assertion', () => {
 
   it('should not break when the assertion fails and there is a fulfilled function in the RHS', () => {
     expect(
-      function() {
+      () => {
         expect({}, 'to satisfy', {
           bar: 123,
           foo: expect.it(function(v) {
@@ -2325,7 +2325,7 @@ describe('to satisfy assertion', () => {
         });
       },
       'to throw',
-      function(err) {
+      err => {
         // Compensate for V8 5.1+ setting { foo: function () {} }.foo.name === 'foo'
         // http://v8project.blogspot.dk/2016/04/v8-release-51.html
         expect(

--- a/test/assertions/to-satisfy.spec.js
+++ b/test/assertions/to-satisfy.spec.js
@@ -691,11 +691,14 @@ describe('to satisfy assertion', () => {
       expect(
         function() {
           expect({ foo: 3 }, 'to satisfy', {
-            foo: expect.it(v => expect(v, 'to equal', 2))
+            foo: expect.it(function(v) {
+              expect(v, 'to equal', 2);
+            })
           });
         },
         'to throw',
-        "expected { foo: 3 } to satisfy { foo: expect.it(v => expect(v, 'to equal', 2)) }\n" +
+        'expected { foo: 3 }\n' +
+          "to satisfy { foo: expect.it(function (v) { expect(v, 'to equal', 2); }) }\n" +
           '\n' +
           '{\n' +
           '  foo: 3 // should equal 2\n' +
@@ -2316,7 +2319,7 @@ describe('to satisfy assertion', () => {
       function() {
         expect({}, 'to satisfy', {
           bar: 123,
-          foo: expect.it(v => {
+          foo: expect.it(function(v) {
             expect(v, 'to be undefined');
           })
         });
@@ -2331,12 +2334,15 @@ describe('to satisfy assertion', () => {
             .toString()
             .replace(/function foo/g, 'function '),
           'to satisfy',
-          'expected {}\n' +
-            "to satisfy { bar: 123, foo: expect.it(v => { expect(v, 'to be undefined'); }) }\n" +
+          'expected {} to satisfy\n' +
+            '{\n' +
+            '  bar: 123,\n' +
+            "  foo: expect.it(function (v) { expect(v, 'to be undefined'); })\n" +
+            '}\n' +
             '\n' +
             '{\n' +
             '  // missing bar: 123\n' +
-            "  // missing foo: should satisfy expect.it(v => { expect(v, 'to be undefined'); })\n" +
+            "  // missing foo: should satisfy expect.it(function (v) { expect(v, 'to be undefined'); })\n" +
             '}'
         );
       }

--- a/test/assertions/to-satisfy.spec.js
+++ b/test/assertions/to-satisfy.spec.js
@@ -680,6 +680,30 @@ describe('to satisfy assertion', () => {
     });
   });
 
+  describe('with a expect.it function wrapper', () => {
+    it("succeeds if the function doesn't throw", () => {
+      expect({ foo: 'bar' }, 'to satisfy', {
+        foo: expect.it(v => expect(v, 'to be a string'))
+      });
+    });
+
+    it('should fail with an diff if the function fails', () => {
+      expect(
+        function() {
+          expect({ foo: 3 }, 'to satisfy', {
+            foo: expect.it(v => expect(v, 'to equal', 2))
+          });
+        },
+        'to throw',
+        "expected { foo: 3 } to satisfy { foo: expect.it(v => expect(v, 'to equal', 2)) }\n" +
+          '\n' +
+          '{\n' +
+          '  foo: 3 // should equal 2\n' +
+          '}'
+      );
+    });
+  });
+
   describe('with a synchronous expect.it in the RHS object', () => {
     it('should support an object with a property value of expect.it', () => {
       expect({ foo: 'bar' }, 'to satisfy', {


### PR DESCRIPTION
This PR changes to satisfy to stop calling functions on the RHS with the value on the LHS, this behavior was too surprising. To replicate the old behavior you would have to use `expect.it(v => ...)` instead.

Before: 
(It is only in rare circumstances you need this functionality as you can usually just use a normal expect.it expression.  

```js
expect({
  value: 42
}, 'to satisfy', {
  value: v => {
    expect(v, 'to be a number')
  }
})
```

After:

```js
expect({
  value: 42
}, 'to satisfy', {
  value: expect.it(v => {
    expect(v, 'to be a number')
  })
})
```

We still support using a function in places where it is not confusing:

```js
expect(
  [0, 1, 2, 3, 4, 5],
  'to have values satisfying', (v) => {
    expect(v, 'to be a number')
  }
)
``` 

(This is also a rare case as you can write the same like this:

```js
expect(
  [0, 1, 2, 3, 4, 5],
  'to have values satisfying', 
  'to be a number'
)
``` 
