### PR TITLE
Render array moves with arrows

### DIFF
--- a/documentation/api/addAssertion.md
+++ b/documentation/api/addAssertion.md
@@ -137,10 +137,11 @@ expect([ 1, 3, 2, 4 ], 'to be sorted');
 expected [ 1, 3, 2, 4 ] to be sorted
 
 [
-  1,
-  3, // should equal 2
-  2, // should equal 3
-  4
+    1,
+┌─>
+│   3,
+└── 2, // should be moved
+    4
 ]
 ```
 
@@ -160,10 +161,11 @@ expect([ 1, 3, 2, 4 ], 'to be sorted');
 expected [ 1, 3, 2, 4 ] to equal [ 1, 2, 3, 4 ]
 
 [
-  1,
-  3, // should equal 2
-  2, // should equal 3
-  4
+    1,
+┌─>
+│   3,
+└── 2, // should be moved
+    4
 ]
 ```
 
@@ -182,10 +184,11 @@ expected [ 1, 3, 2, 4 ] to be sorted
   expected [ 1, 3, 2, 4 ] to equal [ 1, 2, 3, 4 ]
 
   [
-    1,
-    3, // should equal 2
-    2, // should equal 3
-    4
+      1,
+  ┌─>
+  │   3,
+  └── 2, // should be moved
+      4
   ]
 ```
 
@@ -203,10 +206,11 @@ expect([ 1, 3, 2, 4 ], 'to be sorted');
 expected [ 1, 3, 2, 4 ] to be sorted
 
 [
-  1,
-  3, // should equal 2
-  2, // should equal 3
-  4
+    1,
+┌─>
+│   3,
+└── 2, // should be moved
+    4
 ]
 ```
 
@@ -222,10 +226,11 @@ expect([ 1, 3, 2, 4 ], 'to be sorted');
 
 ```output
 [
-  1,
-  3, // should equal 2
-  2, // should equal 3
-  4
+    1,
+┌─>
+│   3,
+└── 2, // should be moved
+    4
 ]
 ```
 

--- a/documentation/api/addAssertion.md
+++ b/documentation/api/addAssertion.md
@@ -138,7 +138,7 @@ expected [ 1, 3, 2, 4 ] to be sorted
 
 [
     1,
-┌─>
+┌─▷
 │   3,
 └── 2, // should be moved
     4
@@ -162,7 +162,7 @@ expected [ 1, 3, 2, 4 ] to equal [ 1, 2, 3, 4 ]
 
 [
     1,
-┌─>
+┌─▷
 │   3,
 └── 2, // should be moved
     4
@@ -185,7 +185,7 @@ expected [ 1, 3, 2, 4 ] to be sorted
 
   [
       1,
-  ┌─>
+  ┌─▷
   │   3,
   └── 2, // should be moved
       4
@@ -207,7 +207,7 @@ expected [ 1, 3, 2, 4 ] to be sorted
 
 [
     1,
-┌─>
+┌─▷
 │   3,
 └── 2, // should be moved
     4
@@ -227,7 +227,7 @@ expect([ 1, 3, 2, 4 ], 'to be sorted');
 ```output
 [
     1,
-┌─>
+┌─▷
 │   3,
 └── 2, // should be moved
     4

--- a/documentation/assertions/array-like/when-sorted-by.md
+++ b/documentation/assertions/array-like/when-sorted-by.md
@@ -20,8 +20,8 @@ expected [ 2, 1, 3 ]
 when sorted by function (a, b) { return a - b; } to equal [ 3, 2, 1 ]
 
 [
-┌───> 
-│ ┌─>
+┌───▷ 
+│ ┌─▷
 │ │   1,
 │ └── 2, // should be moved
 └──── 3 // should be moved

--- a/documentation/assertions/array-like/when-sorted-by.md
+++ b/documentation/assertions/array-like/when-sorted-by.md
@@ -20,8 +20,10 @@ expected [ 2, 1, 3 ]
 when sorted by function (a, b) { return a - b; } to equal [ 3, 2, 1 ]
 
 [
-  1, // should equal 3
-  2,
-  3 // should equal 1
+┌───> 
+│ ┌─>
+│ │   1,
+│ └── 2, // should be moved
+└──── 3 // should be moved
 ]
 ```

--- a/documentation/assertions/array-like/when-sorted-by.md
+++ b/documentation/assertions/array-like/when-sorted-by.md
@@ -20,7 +20,7 @@ expected [ 2, 1, 3 ]
 when sorted by function (a, b) { return a - b; } to equal [ 3, 2, 1 ]
 
 [
-┌───▷ 
+┌───▷
 │ ┌─▷
 │ │   1,
 │ └── 2, // should be moved

--- a/documentation/assertions/array-like/when-sorted.md
+++ b/documentation/assertions/array-like/when-sorted.md
@@ -21,14 +21,10 @@ expect(['c', 'a', 'b'], 'when sorted', 'to equal', ['c', 'b', 'a']);
 expected [ 'c', 'a', 'b' ] when sorted to equal [ 'c', 'b', 'a' ]
 
 [
-  'a', // should equal 'c'
-       //
-       // -a
-       // +c
-  'b',
-  'c' // should equal 'a'
-      //
-      // -c
-      // +a
+┌───> 
+│ ┌─>
+│ │   'a',
+│ └── 'b', // should be moved
+└──── 'c' // should be moved
 ]
 ```

--- a/documentation/assertions/array-like/when-sorted.md
+++ b/documentation/assertions/array-like/when-sorted.md
@@ -21,8 +21,8 @@ expect(['c', 'a', 'b'], 'when sorted', 'to equal', ['c', 'b', 'a']);
 expected [ 'c', 'a', 'b' ] when sorted to equal [ 'c', 'b', 'a' ]
 
 [
-┌───> 
-│ ┌─>
+┌───▷ 
+│ ┌─▷
 │ │   'a',
 │ └── 'b', // should be moved
 └──── 'c' // should be moved

--- a/documentation/assertions/array-like/when-sorted.md
+++ b/documentation/assertions/array-like/when-sorted.md
@@ -21,7 +21,7 @@ expect(['c', 'a', 'b'], 'when sorted', 'to equal', ['c', 'b', 'a']);
 expected [ 'c', 'a', 'b' ] when sorted to equal [ 'c', 'b', 'a' ]
 
 [
-┌───▷ 
+┌───▷
 │ ┌─▷
 │ │   'a',
 │ └── 'b', // should be moved

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1047,61 +1047,63 @@ module.exports = function (expect) {
                             var packing = utils.packArrows(changes); // NOTE: Will have side effects in changes if the packing results in too many arrow lanes
                             output.arrowsAlongsideChangeOutputs(packing, changes.map(function (diffItem, index) {
                                 var delimiterOutput = subjectType.delimiter(output.clone(), index, indexOfLastNonInsert + 1);
-                                return output.clone().block(function () {
-                                    var type = diffItem.type;
-                                    if (type === 'moveSource') {
-                                        this.property(diffItem.actualIndex, inspect(diffItem.value), true)
-                                            .amend(delimiterOutput.sp()).error('// should be moved');
-                                    } else if (type === 'moveTarget') {
-                                        // Leave an empty placeholder
-                                    } else if (type === 'insert') {
-                                        this.annotationBlock(function () {
-                                            var index = typeof diffItem.actualIndex !== 'undefined' ? diffItem.actualIndex : diffItem.expectedIndex;
-                                            if (expect.findTypeOf(diffItem.value).is('function')) {
-                                                this.error('missing: ')
-                                                    .property(index, output.clone().block(function () {
-                                                        this.omitSubject = undefined;
-                                                        var promise = keyPromises[diffItem.expectedIndex];
-                                                        if (promise.isRejected()) {
-                                                            this.appendErrorMessage(promise.reason());
-                                                        } else {
-                                                            this.appendInspected(diffItem.value);
-                                                        }
-                                                    }), true);
-                                            } else {
-                                                this.error('missing ').property(index, inspect(diffItem.value), true);
-                                            }
-                                        });
-                                    } else {
-                                        this.property(diffItem.actualIndex, output.clone().block(function () {
-                                            if (type === 'remove') {
-                                                this.append(inspect(diffItem.value).amend(delimiterOutput.sp()).error('// should be removed'));
-                                            } else if (type === 'equal') {
-                                                this.append(inspect(diffItem.value).amend(delimiterOutput));
-                                            } else {
-                                                var toSatisfyResult = toSatisfyMatrix[diffItem.actualIndex][diffItem.expectedIndex];
-                                                var valueDiff = toSatisfyResult && toSatisfyResult !== true && toSatisfyResult.getDiff({ output: output.clone() });
-                                                if (valueDiff && valueDiff.inline) {
-                                                    this.append(valueDiff.amend(delimiterOutput));
-                                                } else {
-                                                    this.append(inspect(diffItem.value).amend(delimiterOutput)).sp().annotationBlock(function () {
-                                                        this.omitSubject = diffItem.value;
-                                                        var label = toSatisfyResult.getLabel();
-                                                        if (label) {
-                                                            this.error(label).sp()
-                                                                .block(inspect(diffItem.expected));
-                                                            if (valueDiff) {
-                                                                this.nl(2).append(valueDiff);
+                                var type = diffItem.type;
+                                if (type === 'moveTarget') {
+                                    return output.clone();
+                                } else {
+                                    return output.clone().block(function () {
+                                        if (type === 'moveSource') {
+                                            this.property(diffItem.actualIndex, inspect(diffItem.value), true)
+                                                .amend(delimiterOutput.sp()).error('// should be moved');
+                                        } else if (type === 'insert') {
+                                            this.annotationBlock(function () {
+                                                var index = typeof diffItem.actualIndex !== 'undefined' ? diffItem.actualIndex : diffItem.expectedIndex;
+                                                if (expect.findTypeOf(diffItem.value).is('function')) {
+                                                    this.error('missing: ')
+                                                        .property(index, output.clone().block(function () {
+                                                            this.omitSubject = undefined;
+                                                            var promise = keyPromises[diffItem.expectedIndex];
+                                                            if (promise.isRejected()) {
+                                                                this.appendErrorMessage(promise.reason());
+                                                            } else {
+                                                                this.appendInspected(diffItem.value);
                                                             }
-                                                        } else {
-                                                            this.appendErrorMessage(toSatisfyResult);
-                                                        }
-                                                    });
+                                                        }), true);
+                                                } else {
+                                                    this.error('missing ').property(index, inspect(diffItem.value), true);
                                                 }
-                                            }
-                                        }), true);
-                                    }
-                                });
+                                            });
+                                        } else {
+                                            this.property(diffItem.actualIndex, output.clone().block(function () {
+                                                if (type === 'remove') {
+                                                    this.append(inspect(diffItem.value).amend(delimiterOutput.sp()).error('// should be removed'));
+                                                } else if (type === 'equal') {
+                                                    this.append(inspect(diffItem.value).amend(delimiterOutput));
+                                                } else {
+                                                    var toSatisfyResult = toSatisfyMatrix[diffItem.actualIndex][diffItem.expectedIndex];
+                                                    var valueDiff = toSatisfyResult && toSatisfyResult !== true && toSatisfyResult.getDiff({ output: output.clone() });
+                                                    if (valueDiff && valueDiff.inline) {
+                                                        this.append(valueDiff.amend(delimiterOutput));
+                                                    } else {
+                                                        this.append(inspect(diffItem.value).amend(delimiterOutput)).sp().annotationBlock(function () {
+                                                            this.omitSubject = diffItem.value;
+                                                            var label = toSatisfyResult.getLabel();
+                                                            if (label) {
+                                                                this.error(label).sp()
+                                                                    .block(inspect(diffItem.expected));
+                                                                if (valueDiff) {
+                                                                    this.nl(2).append(valueDiff);
+                                                                }
+                                                            } else {
+                                                                this.appendErrorMessage(toSatisfyResult);
+                                                            }
+                                                        });
+                                                    }
+                                                }
+                                            }), true);
+                                        }
+                                    });
+                                }
                             }));
 
                             if (subjectType.indent) {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1044,7 +1044,7 @@ module.exports = function (expect) {
                             if (subjectType.indent) {
                                 output.indentLines();
                             }
-                            var packing = utils.packArrows(changes);
+                            var packing = utils.packArrows(changes); // NOTE: Will have side effects in changes if the packing results in too many arrow lanes
                             output.arrowsAlongsideChangeOutputs(packing, changes.map(function (diffItem, index) {
                                 var delimiterOutput = subjectType.delimiter(output.clone(), index, indexOfLastNonInsert + 1);
                                 return output.clone().block(function () {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1044,7 +1044,8 @@ module.exports = function (expect) {
                             if (subjectType.indent) {
                                 output.indentLines();
                             }
-                            output.arrowsAlongsideChangeOutputs(changes, changes.map(function (diffItem, index) {
+                            var packing = utils.packArrows(changes);
+                            output.arrowsAlongsideChangeOutputs(packing, changes.map(function (diffItem, index) {
                                 var delimiterOutput = subjectType.delimiter(output.clone(), index, indexOfLastNonInsert + 1);
                                 return output.clone().block(function () {
                                     var type = diffItem.type;

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1044,11 +1044,16 @@ module.exports = function (expect) {
                             if (subjectType.indent) {
                                 output.indentLines();
                             }
-                            changes.forEach(function (diffItem, index) {
+                            output.arrowsAlongsideChangeOutputs(changes, changes.map(function (diffItem, index) {
                                 var delimiterOutput = subjectType.delimiter(output.clone(), index, indexOfLastNonInsert + 1);
-                                output.nl(index > 0 ? 1 : 0).i().block(function () {
+                                return output.clone().block(function () {
                                     var type = diffItem.type;
-                                    if (type === 'insert') {
+                                    if (type === 'moveSource') {
+                                        this.property(diffItem.actualIndex, inspect(diffItem.value), true)
+                                            .amend(delimiterOutput.sp()).error('// should be moved');
+                                    } else if (type === 'moveTarget') {
+                                        // Leave an empty placeholder
+                                    } else if (type === 'insert') {
                                         this.annotationBlock(function () {
                                             var index = typeof diffItem.actualIndex !== 'undefined' ? diffItem.actualIndex : diffItem.expectedIndex;
                                             if (expect.findTypeOf(diffItem.value).is('function')) {
@@ -1096,7 +1101,8 @@ module.exports = function (expect) {
                                         }), true);
                                     }
                                 });
-                            });
+                            }));
+
                             if (subjectType.indent) {
                                 output.outdentLines();
                             }

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -442,11 +442,11 @@ module.exports = function (expect) {
             });
 
             if (arrows.length === 1) {
-                this.block(arrows[0]).sp();
+                this.block(arrows[0]);
             } else if (arrows.length > 1) {
                 this.block(function () {
                     this.merge(arrows);
-                }).sp();
+                });
             }
         } else {
             this.i();
@@ -454,7 +454,10 @@ module.exports = function (expect) {
 
         this.block(function () {
             changeOutputs.forEach(function (changeOutput, index) {
-                this.nl(index > 0 ? 1 : 0).i().append(changeOutput);
+                this.nl(index > 0 ? 1 : 0);
+                if (!changeOutput.isEmpty()) {
+                    this.sp(packing ? 1 : 0).append(changeOutput);
+                }
             }, this);
         });
     });

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -450,8 +450,8 @@ module.exports = function (expect) {
                 var lastChangeIndex = Math.max(moveSourceAndMoveTarget.source.changeIndex, moveSourceAndMoveTarget.target.changeIndex);
 
                 arrowSpecs.push({
-                    start: topByChangeNumber[firstChangeIndex],
-                    end: topByChangeNumber[lastChangeIndex] + 1,
+                    start: firstChangeIndex,
+                    end: lastChangeIndex,
                     direction: moveSourceAndMoveTarget.source.changeIndex < moveSourceAndMoveTarget.target.changeIndex ? 'down' : 'up'
                 });
             });
@@ -461,9 +461,9 @@ module.exports = function (expect) {
                 columnSet.forEach(function (entry) {
                     arrows.push(that.clone().arrow({
                         left: i * 2,
-                        top: entry.start,
+                        top: topByChangeNumber[entry.start],
                         width: 1 + (packing.length - i) * 2,
-                        height: entry.end - entry.start,
+                        height: topByChangeNumber[entry.end] - topByChangeNumber[entry.start] + 1,
                         direction: entry.direction
                     }));
                 });

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -451,6 +451,7 @@ module.exports = function (expect) {
         } else {
             this.i();
         }
+
         this.block(function () {
             changeOutputs.forEach(function (changeOutput, index) {
                 this.nl(index > 0 ? 1 : 0).i().append(changeOutput);

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -355,7 +355,7 @@ module.exports = function (expect) {
         var i;
         this.nl(options.top || 0).sp(options.left || 0).text('┌', styles);
         for (i = 1 ; i < options.width ; i += 1) {
-            this.text(i === options.width - 1 && options.direction === 'up' ? '>' : '─', styles);
+            this.text(i === options.width - 1 && options.direction === 'up' ? '▷' : '─', styles);
         }
         this.nl();
         for (i = 1 ; i < options.height - 1 ; i += 1) {
@@ -363,7 +363,7 @@ module.exports = function (expect) {
         }
         this.sp(options.left || 0).text('└', styles);
         for (i = 1 ; i < options.width ; i += 1) {
-            this.text(i === options.width - 1 && options.direction === 'down' ? '>' : '─', styles);
+            this.text(i === options.width - 1 && options.direction === 'down' ? '▷' : '─', styles);
         }
     });
 

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -1,7 +1,6 @@
 var utils = require('./utils');
 var stringDiff = require('diff');
 var specialCharRegExp = require('./specialCharRegExp');
-var greedyIntervalPacker = require('greedy-interval-packer');
 
 module.exports = function (expect) {
     expect.installTheme({ styles: {
@@ -419,45 +418,18 @@ module.exports = function (expect) {
         }
     });
 
-    expect.addStyle('arrowsAlongsideChangeOutputs', function (changes, changeOutputs) {
-        var moveSourceAndTargetByActualIndex = {};
-        changes.forEach(function (diffItem, index) {
-            if (diffItem.type === 'moveSource') {
-                diffItem.changeIndex = index;
-                (moveSourceAndTargetByActualIndex[diffItem.actualIndex] = moveSourceAndTargetByActualIndex[diffItem.actualIndex] || {}).source = diffItem;
-            } else if (diffItem.type === 'moveTarget') {
-                diffItem.changeIndex = index;
-                (moveSourceAndTargetByActualIndex[diffItem.actualIndex] = moveSourceAndTargetByActualIndex[diffItem.actualIndex] || {}).target = diffItem;
-            }
-        });
-
-        var topByChangeNumber = {};
-        var top = 0;
-        changeOutputs.forEach(function (changeOutput, index) {
-            topByChangeNumber[index] = top;
-            top += changeOutput.size().height;
-        });
-        var that = this;
-        var moveIndices = Object.keys(moveSourceAndTargetByActualIndex);
-        if (moveIndices.length > 0) {
-            var arrowSpecs = [];
-            moveIndices.sort(function (a, b) {
-                // Order by distance between change indices descending
-                return Math.abs(moveSourceAndTargetByActualIndex[b].source.changeIndex - moveSourceAndTargetByActualIndex[b].target.changeIndex) - Math.abs(moveSourceAndTargetByActualIndex[a].source.changeIndex - moveSourceAndTargetByActualIndex[a].target.changeIndex);
-            }).forEach(function (actualIndex, i, keys) {
-                var moveSourceAndMoveTarget = moveSourceAndTargetByActualIndex[actualIndex];
-                var firstChangeIndex = Math.min(moveSourceAndMoveTarget.source.changeIndex, moveSourceAndMoveTarget.target.changeIndex);
-                var lastChangeIndex = Math.max(moveSourceAndMoveTarget.source.changeIndex, moveSourceAndMoveTarget.target.changeIndex);
-
-                arrowSpecs.push({
-                    start: firstChangeIndex,
-                    end: lastChangeIndex,
-                    direction: moveSourceAndMoveTarget.source.changeIndex < moveSourceAndMoveTarget.target.changeIndex ? 'down' : 'up'
-                });
+    expect.addStyle('arrowsAlongsideChangeOutputs', function (packing, changeOutputs) {
+        if (packing) {
+            var topByChangeNumber = {};
+            var top = 0;
+            changeOutputs.forEach(function (changeOutput, index) {
+                topByChangeNumber[index] = top;
+                top += changeOutput.size().height;
             });
+            var that = this;
 
             var arrows = [];
-            greedyIntervalPacker(arrowSpecs).forEach(function (columnSet, i, packing) {
+            packing.forEach(function (columnSet, i, packing) {
                 columnSet.forEach(function (entry) {
                     arrows.push(that.clone().arrow({
                         left: i * 2,

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -347,4 +347,128 @@ module.exports = function (expect) {
             }
         }, this);
     });
+
+    expect.addStyle('arrow', function (options) {
+        options = options || {};
+        var styles = options.styles || [];
+        var i;
+        this.nl(options.top || 0).sp(options.left || 0).text('┌', styles);
+        for (i = 1 ; i < options.width ; i += 1) {
+            this.text(i === options.width - 1 && options.up ? '>' : '─', styles);
+        }
+        this.nl();
+        for (i = 1 ; i < options.height - 1 ; i += 1) {
+            this.sp(options.left || 0).text('│', styles).nl();
+        }
+        this.sp(options.left || 0).text('└', styles);
+        for (i = 1 ; i < options.width ; i += 1) {
+            this.text(i === options.width - 1 && options.down ? '>' : '─', styles);
+        }
+    });
+
+    var flattenBlocksInLines = require('magicpen/lib/flattenBlocksInLines');
+    expect.addStyle('merge', function (pens) {
+        var flattenedPens = pens.map(function (pen) {
+            return flattenBlocksInLines(pen.output);
+        }).reverse();
+        var maxHeight = flattenedPens.reduce(function (maxHeight, pen) {
+            return Math.max(maxHeight, pen.length);
+        }, 0);
+        var blockNumbers = new Array(flattenedPens.length);
+        var blockOffsets = new Array(flattenedPens.length);
+        // As long as there's at least one pen with a line left:
+        for (var lineNumber = 0 ; lineNumber < maxHeight ; lineNumber += 1) {
+            if (lineNumber > 0) {
+                this.nl();
+            }
+            var i;
+            for (i = 0 ; i < blockNumbers.length ; i += 1) {
+                blockNumbers[i] = 0;
+                blockOffsets[i] = 0;
+            }
+            var contentLeft;
+            do {
+                contentLeft = false;
+                var hasOutputChar = false;
+                for (i = 0 ; i < flattenedPens.length ; i += 1) {
+                    var currentLine = flattenedPens[i][lineNumber];
+                    if (currentLine) {
+                        while (currentLine[blockNumbers[i]] && blockOffsets[i] >= currentLine[blockNumbers[i]].args.content.length) {
+                            blockNumbers[i] += 1;
+                            blockOffsets[i] = 0;
+                        }
+                        var currentBlock = currentLine[blockNumbers[i]];
+                        if (currentBlock) {
+                            contentLeft = true;
+                            if (!hasOutputChar) {
+                                var ch = currentBlock.args.content.charAt(blockOffsets[i]);
+                                if (ch !== ' ') {
+                                    this.text(ch, currentBlock.args.styles);
+                                    hasOutputChar = true;
+                                }
+                            }
+                            blockOffsets[i] += 1;
+                        }
+                    }
+                }
+                if (!hasOutputChar && contentLeft) {
+                    this.sp();
+                }
+            } while (contentLeft);
+        }
+    });
+
+    expect.addStyle('arrowsAlongsideChangeOutputs', function (changes, changeOutputs) {
+        var moveSourceAndTargetByActualIndex = {};
+        changes.forEach(function (diffItem, index) {
+            if (diffItem.type === 'moveSource') {
+                diffItem.changeIndex = index;
+                (moveSourceAndTargetByActualIndex[diffItem.actualIndex] = moveSourceAndTargetByActualIndex[diffItem.actualIndex] || {}).source = diffItem;
+            } else if (diffItem.type === 'moveTarget') {
+                diffItem.changeIndex = index;
+                (moveSourceAndTargetByActualIndex[diffItem.actualIndex] = moveSourceAndTargetByActualIndex[diffItem.actualIndex] || {}).target = diffItem;
+            }
+        });
+
+        var topByChangeNumber = {};
+        var top = 0;
+        changeOutputs.forEach(function (changeOutput, index) {
+            topByChangeNumber[index] = top;
+            top += changeOutput.size().height;
+        });
+        var that = this;
+        var moveIndices = Object.keys(moveSourceAndTargetByActualIndex);
+        if (moveIndices.length > 0) {
+            var arrows = moveIndices.sort(function (a, b) {
+                // Order by distance between change indices descending
+                return Math.abs(moveSourceAndTargetByActualIndex[b].source.changeIndex - moveSourceAndTargetByActualIndex[b].target.changeIndex) - Math.abs(moveSourceAndTargetByActualIndex[a].source.changeIndex - moveSourceAndTargetByActualIndex[a].target.changeIndex);
+            }).map(function (actualIndex, i, keys) {
+                var moveSourceAndMoveTarget = moveSourceAndTargetByActualIndex[actualIndex];
+                var firstChangeIndex = Math.min(moveSourceAndMoveTarget.source.changeIndex, moveSourceAndMoveTarget.target.changeIndex);
+                var lastChangeIndex = Math.max(moveSourceAndMoveTarget.source.changeIndex, moveSourceAndMoveTarget.target.changeIndex);
+                return that.clone().arrow({
+                    left: 2 * i,
+                    top: topByChangeNumber[firstChangeIndex],
+                    height: topByChangeNumber[lastChangeIndex] - topByChangeNumber[firstChangeIndex] + 1,
+                    width: 1 + (keys.length - i) * 2,
+                    down: moveSourceAndMoveTarget.source.changeIndex < moveSourceAndMoveTarget.target.changeIndex,
+                    up: moveSourceAndMoveTarget.source.changeIndex > moveSourceAndMoveTarget.target.changeIndex
+                });
+            });
+            if (arrows.length === 1) {
+                this.block(arrows[0]).sp();
+            } else if (arrows.length > 1) {
+                this.block(function () {
+                    this.merge(arrows);
+                }).sp();
+            }
+        } else {
+            this.i();
+        }
+        this.block(function () {
+            changeOutputs.forEach(function (changeOutput, index) {
+                this.nl(index > 0 ? 1 : 0).i().append(changeOutput);
+            }, this);
+        });
+    });
 };

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -1,6 +1,7 @@
 var utils = require('./utils');
 var stringDiff = require('diff');
 var specialCharRegExp = require('./specialCharRegExp');
+var greedyIntervalPacker = require('greedy-interval-packer');
 
 module.exports = function (expect) {
     expect.installTheme({ styles: {
@@ -354,7 +355,7 @@ module.exports = function (expect) {
         var i;
         this.nl(options.top || 0).sp(options.left || 0).text('┌', styles);
         for (i = 1 ; i < options.width ; i += 1) {
-            this.text(i === options.width - 1 && options.up ? '>' : '─', styles);
+            this.text(i === options.width - 1 && options.direction === 'up' ? '>' : '─', styles);
         }
         this.nl();
         for (i = 1 ; i < options.height - 1 ; i += 1) {
@@ -362,7 +363,7 @@ module.exports = function (expect) {
         }
         this.sp(options.left || 0).text('└', styles);
         for (i = 1 ; i < options.width ; i += 1) {
-            this.text(i === options.width - 1 && options.down ? '>' : '─', styles);
+            this.text(i === options.width - 1 && options.direction === 'down' ? '>' : '─', styles);
         }
     });
 
@@ -439,22 +440,35 @@ module.exports = function (expect) {
         var that = this;
         var moveIndices = Object.keys(moveSourceAndTargetByActualIndex);
         if (moveIndices.length > 0) {
-            var arrows = moveIndices.sort(function (a, b) {
+            var arrowSpecs = [];
+            moveIndices.sort(function (a, b) {
                 // Order by distance between change indices descending
                 return Math.abs(moveSourceAndTargetByActualIndex[b].source.changeIndex - moveSourceAndTargetByActualIndex[b].target.changeIndex) - Math.abs(moveSourceAndTargetByActualIndex[a].source.changeIndex - moveSourceAndTargetByActualIndex[a].target.changeIndex);
-            }).map(function (actualIndex, i, keys) {
+            }).forEach(function (actualIndex, i, keys) {
                 var moveSourceAndMoveTarget = moveSourceAndTargetByActualIndex[actualIndex];
                 var firstChangeIndex = Math.min(moveSourceAndMoveTarget.source.changeIndex, moveSourceAndMoveTarget.target.changeIndex);
                 var lastChangeIndex = Math.max(moveSourceAndMoveTarget.source.changeIndex, moveSourceAndMoveTarget.target.changeIndex);
-                return that.clone().arrow({
-                    left: 2 * i,
-                    top: topByChangeNumber[firstChangeIndex],
-                    height: topByChangeNumber[lastChangeIndex] - topByChangeNumber[firstChangeIndex] + 1,
-                    width: 1 + (keys.length - i) * 2,
-                    down: moveSourceAndMoveTarget.source.changeIndex < moveSourceAndMoveTarget.target.changeIndex,
-                    up: moveSourceAndMoveTarget.source.changeIndex > moveSourceAndMoveTarget.target.changeIndex
+
+                arrowSpecs.push({
+                    start: topByChangeNumber[firstChangeIndex],
+                    end: topByChangeNumber[lastChangeIndex] + 1,
+                    direction: moveSourceAndMoveTarget.source.changeIndex < moveSourceAndMoveTarget.target.changeIndex ? 'down' : 'up'
                 });
             });
+
+            var arrows = [];
+            greedyIntervalPacker(arrowSpecs).forEach(function (columnSet, i, packing) {
+                columnSet.forEach(function (entry) {
+                    arrows.push(that.clone().arrow({
+                        left: i * 2,
+                        top: entry.start,
+                        width: 1 + (packing.length - i) * 2,
+                        height: entry.end - entry.start,
+                        direction: entry.direction
+                    }));
+                });
+            });
+
             if (arrows.length === 1) {
                 this.block(arrows[0]).sp();
             } else if (arrows.length > 1) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -557,11 +557,16 @@ module.exports = function (expect) {
             var indexOfLastNonInsert = changes.reduce(function (previousValue, diffItem, index) {
                 return (diffItem.type === 'insert') ? previousValue : index;
             }, -1);
-            changes.forEach(function (diffItem, index) {
+            output.arrowsAlongsideChangeOutputs(changes, changes.map(function (diffItem, index) {
                 var delimiterOutput = type.delimiter(output.clone(), index, indexOfLastNonInsert + 1);
-                output.nl(index > 0 ? 1 : 0).i().block(function () {
+                return output.clone().block(function () {
                     var type = diffItem.type;
-                    if (type === 'insert') {
+                    if (type === 'moveSource') {
+                        this.property(diffItem.actualIndex, inspect(diffItem.value), true)
+                            .amend(delimiterOutput.sp()).error('// should be moved');
+                    } else if (type === 'moveTarget') {
+                        // Leave an empty placeholder
+                    } else if (type === 'insert') {
                         this.annotationBlock(function () {
                             this.error('missing ').block(function () {
                                 var index = typeof diffItem.actualIndex !== 'undefined' ? diffItem.actualIndex : diffItem.expectedIndex;
@@ -597,7 +602,7 @@ module.exports = function (expect) {
                         });
                     }
                 });
-            });
+            }));
 
             if (this.indent) {
                 output.outdentLines();

--- a/lib/types.js
+++ b/lib/types.js
@@ -557,7 +557,7 @@ module.exports = function (expect) {
             var indexOfLastNonInsert = changes.reduce(function (previousValue, diffItem, index) {
                 return (diffItem.type === 'insert') ? previousValue : index;
             }, -1);
-            output.arrowsAlongsideChangeOutputs(changes, changes.map(function (diffItem, index) {
+            output.arrowsAlongsideChangeOutputs(utils.packArrows(changes), changes.map(function (diffItem, index) {
                 var delimiterOutput = type.delimiter(output.clone(), index, indexOfLastNonInsert + 1);
                 return output.clone().block(function () {
                     var type = diffItem.type;

--- a/lib/types.js
+++ b/lib/types.js
@@ -560,49 +560,50 @@ module.exports = function (expect) {
             var packing = utils.packArrows(changes); // NOTE: Will have side effects in changes if the packing results in too many arrow lanes
             output.arrowsAlongsideChangeOutputs(packing, changes.map(function (diffItem, index) {
                 var delimiterOutput = type.delimiter(output.clone(), index, indexOfLastNonInsert + 1);
-                return output.clone().block(function () {
-                    var type = diffItem.type;
-                    if (type === 'moveSource') {
-                        this.property(diffItem.actualIndex, inspect(diffItem.value), true)
-                            .amend(delimiterOutput.sp()).error('// should be moved');
-                    } else if (type === 'moveTarget') {
-                        // Leave an empty placeholder
-                    } else if (type === 'insert') {
-                        this.annotationBlock(function () {
-                            this.error('missing ').block(function () {
-                                var index = typeof diffItem.actualIndex !== 'undefined' ? diffItem.actualIndex : diffItem.expectedIndex;
-                                this.property(index, inspect(diffItem.value), true);
+                if (diffItem.type === 'moveTarget') {
+                    return output.clone();
+                } else {
+                    return output.clone().block(function () {
+                        if (diffItem.type === 'moveSource') {
+                            this.property(diffItem.actualIndex, inspect(diffItem.value), true)
+                                .amend(delimiterOutput.sp()).error('// should be moved');
+                        } else if (diffItem.type === 'insert') {
+                            this.annotationBlock(function () {
+                                this.error('missing ').block(function () {
+                                    var index = typeof diffItem.actualIndex !== 'undefined' ? diffItem.actualIndex : diffItem.expectedIndex;
+                                    this.property(index, inspect(diffItem.value), true);
+                                });
                             });
-                        });
-                    } else if (type === 'remove') {
-                        this.block(function () {
-                            this.property(diffItem.actualIndex, inspect(diffItem.value), true)
-                                .amend(delimiterOutput.sp()).error('// should be removed');
-                        });
-                    } else if (type === 'equal') {
-                        this.block(function () {
-                            this.property(diffItem.actualIndex, inspect(diffItem.value), true)
-                                .amend(delimiterOutput);
-                        });
-                    } else {
-                        this.block(function () {
-                            var valueDiff = diff(diffItem.value, diffItem.expected);
-                            this.property(diffItem.actualIndex, output.clone().block(function () {
-                                if (valueDiff && valueDiff.inline) {
-                                    this.append(valueDiff.amend(delimiterOutput));
-                                } else if (valueDiff) {
-                                    this.append(inspect(diffItem.value).amend(delimiterOutput.sp())).annotationBlock(function () {
-                                        this.shouldEqualError(diffItem.expected, inspect).nl(2).append(valueDiff);
-                                    });
-                                } else {
-                                    this.append(inspect(diffItem.value).amend(delimiterOutput.sp())).annotationBlock(function () {
-                                        this.shouldEqualError(diffItem.expected, inspect);
-                                    });
-                                }
-                            }), true);
-                        });
-                    }
-                });
+                        } else if (diffItem.type === 'remove') {
+                            this.block(function () {
+                                this.property(diffItem.actualIndex, inspect(diffItem.value), true)
+                                    .amend(delimiterOutput.sp()).error('// should be removed');
+                            });
+                        } else if (diffItem.type === 'equal') {
+                            this.block(function () {
+                                this.property(diffItem.actualIndex, inspect(diffItem.value), true)
+                                    .amend(delimiterOutput);
+                            });
+                        } else {
+                            this.block(function () {
+                                var valueDiff = diff(diffItem.value, diffItem.expected);
+                                this.property(diffItem.actualIndex, output.clone().block(function () {
+                                    if (valueDiff && valueDiff.inline) {
+                                        this.append(valueDiff.amend(delimiterOutput));
+                                    } else if (valueDiff) {
+                                        this.append(inspect(diffItem.value).amend(delimiterOutput.sp())).annotationBlock(function () {
+                                            this.shouldEqualError(diffItem.expected, inspect).nl(2).append(valueDiff);
+                                        });
+                                    } else {
+                                        this.append(inspect(diffItem.value).amend(delimiterOutput.sp())).annotationBlock(function () {
+                                            this.shouldEqualError(diffItem.expected, inspect);
+                                        });
+                                    }
+                                }), true);
+                            });
+                        }
+                    });
+                }
             }));
 
             if (this.indent) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -557,7 +557,8 @@ module.exports = function (expect) {
             var indexOfLastNonInsert = changes.reduce(function (previousValue, diffItem, index) {
                 return (diffItem.type === 'insert') ? previousValue : index;
             }, -1);
-            output.arrowsAlongsideChangeOutputs(utils.packArrows(changes), changes.map(function (diffItem, index) {
+            var packing = utils.packArrows(changes); // NOTE: Will have side effects in changes if the packing results in too many arrow lanes
+            output.arrowsAlongsideChangeOutputs(packing, changes.map(function (diffItem, index) {
                 var delimiterOutput = type.delimiter(output.clone(), index, indexOfLastNonInsert + 1);
                 return output.clone().block(function () {
                     var type = diffItem.type;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -179,7 +179,15 @@ var utils = module.exports = {
                 });
             });
 
-            return greedyIntervalPacker(arrowSpecs);
+            var packing = greedyIntervalPacker(arrowSpecs);
+            while (packing.length > 3) {
+                // The arrow packing takes up too many lanes. Turn the moveSource/moveTarget items into inserts and removes
+                packing.shift().forEach(function (entry) {
+                    changes[entry.direction === 'up' ? entry.start : entry.end].type = 'insert';
+                    changes[entry.direction === 'up' ? entry.end : entry.start].type = 'remove';
+                });
+            }
+            return packing;
         }
     }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-proto */
 var canSetPrototype = Object.setPrototypeOf || ({ __proto__: [] } instanceof Array);
+var greedyIntervalPacker = require('greedy-interval-packer');
 
 var setPrototypeOf = Object.setPrototypeOf || function setPrototypeOf(obj, proto) {
     obj.__proto__ = proto;
@@ -147,5 +148,38 @@ var utils = module.exports = {
         }, Array.prototype.slice.call(arguments));
     },
 
-    numericalRegExp: /^(?:0|[1-9][0-9]*)$/
+    numericalRegExp: /^(?:0|[1-9][0-9]*)$/,
+
+    packArrows: function (changes) {
+        var moveSourceAndTargetByActualIndex = {};
+        changes.forEach(function (diffItem, index) {
+            if (diffItem.type === 'moveSource') {
+                diffItem.changeIndex = index;
+                (moveSourceAndTargetByActualIndex[diffItem.actualIndex] = moveSourceAndTargetByActualIndex[diffItem.actualIndex] || {}).source = diffItem;
+            } else if (diffItem.type === 'moveTarget') {
+                diffItem.changeIndex = index;
+                (moveSourceAndTargetByActualIndex[diffItem.actualIndex] = moveSourceAndTargetByActualIndex[diffItem.actualIndex] || {}).target = diffItem;
+            }
+        });
+        var moveIndices = Object.keys(moveSourceAndTargetByActualIndex);
+        if (moveIndices.length > 0) {
+            var arrowSpecs = [];
+            moveIndices.sort(function (a, b) {
+                // Order by distance between change indices descending
+                return Math.abs(moveSourceAndTargetByActualIndex[b].source.changeIndex - moveSourceAndTargetByActualIndex[b].target.changeIndex) - Math.abs(moveSourceAndTargetByActualIndex[a].source.changeIndex - moveSourceAndTargetByActualIndex[a].target.changeIndex);
+            }).forEach(function (actualIndex, i, keys) {
+                var moveSourceAndMoveTarget = moveSourceAndTargetByActualIndex[actualIndex];
+                var firstChangeIndex = Math.min(moveSourceAndMoveTarget.source.changeIndex, moveSourceAndMoveTarget.target.changeIndex);
+                var lastChangeIndex = Math.max(moveSourceAndMoveTarget.source.changeIndex, moveSourceAndMoveTarget.target.changeIndex);
+
+                arrowSpecs.push({
+                    start: firstChangeIndex,
+                    end: lastChangeIndex,
+                    direction: moveSourceAndMoveTarget.source.changeIndex < moveSourceAndMoveTarget.target.changeIndex ? 'down' : 'up'
+                });
+            });
+
+            return greedyIntervalPacker(arrowSpecs);
+        }
+    }
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "es5-shim": "4.0.5",
     "eslint": "2.4.0",
     "eslint-config-onelint": "1.0.2",
+    "greedy-interval-packer": "1.2.0",
     "istanbul": "0.3.16",
     "jasmine": "2.2.1",
     "jasmine-core": "~2.2.0",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "array-changes": "1.3.1",
-    "array-changes-async": "2.2.1",
+    "array-changes": "2.0.0",
+    "array-changes-async": "3.0.0",
     "detect-indent": "3.0.1",
     "diff": "1.1.0",
     "leven": "2.0.0",

--- a/test/api/addAssertion.spec.js
+++ b/test/api/addAssertion.spec.js
@@ -298,7 +298,7 @@ describe('addAssertion', function () {
                        'expected [ 3, 2, 1 ] to equal [ 1, 2, 3 ]\n' +
                        '\n' +
                        '[\n' +
-                       '┌───▷ \n' +
+                       '┌───▷\n' +
                        '│ ┌─▷\n' +
                        '│ │   3,\n' +
                        '│ └── 2, // should be moved\n' +
@@ -312,7 +312,7 @@ describe('addAssertion', function () {
                     clonedExpect([3, 2, 1], 'to be sorted');
                 }, 'to throw',
                        '[\n' +
-                       '┌───▷ \n' +
+                       '┌───▷\n' +
                        '│ ┌─▷\n' +
                        '│ │   3,\n' +
                        '│ └── 2, // should be moved\n' +
@@ -397,7 +397,7 @@ describe('addAssertion', function () {
                 clonedExpect([3, 2, 1], 'to be sorted after delay', 1, function (err) {
                     expect(err, 'to have message',
                            '[\n' +
-                           '┌───▷ \n' +
+                           '┌───▷\n' +
                            '│ ┌─▷\n' +
                            '│ │   3,\n' +
                            '│ └── 2, // should be moved\n' +
@@ -508,7 +508,7 @@ describe('addAssertion', function () {
                         clonedExpect([3, 2, 1], 'to be sorted after delay', 1),
                         'to be rejected with',
                         '[\n' +
-                        '┌───▷ \n' +
+                        '┌───▷\n' +
                         '│ ┌─▷\n' +
                         '│ │   3,\n' +
                         '│ └── 2, // should be moved\n' +

--- a/test/api/addAssertion.spec.js
+++ b/test/api/addAssertion.spec.js
@@ -298,9 +298,11 @@ describe('addAssertion', function () {
                        'expected [ 3, 2, 1 ] to equal [ 1, 2, 3 ]\n' +
                        '\n' +
                        '[\n' +
-                       "  3, // should equal 1\n" +
-                       "  2,\n" +
-                       "  1 // should equal 3\n" +
+                       '┌───> \n' +
+                       '│ ┌─>\n' +
+                       '│ │   3,\n' +
+                       '│ └── 2, // should be moved\n' +
+                       '└──── 1 // should be moved\n' +
                        ']');
             });
 
@@ -310,9 +312,11 @@ describe('addAssertion', function () {
                     clonedExpect([3, 2, 1], 'to be sorted');
                 }, 'to throw',
                        '[\n' +
-                       "  3, // should equal 1\n" +
-                       "  2,\n" +
-                       "  1 // should equal 3\n" +
+                       '┌───> \n' +
+                       '│ ┌─>\n' +
+                       '│ │   3,\n' +
+                       '│ └── 2, // should be moved\n' +
+                       '└──── 1 // should be moved\n' +
                        ']');
             });
 
@@ -393,9 +397,11 @@ describe('addAssertion', function () {
                 clonedExpect([3, 2, 1], 'to be sorted after delay', 1, function (err) {
                     expect(err, 'to have message',
                            '[\n' +
-                           "  3, // should equal 1\n" +
-                           "  2,\n" +
-                           "  1 // should equal 3\n" +
+                           '┌───> \n' +
+                           '│ ┌─>\n' +
+                           '│ │   3,\n' +
+                           '│ └── 2, // should be moved\n' +
+                           '└──── 1 // should be moved\n' +
                            ']');
                     done();
                 });
@@ -502,10 +508,12 @@ describe('addAssertion', function () {
                         clonedExpect([3, 2, 1], 'to be sorted after delay', 1),
                         'to be rejected with',
                         '[\n' +
-                            "  3, // should equal 1\n" +
-                            "  2,\n" +
-                            "  1 // should equal 3\n" +
-                            ']'
+                        '┌───> \n' +
+                        '│ ┌─>\n' +
+                        '│ │   3,\n' +
+                        '│ └── 2, // should be moved\n' +
+                        '└──── 1 // should be moved\n' +
+                        ']'
                     );
                 });
 

--- a/test/api/addAssertion.spec.js
+++ b/test/api/addAssertion.spec.js
@@ -298,8 +298,8 @@ describe('addAssertion', function () {
                        'expected [ 3, 2, 1 ] to equal [ 1, 2, 3 ]\n' +
                        '\n' +
                        '[\n' +
-                       '┌───> \n' +
-                       '│ ┌─>\n' +
+                       '┌───▷ \n' +
+                       '│ ┌─▷\n' +
                        '│ │   3,\n' +
                        '│ └── 2, // should be moved\n' +
                        '└──── 1 // should be moved\n' +
@@ -312,8 +312,8 @@ describe('addAssertion', function () {
                     clonedExpect([3, 2, 1], 'to be sorted');
                 }, 'to throw',
                        '[\n' +
-                       '┌───> \n' +
-                       '│ ┌─>\n' +
+                       '┌───▷ \n' +
+                       '│ ┌─▷\n' +
                        '│ │   3,\n' +
                        '│ └── 2, // should be moved\n' +
                        '└──── 1 // should be moved\n' +
@@ -397,8 +397,8 @@ describe('addAssertion', function () {
                 clonedExpect([3, 2, 1], 'to be sorted after delay', 1, function (err) {
                     expect(err, 'to have message',
                            '[\n' +
-                           '┌───> \n' +
-                           '│ ┌─>\n' +
+                           '┌───▷ \n' +
+                           '│ ┌─▷\n' +
                            '│ │   3,\n' +
                            '│ └── 2, // should be moved\n' +
                            '└──── 1 // should be moved\n' +
@@ -508,8 +508,8 @@ describe('addAssertion', function () {
                         clonedExpect([3, 2, 1], 'to be sorted after delay', 1),
                         'to be rejected with',
                         '[\n' +
-                        '┌───> \n' +
-                        '│ ┌─>\n' +
+                        '┌───▷ \n' +
+                        '│ ┌─▷\n' +
                         '│ │   3,\n' +
                         '│ └── 2, // should be moved\n' +
                         '└──── 1 // should be moved\n' +

--- a/test/api/async.spec.js
+++ b/test/api/async.spec.js
@@ -82,9 +82,10 @@ describe('async', function () {
                 '    expected [ 1, 3, 2 ] to equal [ 1, 2, 3 ]\n' +
                 '\n' +
                 '    [\n' +
-                '      1,\n' +
-                '      3, // should equal 2\n' +
-                '      2 // should equal 3\n' +
+                '        1,\n' +
+                '    ┌─>\n' +
+                '    │   3,\n' +
+                '    └── 2 // should be moved\n' +
                 '    ]'
         );
     }));
@@ -97,9 +98,10 @@ describe('async', function () {
                 '  expected [ 1, 3, 2 ] to equal [ 1, 2, 3 ]\n' +
                 '\n' +
                 '  [\n' +
-                '    1,\n' +
-                '    3, // should equal 2\n' +
-                '    2 // should equal 3\n' +
+                '      1,\n' +
+                '  ┌─>\n' +
+                '  │   3,\n' +
+                '  └── 2 // should be moved\n' +
                 '  ]'
         );
     }));
@@ -119,9 +121,10 @@ describe('async', function () {
                        '    expected [ 1, 3, 2 ] to equal [ 1, 2, 3 ]\n' +
                        '\n' +
                        '    [\n' +
-                       '      1,\n' +
-                       '      3, // should equal 2\n' +
-                       '      2 // should equal 3\n' +
+                       '        1,\n' +
+                       '    ┌─>\n' +
+                       '    │   3,\n' +
+                       '    └── 2 // should be moved\n' +
                        '    ]');
 
                 workQueue.onUnhandledRejection = null;

--- a/test/api/async.spec.js
+++ b/test/api/async.spec.js
@@ -83,7 +83,7 @@ describe('async', function () {
                 '\n' +
                 '    [\n' +
                 '        1,\n' +
-                '    ┌─>\n' +
+                '    ┌─▷\n' +
                 '    │   3,\n' +
                 '    └── 2 // should be moved\n' +
                 '    ]'
@@ -99,7 +99,7 @@ describe('async', function () {
                 '\n' +
                 '  [\n' +
                 '      1,\n' +
-                '  ┌─>\n' +
+                '  ┌─▷\n' +
                 '  │   3,\n' +
                 '  └── 2 // should be moved\n' +
                 '  ]'
@@ -122,7 +122,7 @@ describe('async', function () {
                        '\n' +
                        '    [\n' +
                        '        1,\n' +
-                       '    ┌─>\n' +
+                       '    ┌─▷\n' +
                        '    │   3,\n' +
                        '    └── 2 // should be moved\n' +
                        '    ]');

--- a/test/assertions/to-equal.spec.js
+++ b/test/assertions/to-equal.spec.js
@@ -180,27 +180,28 @@ describe('to equal assertion', function () {
                "to equal [ 0, 1, { foo: 'baz' }, 42, { qux: 'qux' }, [ 1, 2, 3 ], 'baz' ]\n" +
                "\n" +
                "[\n" +
-               "  0,\n" +
-               "  // missing 1\n" +
-               "  {\n" +
-               "    foo: 'bar' // should equal 'baz'\n" +
-               "               //\n" +
-               "               // -bar\n" +
-               "               // +baz\n" +
-               "  },\n" +
-               "  // missing 42\n" +
-               "  // missing { qux: 'qux' }\n" +
-               "  1, // should be removed\n" +
-               "  { bar: 'bar' }, // should be removed\n" +
-               "  [\n" +
-               "    1,\n" +
-               "    3, // should equal 2\n" +
-               "    2 // should equal 3\n" +
-               "  ],\n" +
-               "  'bar' // should equal 'baz'\n" +
-               "        //\n" +
-               "        // -bar\n" +
-               "        // +baz\n" +
+               "    0,\n" +
+               "┌─>\n" +
+               "│   {\n" +
+               "│     foo: 'bar' // should equal 'baz'\n" +
+               "│                //\n" +
+               "│                // -bar\n" +
+               "│                // +baz\n" +
+               "│   },\n" +
+               "└── 1, // should be moved\n" +
+               "    // missing 42\n" +
+               "    // missing { qux: 'qux' }\n" +
+               "    { bar: 'bar' }, // should be removed\n" +
+               "    [\n" +
+               "        1,\n" +
+               "    ┌─>\n" +
+               "    │   3,\n" +
+               "    └── 2 // should be moved\n" +
+               "    ],\n" +
+               "    'bar' // should equal 'baz'\n" +
+               "          //\n" +
+               "          // -bar\n" +
+               "          // +baz\n" +
                "]");
     });
 

--- a/test/assertions/to-equal.spec.js
+++ b/test/assertions/to-equal.spec.js
@@ -188,9 +188,9 @@ describe('to equal assertion', function () {
                "│                // -bar\n" +
                "│                // +baz\n" +
                "│   },\n" +
+               "│   // missing 42\n" +
+               "│   // missing { qux: 'qux' }\n" +
                "└── 1, // should be moved\n" +
-               "    // missing 42\n" +
-               "    // missing { qux: 'qux' }\n" +
                "    { bar: 'bar' }, // should be removed\n" +
                "    [\n" +
                "        1,\n" +

--- a/test/assertions/to-equal.spec.js
+++ b/test/assertions/to-equal.spec.js
@@ -181,7 +181,7 @@ describe('to equal assertion', function () {
                "\n" +
                "[\n" +
                "    0,\n" +
-               "┌─>\n" +
+               "┌─▷\n" +
                "│   {\n" +
                "│     foo: 'bar' // should equal 'baz'\n" +
                "│                //\n" +
@@ -194,7 +194,7 @@ describe('to equal assertion', function () {
                "    { bar: 'bar' }, // should be removed\n" +
                "    [\n" +
                "        1,\n" +
-               "    ┌─>\n" +
+               "    ┌─▷\n" +
                "    │   3,\n" +
                "    └── 2 // should be moved\n" +
                "    ],\n" +

--- a/test/assertions/to-satisfy.spec.js
+++ b/test/assertions/to-satisfy.spec.js
@@ -1581,7 +1581,7 @@ describe('to satisfy assertion', function () {
                     "to satisfy [ 1, 2, 3, bar: 456, baz: 789, quux: false ]\n" +
                     "\n" +
                     "[\n" +
-                    "┌─▷ \n" +
+                    "┌─▷\n" +
                     "│   2,\n" +
                     "│   3,\n" +
                     "└── 1, // should be moved\n" +

--- a/test/assertions/to-satisfy.spec.js
+++ b/test/assertions/to-satisfy.spec.js
@@ -1581,14 +1581,14 @@ describe('to satisfy assertion', function () {
                     "to satisfy [ 1, 2, 3, bar: 456, baz: 789, quux: false ]\n" +
                     "\n" +
                     "[\n" +
-                    "  // missing 1\n" +
-                    "  2,\n" +
-                    "  3,\n" +
-                    "  1, // should be removed\n" +
-                    "  foo: 123, // should be removed\n" +
-                    "  bar: 456,\n" +
-                    "  quux: {} // should equal false\n" +
-                    "  // missing baz: 789\n" +
+                    "┌─> \n" +
+                    "│   2,\n" +
+                    "│   3,\n" +
+                    "└── 1, // should be moved\n" +
+                    "    foo: 123, // should be removed\n" +
+                    "    bar: 456,\n" +
+                    "    quux: {} // should equal false\n" +
+                    "    // missing baz: 789\n" +
                     "]"
                 );
             });

--- a/test/assertions/to-satisfy.spec.js
+++ b/test/assertions/to-satisfy.spec.js
@@ -1581,7 +1581,7 @@ describe('to satisfy assertion', function () {
                     "to satisfy [ 1, 2, 3, bar: 456, baz: 789, quux: false ]\n" +
                     "\n" +
                     "[\n" +
-                    "┌─> \n" +
+                    "┌─▷ \n" +
                     "│   2,\n" +
                     "│   3,\n" +
                     "└── 1, // should be moved\n" +

--- a/test/styles/arrow.spec.js
+++ b/test/styles/arrow.spec.js
@@ -2,7 +2,7 @@
 describe('arrow', function () {
     it('should render an arrow with the given dimensions', function () {
         expect(
-            expect.createOutput('text').arrow({ width: 4, height: 5, down: true }).toString(),
+            expect.createOutput('text').arrow({ width: 4, height: 5, direction: 'down' }).toString(),
             'to equal',
             "┌───\n" +
             "│\n" +
@@ -14,7 +14,7 @@ describe('arrow', function () {
 
     it('should support top and left coordinates', function () {
         expect(
-            expect.createOutput('text').arrow({ top: 2, left: 3, width: 4, height: 5, down: true }).toString(),
+            expect.createOutput('text').arrow({ top: 2, left: 3, width: 4, height: 5, direction: 'down' }).toString(),
             'to equal',
             "\n" +
             "\n" +
@@ -26,27 +26,15 @@ describe('arrow', function () {
         );
     });
 
-    it('should render an arrow that points upwards when up:true is given', function () {
+    it('should render an arrow that points upwards when direction:up is given', function () {
         expect(
-            expect.createOutput('text').arrow({ width: 4, height: 5, up: true }).toString(),
+            expect.createOutput('text').arrow({ width: 4, height: 5, direction: 'up' }).toString(),
             'to equal',
             "┌──>\n" +
             "│\n" +
             "│\n" +
             "│\n" +
             "└───"
-        );
-    });
-
-    it('should render an arrow that points both upwards and downwards when down:true and up:true are given', function () {
-        expect(
-            expect.createOutput('text').arrow({ width: 4, height: 5, up: true, down: true }).toString(),
-            'to equal',
-            "┌──>\n" +
-            "│\n" +
-            "│\n" +
-            "│\n" +
-            "└──>"
         );
     });
 });

--- a/test/styles/arrow.spec.js
+++ b/test/styles/arrow.spec.js
@@ -1,0 +1,52 @@
+/*global expect*/
+describe('arrow', function () {
+    it('should render an arrow with the given dimensions', function () {
+        expect(
+            expect.createOutput('text').arrow({ width: 4, height: 5, down: true }).toString(),
+            'to equal',
+            "┌───\n" +
+            "│\n" +
+            "│\n" +
+            "│\n" +
+            "└──>"
+        );
+    });
+
+    it('should support top and left coordinates', function () {
+        expect(
+            expect.createOutput('text').arrow({ top: 2, left: 3, width: 4, height: 5, down: true }).toString(),
+            'to equal',
+            "\n" +
+            "\n" +
+            "   ┌───\n" +
+            "   │\n" +
+            "   │\n" +
+            "   │\n" +
+            "   └──>"
+        );
+    });
+
+    it('should render an arrow that points upwards when up:true is given', function () {
+        expect(
+            expect.createOutput('text').arrow({ width: 4, height: 5, up: true }).toString(),
+            'to equal',
+            "┌──>\n" +
+            "│\n" +
+            "│\n" +
+            "│\n" +
+            "└───"
+        );
+    });
+
+    it('should render an arrow that points both upwards and downwards when down:true and up:true are given', function () {
+        expect(
+            expect.createOutput('text').arrow({ width: 4, height: 5, up: true, down: true }).toString(),
+            'to equal',
+            "┌──>\n" +
+            "│\n" +
+            "│\n" +
+            "│\n" +
+            "└──>"
+        );
+    });
+});

--- a/test/styles/arrow.spec.js
+++ b/test/styles/arrow.spec.js
@@ -8,7 +8,7 @@ describe('arrow', function () {
             "│\n" +
             "│\n" +
             "│\n" +
-            "└──>"
+            "└──▷"
         );
     });
 
@@ -22,7 +22,7 @@ describe('arrow', function () {
             "   │\n" +
             "   │\n" +
             "   │\n" +
-            "   └──>"
+            "   └──▷"
         );
     });
 
@@ -30,7 +30,7 @@ describe('arrow', function () {
         expect(
             expect.createOutput('text').arrow({ width: 4, height: 5, direction: 'up' }).toString(),
             'to equal',
-            "┌──>\n" +
+            "┌──▷\n" +
             "│\n" +
             "│\n" +
             "│\n" +

--- a/test/styles/merge.spec.js
+++ b/test/styles/merge.spec.js
@@ -1,0 +1,24 @@
+/*global expect*/
+describe('merge', function () {
+    it('should overlay a pen on top of another', function () {
+        var pen = expect.createOutput('text');
+        pen.text('abc').nl().text('def');
+        var anotherPen = pen.clone().text(' h').nl().text('i');
+        expect(pen.clone().merge([pen, anotherPen]).toString(),
+            'to equal',
+            "ahc\n" +
+            "ief"
+        );
+    });
+
+    it('should result in a wider pen when merging a wide pen on top of a slim one', function () {
+        var pen = expect.createOutput('text');
+        pen.text('a').nl().text('b');
+        var anotherPen = pen.clone().text('c').nl().text('  d');
+        expect(pen.clone().merge([pen, anotherPen]).toString(),
+            'to equal',
+            "c\n" +
+            "b d"
+        );
+    });
+});

--- a/test/types/array-like-type.spec.js
+++ b/test/types/array-like-type.spec.js
@@ -198,7 +198,7 @@ describe('array-like type', function () {
             "expected [ 'a', 'b', 'c' ] to equal [ 'c', 'a', 'b' ]\n" +
             "\n" +
             "[\n" +
-            "┌─> \n" +
+            "┌─▷ \n" +
             "│   'a',\n" +
             "│   'b',\n" +
             "└── 'c' // should be moved\n" +
@@ -213,8 +213,8 @@ describe('array-like type', function () {
             "expected [ 'a', 'b', 'c', 'd' ] to equal [ 'd', 'b', 'a', 'c' ]\n" +
             "\n" +
             "[\n" +
-            "┌───> \n" +
-            "│ ┌─>\n" +
+            "┌───▷ \n" +
+            "│ ┌─▷\n" +
             "│ │   'a',\n" +
             "│ └── 'b', // should be moved\n" +
             "│     'c',\n" +
@@ -230,9 +230,9 @@ describe('array-like type', function () {
             "expected [ 'a', 'b', 'c', 'd', 'e' ] to equal [ 'c', 'd', 'e', 'a', 'b' ]\n" +
             "\n" +
             "[\n" +
-            "┌─────> \n" +
-            "│ ┌───>\n" +
-            "│ │ ┌─>\n" +
+            "┌─────▷ \n" +
+            "│ ┌───▷\n" +
+            "│ │ ┌─▷\n" +
             "│ │ │   'a',\n" +
             "│ │ │   'b',\n" +
             "└─│─│── 'c', // should be moved\n" +

--- a/test/types/array-like-type.spec.js
+++ b/test/types/array-like-type.spec.js
@@ -191,14 +191,14 @@ describe('array-like type', function () {
         expect([[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]]], 'to inspect as', '[ [ [...] ] ]');
     });
 
-    it('should a moved item with an arrow', function () {
+    it('should render a moved item with an arrow', function () {
         expect(function () {
             expect(['a', 'b', 'c'], 'to equal', ['c', 'a', 'b']);
         }, 'to error with',
             "expected [ 'a', 'b', 'c' ] to equal [ 'c', 'a', 'b' ]\n" +
             "\n" +
             "[\n" +
-            "┌─▷ \n" +
+            "┌─▷\n" +
             "│   'a',\n" +
             "│   'b',\n" +
             "└── 'c' // should be moved\n" +
@@ -234,7 +234,7 @@ describe('array-like type', function () {
             "expected [ 'a', 'b', 'c', 'd' ] to equal [ 'd', 'b', 'a', 'c' ]\n" +
             "\n" +
             "[\n" +
-            "┌───▷ \n" +
+            "┌───▷\n" +
             "│ ┌─▷\n" +
             "│ │   'a',\n" +
             "│ └── 'b', // should be moved\n" +
@@ -251,7 +251,7 @@ describe('array-like type', function () {
             "expected [ 'a', 'b', 'c', 'd', 'e' ] to equal [ 'c', 'd', 'e', 'a', 'b' ]\n" +
             "\n" +
             "[\n" +
-            "┌─────▷ \n" +
+            "┌─────▷\n" +
             "│ ┌───▷\n" +
             "│ │ ┌─▷\n" +
             "│ │ │   'a',\n" +

--- a/test/types/array-like-type.spec.js
+++ b/test/types/array-like-type.spec.js
@@ -206,6 +206,27 @@ describe('array-like type', function () {
         );
     });
 
+    it('should stop rendering more arrows when there would be more than 3 lanes', function () {
+        expect(function () {
+            expect(['a', 'b', 'c', 'd', 'e', 'f'], 'to equal', ['f', 'c', 'd', 'e', 'a', 'b']);
+        }, 'to error with',
+            "expected [ 'a', 'b', 'c', 'd', 'e', 'f' ] to equal [ 'f', 'c', 'd', 'e', 'a', 'b' ]\n" +
+            "\n" +
+            "[\n" +
+            "        // missing 'f'\n" +
+            "┌─────▷\n" +
+            "│ ┌───▷\n" +
+            "│ │ ┌─▷\n" +
+            "│ │ │   'a',\n" +
+            "│ │ │   'b',\n" +
+            "└─│─│── 'c', // should be moved\n" +
+            "  └─│── 'd', // should be moved\n" +
+            "    └── 'e', // should be moved\n" +
+            "        'f' // should be removed\n" +
+            "]"
+        );
+    });
+
     it('should render multiple moved items with arrows', function () {
         expect(function () {
             expect(['a', 'b', 'c', 'd'], 'to equal', ['d', 'b', 'a', 'c']);

--- a/test/types/array-like-type.spec.js
+++ b/test/types/array-like-type.spec.js
@@ -190,4 +190,55 @@ describe('array-like type', function () {
     it('should inspect as [...] at depth 2+', function () {
         expect([[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]]], 'to inspect as', '[ [ [...] ] ]');
     });
+
+    it('should a moved item with an arrow', function () {
+        expect(function () {
+            expect(['a', 'b', 'c'], 'to equal', ['c', 'a', 'b']);
+        }, 'to error with',
+            "expected [ 'a', 'b', 'c' ] to equal [ 'c', 'a', 'b' ]\n" +
+            "\n" +
+            "[\n" +
+            "┌─> \n" +
+            "│   'a',\n" +
+            "│   'b',\n" +
+            "└── 'c' // should be moved\n" +
+            "]"
+        );
+    });
+
+    it('should render multiple moved items with arrows', function () {
+        expect(function () {
+            expect(['a', 'b', 'c', 'd'], 'to equal', ['d', 'b', 'a', 'c']);
+        }, 'to error with',
+            "expected [ 'a', 'b', 'c', 'd' ] to equal [ 'd', 'b', 'a', 'c' ]\n" +
+            "\n" +
+            "[\n" +
+            "┌───> \n" +
+            "│ ┌─>\n" +
+            "│ │   'a',\n" +
+            "│ └── 'b', // should be moved\n" +
+            "│     'c',\n" +
+            "└──── 'd' // should be moved\n" +
+            "]"
+        );
+    });
+
+    it('should render 3 moved neighbor items', function () {
+        expect(function () {
+            expect(['a', 'b', 'c', 'd', 'e'], 'to equal', ['c', 'd', 'e', 'a', 'b']);
+        }, 'to error with',
+            "expected [ 'a', 'b', 'c', 'd', 'e' ] to equal [ 'c', 'd', 'e', 'a', 'b' ]\n" +
+            "\n" +
+            "[\n" +
+            "┌─────> \n" +
+            "│ ┌───>\n" +
+            "│ │ ┌─>\n" +
+            "│ │ │   'a',\n" +
+            "│ │ │   'b',\n" +
+            "└─│─│── 'c', // should be moved\n" +
+            "  └─│── 'd', // should be moved\n" +
+            "    └── 'e' // should be moved\n" +
+            "]"
+        );
+    });
 });

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -474,27 +474,34 @@ describe('unexpected', function () {
             it('handles complicated similarities', function () {
                 expect(function () {
                     expect([4, 3, 1, 2], 'to equal', [1, 2, 3, 4]);
-                }, 'to throw', 'expected [ 4, 3, 1, 2 ] to equal [ 1, 2, 3, 4 ]\n' +
-                       '\n' +
-                       '[\n' +
-                       "  4, // should equal 1\n" +
-                       "  3, // should equal 2\n" +
-                       "  1, // should equal 3\n" +
-                       "  2 // should equal 4\n" +
-                       ']'
-                      );
+                }, 'to throw',
+                       "expected [ 4, 3, 1, 2 ] to equal [ 1, 2, 3, 4 ]\n" +
+                       "\n" +
+                       "[\n" +
+                       "┌─────> \n" +
+                       "│ ┌───>\n" +
+                       "│ │ ┌─>\n" +
+                       "│ │ │   4,\n" +
+                       "│ │ └── 3, // should be moved\n" +
+                       "└─│──── 1, // should be moved\n" +
+                       "  └──── 2 // should be moved\n" +
+                       "]"
+                );
 
                 expect(function () {
                     expect([4, 1, 2, 3], 'to equal', [1, 2, 3, 4]);
                 }, 'to throw', 'expected [ 4, 1, 2, 3 ] to equal [ 1, 2, 3, 4 ]\n' +
-                       '\n' +
-                       '[\n' +
-                       "  4, // should equal 1\n" +
-                       "  1, // should equal 2\n" +
-                       "  2, // should equal 3\n" +
-                       "  3 // should equal 4\n" +
-                       ']'
-                      );
+                       "\n" +
+                       "[\n" +
+                       "┌─────> \n" +
+                       "│ ┌───>\n" +
+                       "│ │ ┌─>\n" +
+                       "│ │ │   4,\n" +
+                       "└─│─│── 1, // should be moved\n" +
+                       "  └─│── 2, // should be moved\n" +
+                       "    └── 3 // should be moved\n" +
+                       "]"
+                );
 
                 expect(function () {
                     expect([1, 2, 3, 0], 'to equal', [0, 1, 2, 3]);
@@ -502,24 +509,26 @@ describe('unexpected', function () {
                        "expected [ 1, 2, 3, 0 ] to equal [ 0, 1, 2, 3 ]\n" +
                        "\n" +
                        "[\n" +
-                       "  // missing 0\n" +
-                       "  1,\n" +
-                       "  2,\n" +
-                       "  3,\n" +
-                       "  0 // should be removed\n" +
+                       "┌─> \n" +
+                       "│   1,\n" +
+                       "│   2,\n" +
+                       "│   3,\n" +
+                       "└── 0 // should be moved\n" +
                        "]");
 
                 expect(function () {
                     expect([4, 3, 1, 2], 'to equal', [3, 4]);
-                }, 'to throw', 'expected [ 4, 3, 1, 2 ] to equal [ 3, 4 ]\n' +
-                       '\n' +
-                       '[\n' +
-                       '  4, // should equal 3\n' +
-                       '  3, // should equal 4\n' +
-                       '  1, // should be removed\n' +
-                       '  2 // should be removed\n' +
-                       ']'
-                      );
+                }, 'to throw',
+                        "expected [ 4, 3, 1, 2 ] to equal [ 3, 4 ]\n" +
+                        "\n" +
+                        '[\n' +
+                        "┌─> \n" +
+                        "│   4,\n" +
+                        "└── 3, // should be moved\n" +
+                        "    1, // should be removed\n" +
+                        "    2 // should be removed\n" +
+                        "]"
+                );
             });
 
 
@@ -586,17 +595,18 @@ describe('unexpected', function () {
                        "expected [ 'twoo', 1, 3, 4, 5 ] to equal [ 0, 1, 'two', 3, 4, 5 ]\n" +
                        "\n" +
                        "[\n" +
-                       "  // missing 0\n" +
-                       "  // missing 1\n" +
-                       "  'twoo', // should equal 'two'\n" +
-                       "          //\n" +
-                       "          // -twoo\n" +
-                       "          // +two\n" +
-                       "  1, // should be removed\n" +
-                       "  3,\n" +
-                       "  4,\n" +
-                       "  5\n" +
-                       "]");
+                       "    // missing 0\n" +
+                       "┌─>\n" +
+                       "│   'twoo', // should equal 'two'\n" +
+                       "│           //\n" +
+                       "│           // -twoo\n" +
+                       "│           // +two\n" +
+                       "└── 1, // should be moved\n" +
+                       "    3,\n" +
+                       "    4,\n" +
+                       "    5\n" +
+                       "]"
+                );
             });
 
             it('does not consider different strings candidates for diffing', function () {

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -478,7 +478,7 @@ describe('unexpected', function () {
                        "expected [ 4, 3, 1, 2 ] to equal [ 1, 2, 3, 4 ]\n" +
                        "\n" +
                        "[\n" +
-                       "┌─────▷ \n" +
+                       "┌─────▷\n" +
                        "│ ┌───▷\n" +
                        "│ │ ┌─▷\n" +
                        "│ │ │   4,\n" +
@@ -493,7 +493,7 @@ describe('unexpected', function () {
                 }, 'to throw', 'expected [ 4, 1, 2, 3 ] to equal [ 1, 2, 3, 4 ]\n' +
                        "\n" +
                        "[\n" +
-                       "┌─────▷ \n" +
+                       "┌─────▷\n" +
                        "│ ┌───▷\n" +
                        "│ │ ┌─▷\n" +
                        "│ │ │   4,\n" +
@@ -509,7 +509,7 @@ describe('unexpected', function () {
                        "expected [ 1, 2, 3, 0 ] to equal [ 0, 1, 2, 3 ]\n" +
                        "\n" +
                        "[\n" +
-                       "┌─▷ \n" +
+                       "┌─▷\n" +
                        "│   1,\n" +
                        "│   2,\n" +
                        "│   3,\n" +
@@ -522,7 +522,7 @@ describe('unexpected', function () {
                         "expected [ 4, 3, 1, 2 ] to equal [ 3, 4 ]\n" +
                         "\n" +
                         '[\n' +
-                        "┌─▷ \n" +
+                        "┌─▷\n" +
                         "│   4,\n" +
                         "└── 3, // should be moved\n" +
                         "    1, // should be removed\n" +

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -478,9 +478,9 @@ describe('unexpected', function () {
                        "expected [ 4, 3, 1, 2 ] to equal [ 1, 2, 3, 4 ]\n" +
                        "\n" +
                        "[\n" +
-                       "┌─────> \n" +
-                       "│ ┌───>\n" +
-                       "│ │ ┌─>\n" +
+                       "┌─────▷ \n" +
+                       "│ ┌───▷\n" +
+                       "│ │ ┌─▷\n" +
                        "│ │ │   4,\n" +
                        "│ │ └── 3, // should be moved\n" +
                        "└─│──── 1, // should be moved\n" +
@@ -493,9 +493,9 @@ describe('unexpected', function () {
                 }, 'to throw', 'expected [ 4, 1, 2, 3 ] to equal [ 1, 2, 3, 4 ]\n' +
                        "\n" +
                        "[\n" +
-                       "┌─────> \n" +
-                       "│ ┌───>\n" +
-                       "│ │ ┌─>\n" +
+                       "┌─────▷ \n" +
+                       "│ ┌───▷\n" +
+                       "│ │ ┌─▷\n" +
                        "│ │ │   4,\n" +
                        "└─│─│── 1, // should be moved\n" +
                        "  └─│── 2, // should be moved\n" +
@@ -509,7 +509,7 @@ describe('unexpected', function () {
                        "expected [ 1, 2, 3, 0 ] to equal [ 0, 1, 2, 3 ]\n" +
                        "\n" +
                        "[\n" +
-                       "┌─> \n" +
+                       "┌─▷ \n" +
                        "│   1,\n" +
                        "│   2,\n" +
                        "│   3,\n" +
@@ -522,7 +522,7 @@ describe('unexpected', function () {
                         "expected [ 4, 3, 1, 2 ] to equal [ 3, 4 ]\n" +
                         "\n" +
                         '[\n' +
-                        "┌─> \n" +
+                        "┌─▷ \n" +
                         "│   4,\n" +
                         "└── 3, // should be moved\n" +
                         "    1, // should be removed\n" +
@@ -596,7 +596,7 @@ describe('unexpected', function () {
                        "\n" +
                        "[\n" +
                        "    // missing 0\n" +
-                       "┌─>\n" +
+                       "┌─▷\n" +
                        "│   'twoo', // should equal 'two'\n" +
                        "│           //\n" +
                        "│           // -twoo\n" +


### PR DESCRIPTION
Affects the array-like diff and the `<array-like> to [exhaustively] satisfy <array-like>` assertion.

Here's what it'll look like in unexpected-sinon: https://github.com/unexpectedjs/unexpected-sinon/compare/feature/arrayMoves

And unexpected-dom: https://github.com/papandreou/unexpected-dom/commit/11b71990aaeef10a3de28f50b6c65963dc4d9bb7 (only one of the existing tests seemed to contain a move)