### PR TITLE
Consistently return the output from the inspect and diff methods of the built-in types

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -18,6 +18,7 @@ module.exports = function (expect) {
             output.append(this.prefix(output.clone(), value));
             output.append(inspect(this.unwrap(value), depth));
             output.append(this.suffix(output.clone(), value));
+            return output;
         },
         diff: function (actual, expected, output, diff, inspect) {
             output.inline = true;
@@ -53,7 +54,7 @@ module.exports = function (expect) {
                 return typeof obj === 'symbol';
             },
             inspect: function (obj, depth, output, inspect) {
-                output
+                return output
                     .jsKeyword('Symbol')
                     .text('(')
                     .singleQuotedString(obj.toString().replace(/^Symbol\(|\)$/g, ''))
@@ -272,7 +273,7 @@ module.exports = function (expect) {
                     .append(itemsOutput)
                     .sp(suffixOutput.isEmpty() ? 0 : 1);
             }
-            output.append(suffixOutput);
+            return output.append(suffixOutput);
         },
         diff: function (actual, expected, output, diff, inspect, equal) {
             if (actual.constructor !== expected.constructor) {
@@ -391,7 +392,7 @@ module.exports = function (expect) {
             return value && value._unexpectedType;
         },
         inspect: function (value, depth, output) {
-            output.text('type: ').jsKeyword(value.name);
+            return output.text('type: ').jsKeyword(value.name);
         }
     });
 
@@ -510,7 +511,7 @@ module.exports = function (expect) {
                     output.nl();
                 }
 
-                output.append(suffixOutput);
+                return output.append(suffixOutput);
             } else {
                 output
                     .append(prefixOutput)
@@ -522,7 +523,7 @@ module.exports = function (expect) {
                         output.sp();
                     }
                 });
-                output
+                return output
                     .sp(suffixOutput.isEmpty() ? 0 : 1)
                     .append(suffixOutput);
             }
@@ -604,11 +605,9 @@ module.exports = function (expect) {
             }
 
             var suffixOutput = this.suffix(output.clone(), actual);
-            output
+            return output
                 .nl(suffixOutput.isEmpty() ? 0 : 1)
                 .append(suffixOutput);
-
-            return output;
         }
     });
 
@@ -673,7 +672,7 @@ module.exports = function (expect) {
             } else {
                 output.append(inspect(this.unwrap(value), depth));
             }
-            output.text(')');
+            return output.text(')');
         },
         diff: function (actual, expected, output, diff) {
             if (actual.constructor !== expected.constructor) {
@@ -715,7 +714,7 @@ module.exports = function (expect) {
             } else {
                 output.append(errorMessage);
             }
-            output.text(')');
+            return output.text(')');
         }
     });
 
@@ -739,7 +738,7 @@ module.exports = function (expect) {
                 dateStr = dateStr.replace(' GMT', '.' + millisecondsStr + ' GMT');
             }
 
-            output.jsKeyword('new').sp().text('Date(').append(inspect(dateStr).text(')'));
+            return output.jsKeyword('new').sp().text('Date(').append(inspect(dateStr).text(')'));
         }
     });
 
@@ -787,7 +786,7 @@ module.exports = function (expect) {
                 args = ' /*...*/ ';
                 body = ' /*...*/ ';
             }
-            output.code('function ' + name + '(' + args + ') {' + body + '}', 'javascript');
+            return output.code('function ' + name + '(' + args + ') {' + body + '}', 'javascript');
         }
     });
 
@@ -822,7 +821,7 @@ module.exports = function (expect) {
                 orBranch = false;
             });
 
-            output.amend(')');
+            return output.amend(')');
         }
     });
 
@@ -851,6 +850,7 @@ module.exports = function (expect) {
                     output.sp().text('=>').sp().append(inspect(promise.reason()));
                 }
             }
+            return output;
         }
     });
 
@@ -867,7 +867,7 @@ module.exports = function (expect) {
             );
         },
         inspect: function (regExp, depth, output) {
-            output.jsRegexp(regExp);
+            return output.jsRegexp(regExp);
         },
         diff: function (actual, expected, output, diff, inspect) {
             output.inline = false;
@@ -945,6 +945,7 @@ module.exports = function (expect) {
             }
             output.code(codeStr, 'javascript');
             this.suffix(output, obj);
+            return output;
         },
         diffLimit: 512,
         diff: function (actual, expected, output, diff, inspect) {
@@ -993,7 +994,7 @@ module.exports = function (expect) {
             return typeof value === 'string';
         },
         inspect: function (value, depth, output) {
-            output.singleQuotedString(value);
+            return output.singleQuotedString(value);
         },
         diffLimit: 4096,
         diff: function (actual, expected, output, diff, inspect) {
@@ -1018,7 +1019,7 @@ module.exports = function (expect) {
             } else {
                 value = String(value);
             }
-            output.jsNumber(String(value));
+            return output.jsNumber(String(value));
         }
     });
 
@@ -1028,7 +1029,7 @@ module.exports = function (expect) {
             return typeof value === 'number' && isNaN(value);
         },
         inspect: function (value, depth, output) {
-            output.jsPrimitive(value);
+            return output.jsPrimitive(value);
         }
     });
 
@@ -1038,7 +1039,7 @@ module.exports = function (expect) {
             return typeof value === 'boolean';
         },
         inspect: function (value, depth, output) {
-            output.jsPrimitive(value);
+            return output.jsPrimitive(value);
         }
     });
 
@@ -1048,7 +1049,7 @@ module.exports = function (expect) {
             return typeof value === 'undefined';
         },
         inspect: function (value, depth, output) {
-            output.jsPrimitive(value);
+            return output.jsPrimitive(value);
         }
     });
 
@@ -1058,7 +1059,7 @@ module.exports = function (expect) {
             return value === null;
         },
         inspect: function (value, depth, output) {
-            output.jsPrimitive(value);
+            return output.jsPrimitive(value);
         }
     });
 


### PR DESCRIPTION
I was trying to do something like this (simplified):

```js
expect.addType({
    name: 'customBuffer',
    base: 'Buffer',
    inspect: function (value, depth, output, inspect) {
        if (value.length > 10) {
            return output.text('something custom');
        } else {
            return output.append(this.baseType.inspect.call(this, value, depth, output, inspect));
        }
    },
    hexDumpWidth: Infinity
});
```

... but it turns out that since the `inspect` method of `binaryArray` did not return the output, I couldn't delegate to it.