### PR TITLE
to throw a/an

### DIFF
--- a/documentation/assertions/function/to-throw-a.md
+++ b/documentation/assertions/function/to-throw-a.md
@@ -32,4 +32,6 @@ expect(willNotThrow, 'to throw a', RangeError);
 
 ```output
 expected function willNotThrow() {} to throw a RangeError
+  expected function willNotThrow() {} to throw
+    did not throw
 ```

--- a/documentation/assertions/function/to-throw-a.md
+++ b/documentation/assertions/function/to-throw-a.md
@@ -1,0 +1,35 @@
+Asserts that the function throws an instance of a specific constructor.
+
+```javascript
+function willThrow() {
+  throw new SyntaxError('The error message');
+}
+expect(willThrow, 'to throw a', SyntaxError);
+```
+
+In case of a failing expectation you get the following output:
+
+```javascript
+expect(willThrow, 'to throw a', RangeError);
+```
+
+```output
+expected
+function willThrow() {
+  throw new SyntaxError('The error message');
+}
+to throw a RangeError
+  expected SyntaxError('The error message') to be a RangeError
+```
+
+The assertion also fails if the function doesn't throw at all:
+
+```javascript
+function willNotThrow() {}
+
+expect(willNotThrow, 'to throw a', RangeError);
+```
+
+```output
+expected function willNotThrow() {} to throw a RangeError
+```

--- a/documentation/assertions/function/to-throw.md
+++ b/documentation/assertions/function/to-throw.md
@@ -17,6 +17,7 @@ expect(function willNotThrow() {}, 'to throw');
 
 ```output
 expected function willNotThrow() {} to throw
+  did not throw
 ```
 
 You can assert the error message is a given string if you provide a

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -667,7 +667,8 @@ module.exports = function (expect) {
         } catch (e) {
             return e;
         }
-        expect.fail();
+        expect.errorMode = 'nested';
+        expect.fail('did not throw');
     });
 
     expect.addAssertion('<function> to (throw|throw error|throw exception) <any>', function (expect, subject, arg) {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -671,6 +671,19 @@ module.exports = function (expect) {
         expect.fail('did not throw');
     });
 
+    expect.addAssertion('<function> to throw (a|an) <function>', function (expect, subject, value) {
+        var constructorName = utils.getFunctionName(value);
+        if (constructorName) {
+            expect.argsOutput[0] = function (output) {
+                output.jsFunctionName(constructorName);
+            };
+        }
+        return expect(subject, 'to throw').then(function (error) {
+            expect.errorMode = 'nested';
+            expect(error, 'to be a', value);
+        });
+    });
+
     expect.addAssertion('<function> to (throw|throw error|throw exception) <any>', function (expect, subject, arg) {
         return expect(subject, 'to throw').then(function (error) {
             var isUnexpected = error && error._isUnexpected;

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -678,13 +678,14 @@ module.exports = function (expect) {
                 output.jsFunctionName(constructorName);
             };
         }
+        expect.errorMode = 'nested';
         return expect(subject, 'to throw').then(function (error) {
-            expect.errorMode = 'nested';
             expect(error, 'to be a', value);
         });
     });
 
     expect.addAssertion('<function> to (throw|throw error|throw exception) <any>', function (expect, subject, arg) {
+        expect.errorMode = 'nested';
         return expect(subject, 'to throw').then(function (error) {
             var isUnexpected = error && error._isUnexpected;
             // in the presence of a matcher an error must have been thrown.

--- a/test/assertions/to-throw-a.spec.js
+++ b/test/assertions/to-throw-a.spec.js
@@ -1,0 +1,59 @@
+/*global expect*/
+describe('to throw a/an assertion', function () {
+    it('fails if no exception is thrown', function () {
+        expect(function () {
+            expect(function () {
+                // Don't throw
+            }, 'to throw an', Error);
+        }, 'to throw', function (err) {
+            var message = err.getErrorMessage({ format: 'text' }).toString();
+            // PhantomJS adds a semicolon after the comment
+            message = message.replace(';', '');
+            expect(message, 'to equal',
+                   'expected\n' +
+                   'function () {\n' +
+                   '  // Don\'t throw\n' +
+                   '}\n' +
+                   'to throw an Error');
+        });
+    });
+
+    it('succeeds if the function throws an instance of the supplied constructor function', function () {
+        expect(function () {
+            throw new SyntaxError();
+        }, 'to throw a', SyntaxError);
+    });
+
+    it('fails if the function throws an instance of a different constructor', function () {
+        expect(function () {
+            expect(function () {
+                throw new SyntaxError('foo');
+            }, 'to throw a', RangeError);
+        }, 'to throw',
+            "expected function () { throw new SyntaxError('foo'); } to throw a RangeError\n" +
+            "  expected SyntaxError('foo') to be a RangeError"
+        );
+    });
+
+    it('fails with a proper error if the function throws null', function () {
+        expect(function () {
+            expect(function () {
+                throw null;
+            }, 'to throw a', RangeError);
+        }, 'to throw',
+            'expected function () { throw null; } to throw a RangeError\n' +
+            '  expected null to be a RangeError'
+        );
+    });
+
+    it('fails with a proper error if the function throws an empty string', function () {
+        expect(function () {
+            expect(function () {
+                throw null;
+            }, 'to throw a', RangeError);
+        }, 'to throw',
+            'expected function () { throw null; } to throw a RangeError\n' +
+            '  expected null to be a RangeError'
+        );
+    });
+});

--- a/test/assertions/to-throw-a.spec.js
+++ b/test/assertions/to-throw-a.spec.js
@@ -10,11 +10,14 @@ describe('to throw a/an assertion', function () {
             // PhantomJS adds a semicolon after the comment
             message = message.replace(';', '');
             expect(message, 'to equal',
-                   'expected\n' +
-                   'function () {\n' +
-                   '  // Don\'t throw\n' +
-                   '}\n' +
-                   'to throw an Error');
+                'expected\n' +
+                'function () {\n' +
+                '  // Don\'t throw\n' +
+                '}\n' +
+                'to throw an Error\n' +
+                '  expected function to throw\n' +
+                '    did not throw'
+            );
         });
     });
 

--- a/test/assertions/to-throw.spec.js
+++ b/test/assertions/to-throw.spec.js
@@ -10,11 +10,13 @@ describe('to throw assertion', function () {
             // PhantomJS adds a semicolon after the comment
             message = message.replace(';', '');
             expect(message, 'to equal',
-                   'expected\n' +
-                   'function () {\n' +
-                   '  // Don\'t throw\n' +
-                   '}\n' +
-                   'to throw exception');
+                'expected\n' +
+                'function () {\n' +
+                '  // Don\'t throw\n' +
+                '}\n' +
+                'to throw exception\n' +
+                '  did not throw'
+            );
         });
     });
 


### PR DESCRIPTION
Fixes #360.

Includes a bonus feature: This and the other `to throw...` assertions explicitly fail with "did not throw" when the function didn't throw at all.