### PR TITLE
Not reporting the location of the top-level expect when failing in a then block without UNEXPECTED_FULL_TRACE=yes

### DIFF
--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -958,4 +958,17 @@ describe('unexpected', function () {
             });
         });
     });
+
+    describe('when failing asynchronously in an asynchronous .then block', function () {
+        it('should produce an error message that includes the location of the top-level expect in the stack trace', function () {
+            return expect(function theOuterFunction() {
+                return expect(123, 'when delayed a little bit to equal', 123)
+                    .then(function theInnerFunction() {
+                        return expect('foo', 'when delayed a little bit to equal', 123);
+                    });
+            }, 'to error with', function (err) {
+                expect(err.stack, 'to match', /unexpected.spec.js:964:20/); // FIXME: This is unstable and unportable
+            });
+        });
+    });
 });


### PR DESCRIPTION
I found a case where oathbreaker fails to capture the correct stack traces at the right time.

With `UNEXPECTED_FULL_TRACE=yes`:

```
  UnexpectedError
      at Function.wrappedExpectProto.callInNestedContext (lib/createWrappedExpectProto.js:90:40)
      at Function.wrappedExpect [as execute] (lib/Unexpected.js:1082:34)
      at Function.wrappedExpectProto.shift (lib/createWrappedExpectProto.js:160:41)
      at test/common.js:14:27
      at Timeout._onTimeout (lib/makePromise.js:39:49)
  From previous event:
      at Promise._captureStackTrace (node_modules/unexpected-bluebird/js/main/debuggability.js:89:23)
      at Promise._resolveFromResolver (node_modules/unexpected-bluebird/js/main/promise.js:473:10)
      at new Promise (node_modules/unexpected-bluebird/js/main/promise.js:69:37)
      at Function.makePromise [as promise] (lib/makePromise.js:15:12)
      at Function.<anonymous> (lib/assertions.js:586:23)
      at executeExpect (lib/Unexpected.js:1119:50)
      at lib/Unexpected.js:1083:24
      at Function.wrappedExpectProto.callInNestedContext (lib/createWrappedExpectProto.js:74:42)
      at wrappedExpect (lib/Unexpected.js:1082:34)
      at Function.<anonymous> (lib/assertions.js:596:16)
      at executeExpect (lib/Unexpected.js:1119:50)
      at Unexpected.expect (lib/Unexpected.js:1127:22)
      at Context.<anonymous> (test/unexpected.spec.js:964:20)
```

And without:

```
  UnexpectedError
      at Function.wrappedExpectProto.callInNestedContext (lib/createWrappedExpectProto.js:90:40)
      at Function.wrappedExpect [as execute] (lib/Unexpected.js:1082:34)
      at Function.wrappedExpectProto.shift (lib/createWrappedExpectProto.js:160:41)
      at test/common.js:14:27
      at Timeout._onTimeout (lib/makePromise.js:39:49)
  From previous event:
      at oathbreaker (lib/oathbreaker.js:52:15)
      at executeExpect (lib/Unexpected.js:1119:16)
      at Unexpected.expect (lib/Unexpected.js:1127:22)
      at theInnerFunction (test/unexpected.spec.js:967:32)
      at lib/workQueue.js:7:13
      at Array.forEach (native)
      at Object.workQueue.drain (lib/workQueue.js:6:20)
      at Immediate.<anonymous> (lib/workQueue.js:16:19)
      set UNEXPECTED_FULL_TRACE=true to see the full stack trace
```
