### PR TITLE
Add <object|array-like> to have (a value|an item) satisfying <any|assertion>

### DIFF
--- a/documentation/assertions/array-like/to-have-an-item-satisfying.md
+++ b/documentation/assertions/array-like/to-have-an-item-satisfying.md
@@ -1,0 +1,75 @@
+Asserts an array (or array-like object) contains at least one item that satisfies
+a given value, function or other assertion.
+
+Note that this assertion fails if passed an empty array as the subject.
+
+```javascript
+expect([ { a: 1 },  { b: 2 } ], 'to have an item satisfying',  { a: 1 } );
+
+expect([0, 1, 2, 3, 4], 'to have an item satisfying', 'to be a number');
+
+expect([0, 1, 2, 3, 4], 'to have an item satisfying', function (item, index) {
+    expect(item, 'to be a number');
+});
+
+expect(
+    [[1], ['foo']],
+    'to have an item satisfying',
+    'to have an item satisfying',
+    'to be a number'
+);
+
+expect(
+    [-1, -2, 3],
+    'to have an item satisfying',
+    expect.it('to be a number').and('to be positive')
+);
+```
+
+The expected value will be matched against the value with
+[to satisfy](/assertions/any/to-satisfy/) semantics, so you can pass any of the
+values supported by `to satisfy`. To use strict `to satisfy` semantics, you can
+use the "exhaustively" flag:
+
+```javascript
+expect([ { a: 1, b: 2 } ], 'to have a value satisfying', { a: 1 });
+```
+
+```javascript
+expect([ { a: 1, b: 2 } ], 'to have a value exhaustively satisfying', { a: 1 });
+```
+
+```output
+expected [ { a: 1, b: 2 } ] to have a value exhaustively satisfying { a: 1 }
+```
+
+In case of a failing expectation you get the following output:
+
+```javascript
+expect(
+    [ ['0', '1'], ['5', '6'], ['7', '8'] ],
+    'to have an item satisfying',
+    'to have an item satisfying',
+    'to be a number'
+);
+```
+
+```output
+expected array to have an item satisfying to have an item satisfying to be a number
+```
+
+Here a another example:
+
+```javascript
+expect(
+    [0, -1, -2, -3, -4],
+    'to have an item satisfying',
+    expect.it('to be a number').and('to be positive')
+);
+```
+
+```output
+expected [ 0, -1, -2, -3, -4 ] to have an item satisfying
+expect.it('to be a number')
+        .and('to be positive')
+```

--- a/documentation/assertions/object/to-have-a-value-satisfying.md
+++ b/documentation/assertions/object/to-have-a-value-satisfying.md
@@ -1,0 +1,60 @@
+Asserts that an object contains at least one value that satisfies a given
+value, function or other assertion.
+
+Note that this assertion fails if passed an empty object as the subject.
+
+```javascript
+expect(
+    { foo: { a: 1 }, bar: { b: 2 }, baz: { c: 3 }, qux: { d: 4} },
+    'to have a value satisfying',
+    { a: 1 }
+);
+
+expect(
+    { foo: 0, bar: 1, baz: 2, qux: 3 },
+    'to have a value satisfying',
+    function (value, index) {
+        expect(value, 'to be a number');
+    }
+);
+
+expect(
+    { foo: 0, bar: 1, baz: 2, qux: 3 },
+    'to have a value satisfying',
+    'to be a number'
+);
+```
+
+The expected value will be matched against the value with
+[to satisfy](/assertions/any/to-satisfy/) semantics, so you can pass any of the
+values supported by `to satisfy`. To use strict `to satisfy` semantics, you can
+use the "exhaustively" flag:
+
+```javascript
+expect({ foo: { a: 1, b: 2 } }, 'to have a value satisfying', { a: 1 });
+```
+
+```javascript
+expect({ foo: { a: 1, b: 2 } }, 'to have a value exhaustively satisfying', { a: 1 });
+```
+
+```output
+expected { foo: { a: 1, b: 2 } } to have a value exhaustively satisfying { a: 1 }
+```
+
+In case of a failing expectation you get the following output:
+
+```javascript
+expect(
+    { foo: [10, 11, 12], bar: [14, 15, 16], baz: [17, 18, 19] },
+    'to have a value satisfying',
+    'to have items satisfying',
+    expect.it('to be a number').and('to be below', 8)
+);
+```
+
+```output
+expected object to have a value satisfying
+to have items satisfying expect.it('to be a number')
+        .and('to be below', 8)
+```

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -771,7 +771,6 @@ module.exports = function (expect) {
         '<object> to be (a map|a hash|an object) whose (keys|properties) satisfy <any>',
         '<object> to be (a map|a hash|an object) whose (keys|properties) satisfy <assertion>'
     ], function (expect, subject) {
-        var extraArgs = Array.prototype.slice.call(arguments, 2);
         expect.errorMode = 'nested';
         if (expect.subjectType.is('array')) {
             expect(subject, 'not to equal', []);
@@ -781,6 +780,7 @@ module.exports = function (expect) {
         expect.errorMode = 'default';
 
         var keys = expect.subjectType.getKeys(subject);
+        var extraArgs = Array.prototype.slice.call(arguments, 2);
         return expect.apply(expect, [keys, 'to have items satisfying'].concat(extraArgs));
     });
 
@@ -811,6 +811,24 @@ module.exports = function (expect) {
             });
         })).catch(function (e) {
             return expect.fail(function (output) {
+                output.append(expect.standardErrorMessage(output.clone(), { compact: true }));
+            });
+        });
+    });
+
+    expect.addAssertion([
+        '<array-like> to have an item [exhaustively] satisfying <any>',
+        '<array-like> to have an item [exhaustively] satisfying <assertion>'
+    ], function (expect, subject) { // ...
+        expect.errorMode = 'nested';
+        expect(subject, 'to be non-empty');
+        expect.errorMode = 'bubble';
+
+        var extraArgs = Array.prototype.slice.call(arguments, 2);
+        return expect.withError(function () {
+            return expect.apply(expect, [subject, 'to have a value [exhaustively] satisfying'].concat(extraArgs));
+        }, function (err) {
+            expect.fail(function (output) {
                 output.append(expect.standardErrorMessage(output.clone(), { compact: true }));
             });
         });

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -784,6 +784,38 @@ module.exports = function (expect) {
         return expect.apply(expect, [keys, 'to have items satisfying'].concat(extraArgs));
     });
 
+    expect.addAssertion([
+        '<object> to have a value [exhaustively] satisfying <any>',
+        '<object> to have a value [exhaustively] satisfying <assertion>'
+    ], function (expect, subject, nextArg) {
+        expect.errorMode = 'nested';
+        expect(subject, 'not to equal', {});
+        expect.errorMode = 'bubble';
+
+        var keys = expect.subjectType.getKeys(subject);
+        return expect.promise.any(keys.map(function (key, index) {
+            var expected;
+            if (typeof nextArg === 'string') {
+                expected = function (s) {
+                    return expect.shift(s);
+                };
+            } else if (typeof nextArg === 'function') {
+                expected = function (s) {
+                    return nextArg(s, index);
+                };
+            } else {
+                expected = nextArg;
+            }
+            return expect.promise(function () {
+                return expect(subject[key], 'to [exhaustively] satisfy', expected);
+            });
+        })).catch(function (e) {
+            return expect.fail(function (output) {
+                output.append(expect.standardErrorMessage(output.clone(), { compact: true }));
+            });
+        });
+    });
+
     expect.addAssertion('<object> to be canonical', function (expect, subject) {
         var stack = [];
 

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -789,7 +789,11 @@ module.exports = function (expect) {
         '<object> to have a value [exhaustively] satisfying <assertion>'
     ], function (expect, subject, nextArg) {
         expect.errorMode = 'nested';
-        expect(subject, 'not to equal', {});
+        if (expect.subjectType.is('array-like')) {
+            expect(subject, 'to be non-empty');
+        } else {
+            expect(subject, 'not to equal', {});
+        }
         expect.errorMode = 'bubble';
 
         var keys = expect.subjectType.getKeys(subject);

--- a/test/assertions/to-have-a-value-satisfying.spec.js
+++ b/test/assertions/to-have-a-value-satisfying.spec.js
@@ -50,7 +50,7 @@ describe('to have a value satisfying assertion', function () {
                 expect({}, 'to have a value satisfying', 'to be a number');
             },
             'to throw',
-            "expected {} to have a value satisfying 'to be a number'\n" +
+            "expected {} to have a value satisfying to be a number\n" +
             "  expected {} not to equal {}"
         );
     });
@@ -61,7 +61,7 @@ describe('to have a value satisfying assertion', function () {
                 expect([], 'to have a value satisfying', 'to be a number');
             },
             'to throw',
-            "expected [] to have a value satisfying 'to be a number'\n" +
+            "expected [] to have a value satisfying to be a number\n" +
             "  expected [] to be non-empty"
         );
     });

--- a/test/assertions/to-have-a-value-satisfying.spec.js
+++ b/test/assertions/to-have-a-value-satisfying.spec.js
@@ -1,0 +1,125 @@
+/*global expect*/
+describe('to have a value satisfying assertion', function () {
+    it('requires a third argument', function () {
+        expect(
+            function () {
+                expect([1, 2, 3], 'to have a value satisfying');
+            },
+            'to throw',
+            "expected [ 1, 2, 3 ] to have a value satisfying\n" +
+            "  No matching assertion, did you mean:\n" +
+            "  <object> to have a value [exhaustively] satisfying <any>\n" +
+            "  <object> to have a value [exhaustively] satisfying <assertion>"
+        );
+    });
+
+    it('accepts objects as the subject', function () {
+        expect(
+            function () {
+                expect({ foo: 1 }, 'to have a value satisfying', 'to be a number');
+            },
+            'not to throw'
+        );
+    });
+
+    it('accepts arrays as the subject', function () {
+        expect(
+            function () {
+                expect([ 1 ], 'to have a value satisfying', 'to be a number');
+            },
+            'not to throw'
+        );
+    });
+
+    it('only accepts objects and arrays as the subject', function () {
+        expect(
+            function () {
+                expect(42, 'to have a value satisfying', function (value) {});
+            },
+            'to throw',
+            "expected 42 to have a value satisfying function (value) {}\n" +
+            "  No matching assertion, did you mean:\n" +
+            "  <object> to have a value [exhaustively] satisfying <any>\n" +
+            "  <object> to have a value [exhaustively] satisfying <assertion>"
+        );
+    });
+
+    it('fails if the given object is empty', function () {
+        expect(
+            function () {
+                expect({}, 'to have a value satisfying', 'to be a number');
+            },
+            'to throw',
+            "expected {} to have a value satisfying 'to be a number'\n" +
+            "  expected {} not to equal {}"
+        );
+    });
+
+    it('fails if the given array is empty', function () {
+        expect(
+            function () {
+                expect([], 'to have a value satisfying', 'to be a number');
+            },
+            'to throw',
+            "expected [] to have a value satisfying 'to be a number'\n" +
+            "  expected [] to be non-empty"
+        );
+    });
+
+    it('asserts that at least one value in the object satisfies the RHS expectation', function () {
+        expect({ foo: 0, bar: 1, baz: 2, qux: 3 }, 'to have a value satisfying', 'to be a number');
+
+        expect({ foo: '0', bar: 1 }, 'to have a value satisfying', function (value) {
+            expect(value, 'to be a number');
+        });
+
+        expect({ foo: 0, bar: 'bar' }, 'to have a value satisfying', 'not to be a number');
+
+        expect({ foo: { foo: 0 }, bar: { bar: 1 } }, 'to have a value satisfying', 'to have a value satisfying', 'to be a number');
+    });
+
+    it('throws the correct error if none of the subject\'s values match the RHS expectation', function () {
+        expect(
+            function () {
+                expect({ foo: 'foo', bar: 'bar' }, 'to have a value satisfying', expect.it('to be a number'));
+            },
+            'to throw',
+            "expected { foo: 'foo', bar: 'bar' }\n" +
+            "to have a value satisfying expect.it('to be a number')"
+        );
+    });
+
+    describe('delegating to an async assertion', function () {
+        var clonedExpect = expect.clone()
+            .addAssertion('to be a number after a short delay', function (expect, subject, delay) {
+                expect.errorMode = 'nested';
+
+                return expect.promise(function (run) {
+                    setTimeout(run(function () {
+                        expect(subject, 'to be a number');
+                    }), 1);
+                });
+            });
+
+        it('should succeed', function () {
+            return clonedExpect({0: 1, 1: 2, 2: 3}, 'to have a value satisfying', 'to be a number after a short delay');
+        });
+    });
+
+    describe('with the exhaustively flag', function () {
+        it('should succeed', function () {
+            expect([{foo: 'bar', quux: 'baz'}], 'to have a value exhaustively satisfying', {foo: 'bar', quux: 'baz'});
+        });
+
+        it('should fail when the spec is not met only because of the "exhaustively" semantics', function () {
+            expect(
+                function () {
+                    expect([{foo: 'bar', quux: 'baz'}], 'to have a value exhaustively satisfying', {foo: 'bar'});
+                },
+                'to throw',
+                "expected [ { foo: 'bar', quux: 'baz' } ]\n" +
+                "to have a value exhaustively satisfying { foo: 'bar' }"
+            );
+        });
+    });
+});

--- a/test/assertions/to-have-an-item-satisfying.spec.js
+++ b/test/assertions/to-have-an-item-satisfying.spec.js
@@ -30,7 +30,7 @@ describe('to have an item satisfying assertion', function () {
                 expect([], 'to have an item satisfying', 'to be a number');
             },
             'to throw',
-            "expected [] to have an item satisfying 'to be a number'\n" +
+            "expected [] to have an item satisfying to be a number\n" +
             "  expected [] to be non-empty");
     });
 

--- a/test/assertions/to-have-an-item-satisfying.spec.js
+++ b/test/assertions/to-have-an-item-satisfying.spec.js
@@ -1,0 +1,122 @@
+/*global expect*/
+describe('to have an item satisfying assertion', function () {
+    it('requires a third argument', function () {
+        expect(
+            function () {
+                expect([1, 2, 3], 'to have an item satisfying');
+            },
+            'to throw',
+            "expected [ 1, 2, 3 ] to have an item satisfying\n" +
+            "  No matching assertion, did you mean:\n" +
+            "  <array-like> to have an item [exhaustively] satisfying <any>\n" +
+            "  <array-like> to have an item [exhaustively] satisfying <assertion>");
+    });
+
+    it('only accepts arrays as the subject', function () {
+        expect(
+            function () {
+                expect(42, 'to have an item satisfying', 'to be a number');
+            },
+            'to throw',
+            "expected 42 to have an item satisfying 'to be a number'\n" +
+            "  No matching assertion, did you mean:\n" +
+            "  <array-like> to have an item [exhaustively] satisfying <any>\n" +
+            "  <array-like> to have an item [exhaustively] satisfying <assertion>");
+    });
+
+    it('fails if the given array is empty', function () {
+        expect(
+            function () {
+                expect([], 'to have an item satisfying', 'to be a number');
+            },
+            'to throw',
+            "expected [] to have an item satisfying 'to be a number'\n" +
+            "  expected [] to be non-empty");
+    });
+
+    it('asserts that at least one item in the array satisfies the RHS expectation', function () {
+        expect(['foo', 1], 'to have an item satisfying', 'to be a number');
+
+        expect(['foo', 1], 'to have an item satisfying', function (item) {
+            expect(item, 'to be a number');
+        });
+
+        expect([0, 1, 'foo', 2], 'to have an item satisfying', 'not to be a number');
+
+        expect([[1], [2]], 'to have an item satisfying', 'to have an item satisfying', 'to be a number');
+    });
+
+    it('throws the correct error if none of the subject\'s values match the RHS expectation', function () {
+        expect(
+            function () {
+                expect(['foo', 'bar'], 'to have an item satisfying', expect.it('to be a number'));
+            },
+            'to throw',
+            "expected [ 'foo', 'bar' ] to have an item satisfying expect.it('to be a number')"
+        );
+    });
+
+    it('formats non-Unexpected errors correctly', function () {
+        expect(
+            function () {
+                expect(
+                    [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]],
+                    'to have an item satisfying',
+                    function (item) {
+                        expect.fail(function (output) {
+                            output.text('foo').nl().text('bar');
+                        });
+                    });
+            },
+            'to throw',
+            "expected array to have an item satisfying\n" +
+            "function (item) {\n" +
+            "  expect.fail(function (output) {\n" +
+            "    output.text('foo').nl().text('bar');\n" +
+            "  });\n" +
+            "}"
+        );
+    });
+
+    it('provides the item index to the callback function', function () {
+        var arr = ['0', '1', '2', '3'];
+        expect(arr, 'to have an item satisfying', function (item, index) {
+            expect(index, 'to be a number');
+            expect(index, 'to be', parseInt(item, 10));
+        });
+    });
+
+    describe('delegating to an async assertion', function () {
+        var clonedExpect = expect.clone()
+            .addAssertion('to be a number after a short delay', function (expect, subject, delay) {
+                expect.errorMode = 'nested';
+
+                return expect.promise(function (run) {
+                    setTimeout(run(function () {
+                        expect(subject, 'to be a number');
+                    }), 1);
+                });
+            });
+
+        it('should succeed', function () {
+            return clonedExpect([1, 2, 3], 'to have an item satisfying', 'to be a number after a short delay');
+        });
+    });
+
+    describe('with the exhaustively flag', function () {
+        it('should succeed', function () {
+            expect([{foo: 'bar', quux: 'baz'}], 'to have an item exhaustively satisfying', {foo: 'bar', quux: 'baz'});
+        });
+
+        it('should fail when the spec is not met only because of the "exhaustively" semantics', function () {
+            expect(
+                function () {
+                    expect([{foo: 'bar', quux: 'baz'}], 'to have an item exhaustively satisfying', {foo: 'bar'});
+                },
+                'to throw',
+                "expected [ { foo: 'bar', quux: 'baz' } ]\n" +
+                "to have an item exhaustively satisfying { foo: 'bar' }"
+            );
+        });
+    });
+});


### PR DESCRIPTION
Use cases:
- `<spy> to have a call satisfying ...`: http://unexpected.js.org/unexpected-sinon/assertions/spy/to-have-a-call-satisfying/
- `<knexQuery> to have a row satisfying ...`: https://github.com/unexpectedjs/unexpected-knex/blob/9b691beb5025a18fb0abd773716d159f471f2c30/lib/unexpected-knex.js#L141

Discussion points:
- do we need a diff for this assertion? the problem being that the diffing code would have to find an item (or value in the case of objects) within the array that has the closest match to the expected value and diff against it. Otherwise it would have to diff against every item, which would look like the last example [here](http://unexpected.js.org/unexpected-sinon/assertions/spy/to-have-a-call-satisfying/)
- do we need to support the legacy "to be an array containing an item satisfying" / "to be an object containing a value satisfying" assertions?
- the implementation :)
- others?

TODOs:
- [x] Update tests (currently ripped off from "to have items satisfying" :see_no_evil:)
- [x] Add documentation
