### PR TITLE
Normalized line breaks in test output.

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -760,7 +760,7 @@ module.exports = function (expect) {
             return a === b;
         },
         inspect: function (f, depth, output, inspect) {
-            var source = f.toString();
+            var source = f.toString().replace(/\r\n?|\n\r?/g, '\n');
             var name = utils.getFunctionName(f) || '';
             var args;
             var body;


### PR DESCRIPTION
Function type on Windows would use `\r\n` line breaks.