### PR TITLE
Add assertion type signature to error messages relevant to it

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -565,7 +565,7 @@ Unexpected.prototype.addAssertion = function (patternOrPatterns, handler) {
             throw new Error('Assertion patterns must be a non-empty string');
         } else {
             if (pattern !== pattern.trim()) {
-                throw new Error("Assertion patterns can't start or end with whitespace");
+                throw new Error("Assertion patterns can't start or end with whitespace:\n\n    " + JSON.stringify(pattern));
             }
         }
     });
@@ -601,7 +601,7 @@ Unexpected.prototype.addAssertion = function (patternOrPatterns, handler) {
         });
     });
     if (handler.length - 2 > maxNumberOfArgs) {
-        throw new Error('The provided assertion handler takes ' + (handler.length - 2) + ' parameters, but the type signature specifies a maximum of ' + maxNumberOfArgs);
+        throw new Error('The provided assertion handler takes ' + (handler.length - 2) + ' parameters, but the type signature specifies a maximum of ' + maxNumberOfArgs + ':\n\n    ' + JSON.stringify(patterns));
     }
 
     assertionHandlers.forEach(function (handler) {

--- a/test/api/addAssertion.spec.js
+++ b/test/api/addAssertion.spec.js
@@ -26,7 +26,7 @@ describe('addAssertion', function () {
     it('throws when a handler takes more parameters than are specified in the type signature', function () {
         expect(function () {
             expect.addAssertion('<string> to foobar <number>', function (expect, subject, one, toomany) {});
-        }, 'to throw', 'The provided assertion handler takes 2 parameters, but the type signature specifies a maximum of 1');
+        }, 'to throw', 'The provided assertion handler takes 2 parameters, but the type signature specifies a maximum of 1:\n\n    ["<string> to foobar <number>"]');
     });
 
     it('allows a handler with many parameters when the type signature contains varargs', function () {
@@ -102,19 +102,19 @@ describe('addAssertion', function () {
         it("can't start or end with whitespace", function () {
             expect(function () {
                 expect.addAssertion('   ', function () {});
-            }, 'to throw', "Assertion patterns can't start or end with whitespace");
+            }, 'to throw', "Assertion patterns can't start or end with whitespace:\n\n    \"   \"");
         });
 
         it("can't start with whitespace", function () {
             expect(function () {
                 expect.addAssertion(' foo', function () {});
-            }, 'to throw', "Assertion patterns can't start or end with whitespace");
+            }, 'to throw', "Assertion patterns can't start or end with whitespace:\n\n    \" foo\"");
         });
 
         it("can't end with whitespace", function () {
             expect(function () {
                 expect.addAssertion('foo   ', function () {});
-            }, 'to throw', "Assertion patterns can't start or end with whitespace");
+            }, 'to throw', "Assertion patterns can't start or end with whitespace:\n\n    \"foo   \"");
         });
 
         it("must not contain unbalanced brackets", function () {


### PR DESCRIPTION
This adds a stringification of all the type signatures relevant to error messages related to it.

This might be for leading or trailing spaces in the type signature, or argument length mismatch