### PR TITLE
to have keys satisfying, to have values satisfying: Disallow an empty array

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -700,7 +700,11 @@ module.exports = function (expect) {
         '<object> to be (a map|a hash|an object) whose values [exhaustively] satisfy <assertion>'
     ], function (expect, subject, nextArg) {
         expect.errorMode = 'nested';
-        expect(subject, 'not to equal', {});
+        if (expect.subjectType.is('array')) {
+            expect(subject, 'not to equal', []);
+        } else {
+            expect(subject, 'not to equal', {});
+        }
         expect.errorMode = 'bubble';
 
         var keys = expect.subjectType.getKeys(subject);
@@ -769,8 +773,11 @@ module.exports = function (expect) {
     ], function (expect, subject) {
         var extraArgs = Array.prototype.slice.call(arguments, 2);
         expect.errorMode = 'nested';
-        expect(subject, 'to be an object');
-        expect(subject, 'not to equal', {});
+        if (expect.subjectType.is('array')) {
+            expect(subject, 'not to equal', []);
+        } else {
+            expect(subject, 'not to equal', {});
+        }
         expect.errorMode = 'default';
 
         var keys = expect.subjectType.getKeys(subject);

--- a/test/assertions/to-have-keys-satisfying.spec.js
+++ b/test/assertions/to-have-keys-satisfying.spec.js
@@ -53,6 +53,14 @@ describe('to have keys satisfying assertion', function () {
                "  expected {} not to equal {}");
     });
 
+    it('fails for an empty array', function () {
+        expect(function () {
+            expect([], 'to have keys satisfying', 123);
+        }, 'to throw',
+            "expected [] to have keys satisfying 123\n" +
+            "  expected [] not to equal []");
+    });
+
     it('should work with non-enumerable keys returned by the getKeys function of the subject type', function () {
         expect(function () {
             expect(new Error('foo'), 'to have keys satisfying', /bar/);

--- a/test/assertions/to-have-values-satisfying.spec.js
+++ b/test/assertions/to-have-values-satisfying.spec.js
@@ -47,6 +47,14 @@ describe('to have values satisfying assertion', function () {
                "  expected {} not to equal {}");
     });
 
+    it('fails for an empty array', function () {
+        expect(function () {
+            expect([], 'to have values satisfying', 123);
+        }, 'to throw',
+            "expected [] to have values satisfying 123\n" +
+            "  expected [] not to equal []");
+    });
+
     it('fails if the given array is empty', function () {
         expect(function () {
             expect([], 'to have items satisfying', function (item) {


### PR DESCRIPTION
(like we disallow empty objects)