### PR TITLE
Allow plugins to hook into the main expect function

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -1337,7 +1337,8 @@ Unexpected.prototype.clone = function () {
         format: this.outputFormat(),
         installedPlugins: [].concat(this.installedPlugins)
     });
-
+    // Install the hooks:
+    unexpected._expect = this._expect;
     return makeExpectFunction(unexpected);
 };
 

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -840,8 +840,10 @@ Unexpected.prototype.withError = function (body, handler) {
 
 Unexpected.prototype.installPlugin = Unexpected.prototype.use; // Legacy alias
 
-function installExpectMethods(unexpected, expectFunction) {
-    var expect = expectFunction.bind(unexpected);
+function installExpectMethods(unexpected) {
+    var expect = function () { /// ...
+        return unexpected._expect.apply(unexpected, arguments);
+    };
     expect.it = unexpected.it.bind(unexpected);
     expect.equal = unexpected.equal.bind(unexpected);
     expect.inspect = unexpected.inspect.bind(unexpected);
@@ -875,6 +877,9 @@ function installExpectMethods(unexpected, expectFunction) {
     expect.output = unexpected.output;
     expect.outputFormat = unexpected.outputFormat.bind(unexpected);
     expect.notifyPendingPromise = notifyPendingPromise;
+    expect.hook = function (fn) {
+        unexpected._expect = fn(unexpected._expect.bind(unexpected));
+    };
     // TODO For testing purpose while we don't have all the pieces yet
     expect.parseAssertion = unexpected.parseAssertion.bind(unexpected);
 
@@ -1081,7 +1086,7 @@ Unexpected.prototype.lookupAssertionRule = function (subject, testDescriptionStr
 };
 
 function makeExpectFunction(unexpected) {
-    var expect = installExpectMethods(unexpected, unexpected.expect);
+    var expect = installExpectMethods(unexpected);
     unexpected.expect = expect;
     return expect;
 }
@@ -1090,7 +1095,7 @@ Unexpected.prototype.setErrorMessage = function (err) {
     err.serializeMessage(this.outputFormat());
 };
 
-Unexpected.prototype.expect = function expect(subject, testDescriptionString) {
+Unexpected.prototype._expect = function expect(subject, testDescriptionString) {
     var that = this;
     if (arguments.length < 2) {
         throw new Error('The expect function requires at least two parameters.');

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -1353,6 +1353,7 @@ Unexpected.prototype.child = function () {
     });
     var parent = childUnexpected.parent = this;
     var childExpect = makeExpectFunction(childUnexpected);
+
     childExpect.exportAssertion = function (testDescription, handler) {
         parent.addAssertion(testDescription, handler, childUnexpected);
         return this;

--- a/test/api/hook.js
+++ b/test/api/hook.js
@@ -1,0 +1,76 @@
+/*global expect*/
+describe('hook', function () {
+    it('should hook into the expect function itself', function () {
+        var clonedExpect = expect.clone();
+        var called = false;
+        clonedExpect.hook(function (next) {
+            return function (subject, testDescriptionString) {
+                called = true;
+                return next.apply(this, arguments);
+            };
+        });
+        expect(called, 'to be false');
+        clonedExpect(123, 'to equal', 123);
+        expect(called, 'to be true');
+    });
+
+    it('should not affect clones', function () {
+        var clonedExpect = expect.clone();
+        var called = false;
+        clonedExpect.hook(function (next) {
+            return function (subject, testDescriptionString) {
+                called = true;
+                return next.apply(this, arguments);
+            };
+        });
+        var clonedClonedExpect = clonedExpect.clone();
+        clonedClonedExpect(123, 'to equal', 123);
+        expect(called, 'to be false');
+    });
+
+    it('should allow rewriting the assertion string', function () {
+        var clonedExpect = expect.clone();
+        clonedExpect.hook(function (next) {
+            return function () {
+                arguments[1] = 'to equal';
+                return next.apply(this, arguments);
+            };
+        });
+        clonedExpect(123, 'to foobarquux', 123);
+    });
+
+    it('should allow suppressing the return value of the "next" expect', function () {
+        var clonedExpect = expect.clone();
+        clonedExpect.hook(function (next) {
+            return function () {
+                try {
+                    next.apply(this, arguments);
+                } catch (e) {
+                    return expect.promise.resolve();
+                }
+            };
+        });
+        clonedExpect(123, 'to equal', 456);
+    });
+
+    it('should allow installing multiple hooks', function () {
+        var firstCalled = false;
+        var secondCalled = false;
+        var clonedExpect = expect.clone();
+        clonedExpect.hook(function (next) {
+            return function () {
+                firstCalled = true;
+                return next.apply(this, arguments);
+            };
+        });
+        clonedExpect.hook(function (next) {
+            return function () {
+                secondCalled = true;
+                return next.apply(this, arguments);
+            };
+        });
+        clonedExpect(123, 'to equal', 123);
+        expect(firstCalled, 'to be true');
+        expect(secondCalled, 'to be true');
+    });
+});

--- a/test/api/hook.js
+++ b/test/api/hook.js
@@ -14,33 +14,35 @@ describe('hook', function () {
         expect(called, 'to be true');
     });
 
-    it('should not affect clones made before hooking in', function () {
-        var clonedExpect = expect.clone();
-        var clonedClonedExpect = clonedExpect.clone();
+    describe('with expect.clone', function () {
+        it('should not affect clones made before hooking in', function () {
+            var clonedExpect = expect.clone();
+            var clonedClonedExpect = clonedExpect.clone();
 
-        var called = false;
-        clonedExpect.hook(function (next) {
-            return function (subject, testDescriptionString) {
-                called = true;
-                return next.apply(this, arguments);
-            };
+            var called = false;
+            clonedExpect.hook(function (next) {
+                return function (subject, testDescriptionString) {
+                    called = true;
+                    return next.apply(this, arguments);
+                };
+            });
+            clonedClonedExpect(123, 'to equal', 123);
+            expect(called, 'to be false');
         });
-        clonedClonedExpect(123, 'to equal', 123);
-        expect(called, 'to be false');
-    });
 
-    it('should affect clones made after hooking in', function () {
-        var clonedExpect = expect.clone();
-        var called = false;
-        clonedExpect.hook(function (next) {
-            return function (subject, testDescriptionString) {
-                called = true;
-                return next.apply(this, arguments);
-            };
+        it('should affect clones made after hooking in', function () {
+            var clonedExpect = expect.clone();
+            var called = false;
+            clonedExpect.hook(function (next) {
+                return function (subject, testDescriptionString) {
+                    called = true;
+                    return next.apply(this, arguments);
+                };
+            });
+            var clonedClonedExpect = clonedExpect.clone();
+            clonedClonedExpect(123, 'to equal', 123);
+            expect(called, 'to be true');
         });
-        var clonedClonedExpect = clonedExpect.clone();
-        clonedClonedExpect(123, 'to equal', 123);
-        expect(called, 'to be true');
     });
 
     it('should allow rewriting the assertion string', function () {

--- a/test/api/hook.js
+++ b/test/api/hook.js
@@ -45,6 +45,41 @@ describe('hook', function () {
         });
     });
 
+    describe('with expect.child', function () {
+        it('should not affect child instances made before installing the hook', function () {
+            var parentExpect = expect.clone();
+            var childExpect = parentExpect.child();
+
+            var called = false;
+            parentExpect.hook(function (next) {
+                return function (subject, testDescriptionString) {
+                    called = true;
+                    return next.apply(this, arguments);
+                };
+            });
+
+            childExpect(123, 'to equal', 123);
+            expect(called, 'to be false');
+        });
+
+        it('should not affect child instances made after installing the hook', function () {
+            var parentExpect = expect.clone();
+
+            var called = false;
+            parentExpect.hook(function (next) {
+                return function (subject, testDescriptionString) {
+                    called = true;
+                    return next.apply(this, arguments);
+                };
+            });
+
+            var childExpect = parentExpect.clone();
+
+            childExpect(123, 'to equal', 123);
+            expect(called, 'to be true');
+        });
+    });
+
     it('should allow rewriting the assertion string', function () {
         var clonedExpect = expect.clone();
         clonedExpect.hook(function (next) {

--- a/test/api/hook.js
+++ b/test/api/hook.js
@@ -14,7 +14,22 @@ describe('hook', function () {
         expect(called, 'to be true');
     });
 
-    it('should not affect clones', function () {
+    it('should not affect clones made before hooking in', function () {
+        var clonedExpect = expect.clone();
+        var clonedClonedExpect = clonedExpect.clone();
+
+        var called = false;
+        clonedExpect.hook(function (next) {
+            return function (subject, testDescriptionString) {
+                called = true;
+                return next.apply(this, arguments);
+            };
+        });
+        clonedClonedExpect(123, 'to equal', 123);
+        expect(called, 'to be false');
+    });
+
+    it('should affect clones made after hooking in', function () {
         var clonedExpect = expect.clone();
         var called = false;
         clonedExpect.hook(function (next) {
@@ -25,7 +40,7 @@ describe('hook', function () {
         });
         var clonedClonedExpect = clonedExpect.clone();
         clonedClonedExpect(123, 'to equal', 123);
-        expect(called, 'to be false');
+        expect(called, 'to be true');
     });
 
     it('should allow rewriting the assertion string', function () {


### PR DESCRIPTION
Allows [consider](https://github.com/papandreou/consider/tree/feature/hook) and [fixpect](https://github.com/papandreou/fixpect/tree/feature/hook) to install themselves as almost regular Unexpected plugins.

I'm not sure about the exact semantics of hooks, or to what extent they should automatically be made available in clones (or children?).