### PR TITLE
Consistently use the 'not to be empty' assertion for objects and arrays

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -259,7 +259,7 @@ module.exports = function (expect) {
         expect(subject, '[not] to have length', 0);
     });
 
-    expect.addAssertion('<string|array-like> to be non-empty', function (expect, subject) {
+    expect.addAssertion('<string|array-like|object> to be non-empty', function (expect, subject) {
         expect(subject, 'not to be empty');
     });
 
@@ -700,11 +700,7 @@ module.exports = function (expect) {
         '<object> to be (a map|a hash|an object) whose values [exhaustively] satisfy <assertion>'
     ], function (expect, subject, nextArg) {
         expect.errorMode = 'nested';
-        if (expect.subjectType.is('array')) {
-            expect(subject, 'not to equal', []);
-        } else {
-            expect(subject, 'not to equal', {});
-        }
+        expect(subject, 'not to be empty');
         expect.errorMode = 'bubble';
 
         var keys = expect.subjectType.getKeys(subject);
@@ -746,7 +742,7 @@ module.exports = function (expect) {
     ], function (expect, subject) { // ...
         var extraArgs = Array.prototype.slice.call(arguments, 2);
         expect.errorMode = 'nested';
-        expect(subject, 'to be non-empty');
+        expect(subject, 'not to be empty');
         expect.errorMode = 'bubble';
 
         return expect.withError(function () {
@@ -772,11 +768,7 @@ module.exports = function (expect) {
         '<object> to be (a map|a hash|an object) whose (keys|properties) satisfy <assertion>'
     ], function (expect, subject) {
         expect.errorMode = 'nested';
-        if (expect.subjectType.is('array')) {
-            expect(subject, 'not to equal', []);
-        } else {
-            expect(subject, 'not to equal', {});
-        }
+        expect(subject, 'not to be empty');
         expect.errorMode = 'default';
 
         var keys = expect.subjectType.getKeys(subject);
@@ -789,11 +781,7 @@ module.exports = function (expect) {
         '<object> to have a value [exhaustively] satisfying <assertion>'
     ], function (expect, subject, nextArg) {
         expect.errorMode = 'nested';
-        if (expect.subjectType.is('array-like')) {
-            expect(subject, 'to be non-empty');
-        } else {
-            expect(subject, 'not to equal', {});
-        }
+        expect(subject, 'not to be empty');
         expect.errorMode = 'bubble';
 
         var keys = expect.subjectType.getKeys(subject);
@@ -825,7 +813,7 @@ module.exports = function (expect) {
         '<array-like> to have an item [exhaustively] satisfying <assertion>'
     ], function (expect, subject) { // ...
         expect.errorMode = 'nested';
-        expect(subject, 'to be non-empty');
+        expect(subject, 'not to be empty');
         expect.errorMode = 'bubble';
 
         var extraArgs = Array.prototype.slice.call(arguments, 2);

--- a/test/assertions/to-have-a-value-satisfying.spec.js
+++ b/test/assertions/to-have-a-value-satisfying.spec.js
@@ -55,7 +55,7 @@ describe('to have a value satisfying assertion', function () {
             },
             'to throw',
             "expected {} to have a value satisfying to be a number\n" +
-            "  expected {} not to equal {}"
+            "  expected {} not to be empty"
         );
     });
 
@@ -66,7 +66,7 @@ describe('to have a value satisfying assertion', function () {
             },
             'to throw',
             "expected [] to have a value satisfying to be a number\n" +
-            "  expected [] to be non-empty"
+            "  expected [] not to be empty"
         );
     });
 

--- a/test/assertions/to-have-an-item-satisfying.spec.js
+++ b/test/assertions/to-have-an-item-satisfying.spec.js
@@ -37,7 +37,7 @@ describe('to have an item satisfying assertion', function () {
             },
             'to throw',
             "expected [] to have an item satisfying to be a number\n" +
-            "  expected [] to be non-empty");
+            "  expected [] not to be empty");
     });
 
     it('asserts that at least one item in the array satisfies the RHS expectation', function () {

--- a/test/assertions/to-have-items-satisfying.spec.js
+++ b/test/assertions/to-have-items-satisfying.spec.js
@@ -49,7 +49,7 @@ describe('to have items satisfying assertion', function () {
                "function (item) {\n" +
                "  expect(item, 'to be a number');\n" +
                "}\n" +
-               "  expected [] to be non-empty");
+               "  expected [] not to be empty");
     });
 
     it('asserts that the given callback does not throw for any items in the array', function () {

--- a/test/assertions/to-have-keys-satisfying.spec.js
+++ b/test/assertions/to-have-keys-satisfying.spec.js
@@ -69,7 +69,7 @@ describe('to have keys satisfying assertion', function () {
                "function (key) {\n" +
                "  expect(key, 'to match', /^[a-z]{3}$/);\n" +
                "}\n" +
-               "  expected {} not to equal {}");
+               "  expected {} not to be empty");
     });
 
     it('fails for an empty array', function () {
@@ -77,7 +77,7 @@ describe('to have keys satisfying assertion', function () {
             expect([], 'to have keys satisfying', 123);
         }, 'to throw',
             "expected [] to have keys satisfying 123\n" +
-            "  expected [] not to equal []");
+            "  expected [] not to be empty");
     });
 
     it('should work with non-enumerable keys returned by the getKeys function of the subject type', function () {

--- a/test/assertions/to-have-values-satisfying.spec.js
+++ b/test/assertions/to-have-values-satisfying.spec.js
@@ -63,7 +63,7 @@ describe('to have values satisfying assertion', function () {
                "function (value) {\n" +
                "  expect(value, 'to equal', '0');\n" +
                "}\n" +
-               "  expected {} not to equal {}");
+               "  expected {} not to be empty");
     });
 
     it('fails for an empty array', function () {
@@ -71,7 +71,7 @@ describe('to have values satisfying assertion', function () {
             expect([], 'to have values satisfying', 123);
         }, 'to throw',
             "expected [] to have values satisfying 123\n" +
-            "  expected [] not to equal []");
+            "  expected [] not to be empty");
     });
 
     it('fails if the given array is empty', function () {
@@ -84,7 +84,7 @@ describe('to have values satisfying assertion', function () {
                "function (item) {\n" +
                "  expect(item, 'to be a number');\n" +
                "}\n" +
-               "  expected [] to be non-empty");
+               "  expected [] not to be empty");
     });
 
     it('supports legacy aliases', function () {


### PR DESCRIPTION
Produces a better error message than "not to equal []|{}" and "to be non-empty".