### PR TITLE
Introduce a first class context and use it to avoid serializing expect.it(...).or(...)

### DIFF
--- a/documentation/api/promise-any.md
+++ b/documentation/api/promise-any.md
@@ -59,6 +59,7 @@ return expect.promise.any({
     output.error(aggregateError.message);
     var errors = [];
     for (var i = 0; i < aggregateError.length; i += 1) {
+      aggregateError[i].serializeMessage(expect.outputFormat())
       errors.push(aggregateError[i]);
     }
 

--- a/documentation/assertions/function/when-called-with.md
+++ b/documentation/assertions/function/when-called-with.md
@@ -27,3 +27,25 @@ return expect(add, 'called with', [1, 2]).then(function (result) {
     expect(result, 'to equal', 3);
 });
 ```
+
+When this assertion in used together with [to satisfy](/assertions/any/to-satisfy)
+we make sure that `this` is bound correctly:
+
+```js
+function Greeter(prefix) {
+    this.prefix = prefix;
+}
+
+Greeter.prototype.greet = function (name) {
+    return this.prefix + name;
+};
+
+var helloGreeter = new Greeter('Hello, ')
+
+expect(helloGreeter, 'to satisfy', {
+    greet: expect.it(
+      'when called with', ['John Doe'],
+      'to equal', 'Hello, John Doe'
+    )
+});
+```

--- a/documentation/assertions/function/when-called.md
+++ b/documentation/assertions/function/when-called.md
@@ -27,3 +27,20 @@ return expect(giveMeFive, 'called').then(function (result) {
     expect(result, 'to equal', 5);
 });
 ```
+
+When this assertion in used together with [to satisfy](/assertions/any/to-satisfy)
+we make sure that `this` is bound correctly:
+
+```js
+function Person(name) {
+    this.name = name;
+}
+
+Person.prototype.toString = function () {
+    return this.name;
+};
+
+expect(new Person('John Doe'), 'to satisfy', {
+    toString: expect.it('when called to equal', 'John Doe')
+});
+```

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -19,6 +19,17 @@ function isAssertionArg(arg) {
     return arg.type.is('assertion');
 }
 
+function Context(unexpected) {
+    this.expect = unexpected;
+    this.level = 0;
+}
+
+Context.prototype.child = function () {
+    var child = Object.create(this);
+    child.level++;
+    return child;
+};
+
 var anyType = {
     _unexpectedType: true,
     name: 'any',
@@ -125,7 +136,7 @@ function getOrGroups(expectations) {
     return orGroups;
 }
 
-function evaluateGroup(expect, subject, orGroup) {
+function evaluateGroup(unexpected, context, subject, orGroup) {
     return orGroup.map(function (expectation) {
         var args = Array.prototype.slice.call(expectation);
         args.unshift(subject);
@@ -140,14 +151,14 @@ function evaluateGroup(expect, subject, orGroup) {
                         return args[1](args[0]);
                     }
                 } else {
-                    return expect.apply(expect, args);
+                    return unexpected._expect.call(unexpected, context.child(), args);
                 }
             })
         };
     });
 }
 
-function writeGroupEvaluationsToOutput(expect, output, groupEvaluations) {
+function writeGroupEvaluationsToOutput(output, groupEvaluations) {
     var hasOrClauses = groupEvaluations.length > 1;
     var hasAndClauses = groupEvaluations.some(function (groupEvaluation) {
         return groupEvaluation.length > 1;
@@ -208,21 +219,27 @@ function writeGroupEvaluationsToOutput(expect, output, groupEvaluations) {
     });
 }
 
-function createExpectIt(expect, expectations) {
+function createExpectIt(unexpected, expectations) {
     var orGroups = getOrGroups(expectations);
 
-    function expectIt(subject) {
+    function expectIt(subject, context) {
+        context = (
+            context &&
+            typeof context === 'object' &&
+            context instanceof Context
+        ) ? context : new Context(unexpected);
+
         var groupEvaluations = [];
         var promises = [];
         orGroups.forEach(function (orGroup) {
-            var evaluations = evaluateGroup(expect, subject, orGroup);
+            var evaluations = evaluateGroup(unexpected, context, subject, orGroup);
             evaluations.forEach(function (evaluation) {
                 promises.push(evaluation.promise);
             });
             groupEvaluations.push(evaluations);
         });
 
-        return oathbreaker(expect.promise.settle(promises).then(function () {
+        return oathbreaker(makePromise.settle(promises).then(function () {
             groupEvaluations.forEach(function (groupEvaluation) {
                 groupEvaluation.forEach(function (evaluation) {
                     if (evaluation.promise.isRejected() && evaluation.promise.reason().errorMode === 'bubbleThrough') {
@@ -236,8 +253,8 @@ function createExpectIt(expect, expectations) {
                     return evaluation.promise.isFulfilled();
                 });
             })) {
-                expect.fail(function (output) {
-                    writeGroupEvaluationsToOutput(expect, output, groupEvaluations);
+                unexpected.fail(function (output) {
+                    writeGroupEvaluationsToOutput(output, groupEvaluations);
                 });
             }
         }));
@@ -248,18 +265,18 @@ function createExpectIt(expect, expectations) {
     expectIt.and = function () {
         var copiedExpectations = expectations.slice();
         copiedExpectations.push(arguments);
-        return createExpectIt(expect, copiedExpectations);
+        return createExpectIt(unexpected, copiedExpectations);
     };
     expectIt.or = function () {
         var copiedExpectations = expectations.slice();
         copiedExpectations.push(OR, arguments);
-        return createExpectIt(expect, copiedExpectations);
+        return createExpectIt(unexpected, copiedExpectations);
     };
     return expectIt;
 }
 
 Unexpected.prototype.it = function () { // ...
-    return createExpectIt(this.expect, [arguments]);
+    return createExpectIt(this, [arguments]);
 };
 
 Unexpected.prototype.equal = function (actual, expected, depth, seen) {
@@ -851,7 +868,7 @@ Unexpected.prototype.installPlugin = Unexpected.prototype.use; // Legacy alias
 
 function installExpectMethods(unexpected) {
     var expect = function () { /// ...
-        return unexpected._expect.apply(unexpected, arguments);
+        return unexpected._expect.call(unexpected, new Context(unexpected), arguments);
     };
     expect.it = unexpected.it.bind(unexpected);
     expect.equal = unexpected.equal.bind(unexpected);
@@ -1104,9 +1121,12 @@ Unexpected.prototype.setErrorMessage = function (err) {
     err.serializeMessage(this.outputFormat());
 };
 
-Unexpected.prototype._expect = function expect(subject, testDescriptionString) {
+Unexpected.prototype._expect = function expect(context, args) {
     var that = this;
-    if (arguments.length < 2) {
+    var subject = args[0];
+    var testDescriptionString = args[1];
+
+    if (args.length < 2) {
         throw new Error('The expect function requires at least two parameters.');
     } else if (testDescriptionString && testDescriptionString._expectIt) {
         return that.expect.withError(function () {
@@ -1116,12 +1136,7 @@ Unexpected.prototype._expect = function expect(subject, testDescriptionString) {
         });
     }
 
-    var executionContext = {
-        expect: that,
-        serializeErrorsFromWrappedExpect: false
-    };
-
-    function executeExpect(subject, testDescriptionString, args) {
+    function executeExpect(context, subject, testDescriptionString, args) {
         var assertionRule = that.lookupAssertionRule(subject, testDescriptionString, args);
 
         if (!assertionRule) {
@@ -1166,13 +1181,13 @@ Unexpected.prototype._expect = function expect(subject, testDescriptionString) {
                 args[i - 2] = arguments[i];
             }
             return wrappedExpect.callInNestedContext(function () {
-                return executeExpect(subject, testDescriptionString, args);
+                return executeExpect(context.child(), subject, testDescriptionString, args);
             });
         };
 
         utils.setPrototypeOfOrExtend(wrappedExpect, that._wrappedExpectProto);
 
-        wrappedExpect._context = executionContext;
+        wrappedExpect.context = context;
         wrappedExpect.execute = wrappedExpect;
         wrappedExpect.alternations = assertionRule.alternations;
         wrappedExpect.flags = flags;
@@ -1205,22 +1220,17 @@ Unexpected.prototype._expect = function expect(subject, testDescriptionString) {
         return oathbreaker(assertionRule.handler.apply(wrappedExpect, [wrappedExpect, subject].concat(args)));
     }
 
-    var args = new Array(arguments.length - 2);
-    for (var i = 2 ; i < arguments.length ; i += 1) {
-        args[i - 2] = arguments[i];
-    }
     try {
-        var result = executeExpect(subject, testDescriptionString, args);
+        var result = executeExpect(context, subject, testDescriptionString, Array.prototype.slice.call(args, 2));
         if (isPendingPromise(result)) {
             that.expect.notifyPendingPromise(result);
             result = result.then(undefined, function (e) {
-                if (e && e._isUnexpected) {
+                if (e && e._isUnexpected && context.level === 0) {
                     that.setErrorMessage(e);
                 }
                 throw e;
             });
         } else {
-            executionContext.serializeErrorsFromWrappedExpect = true;
             if (!result || typeof result.then !== 'function') {
                 result = makePromise.resolve(result);
             }
@@ -1232,7 +1242,9 @@ Unexpected.prototype._expect = function expect(subject, testDescriptionString) {
             if (typeof mochaPhantomJS !== 'undefined') {
                 newError = e.clone();
             }
-            that.setErrorMessage(newError);
+            if (context.level === 0) {
+                that.setErrorMessage(newError);
+            }
             throw newError;
         }
         throw e;

--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -151,7 +151,7 @@ function evaluateGroup(unexpected, context, subject, orGroup) {
                         return args[1](args[0]);
                     }
                 } else {
-                    return unexpected._expect.call(unexpected, context.child(), args);
+                    return unexpected._expect(context.child(), args);
                 }
             })
         };
@@ -868,7 +868,7 @@ Unexpected.prototype.installPlugin = Unexpected.prototype.use; // Legacy alias
 
 function installExpectMethods(unexpected) {
     var expect = function () { /// ...
-        return unexpected._expect.call(unexpected, new Context(unexpected), arguments);
+        return unexpected._expect(new Context(unexpected), arguments);
     };
     expect.it = unexpected.it.bind(unexpected);
     expect.equal = unexpected.equal.bind(unexpected);

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1247,6 +1247,7 @@ module.exports = function (expect) {
             promiseByKey[key] = expect.promise(function () {
                 var valueKeyType = expect.findTypeOf(value[key]);
                 if (valueKeyType.is('expect.it')) {
+                    expect.context.thisObject = subject;
                     return value[key](subject[key], expect.context);
                 } else if (valueKeyType.is('function')) {
                     return value[key](subject[key]);
@@ -1444,12 +1445,18 @@ module.exports = function (expect) {
         expect.argsOutput[0] = function (output) {
             output.appendItems(args, ', ');
         };
-        return expect.shift(subject.apply(subject, args));
+
+        var thisObject = expect.context.thisObject || null;
+
+        return expect.shift(subject.apply(thisObject, args));
     });
 
     expect.addAssertion('<function> [when] called <assertion?>', function (expect, subject) {
         expect.errorMode = 'nested';
-        return expect.shift(subject.call(subject));
+
+        var thisObject = expect.context.thisObject || null;
+
+        return expect.shift(subject.call(thisObject));
     });
 
     function instantiate(Constructor, args) {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -727,7 +727,9 @@ module.exports = function (expect) {
                 };
             } else if (typeof nextArg === 'function') {
                 expected[key] = function (s) {
-                    return nextArg(s, index);
+                    return nextArg._expectIt
+                      ? nextArg(s, expect.context)
+                      : nextArg(s, index);
                 };
             } else {
                 expected[key] = nextArg;
@@ -911,7 +913,7 @@ module.exports = function (expect) {
 
     expect.addAssertion('<binaryArray> to [exhaustively] satisfy <expect.it>', function (expect, subject, value) {
         return expect.withError(function () {
-            return value(subject);
+            return value(subject, expect.context);
         }, function (e) {
             expect.fail({
                 diff: function (output, diff, inspect, equal) {
@@ -919,6 +921,13 @@ module.exports = function (expect) {
                     return output.appendErrorMessage(e);
                 }
             });
+        });
+    });
+
+    expect.addAssertion('<UnexpectedError> to [exhaustively] satisfy <function>', function (expect, subject, value) {
+        return expect.promise(function () {
+            subject.serializeMessage(expect.outputFormat());
+            return value(subject);
         });
     });
 
@@ -966,7 +975,7 @@ module.exports = function (expect) {
 
     expect.addAssertion('<any> to [exhaustively] satisfy [assertion] <expect.it>', function (expect, subject, value) {
         return expect.withError(function () {
-            return value(subject);
+            return value(subject, expect.context);
         }, function (e) {
             expect.fail({
                 diff: function (output) {
@@ -1237,7 +1246,9 @@ module.exports = function (expect) {
         keys.forEach(function (key, index) {
             promiseByKey[key] = expect.promise(function () {
                 var valueKeyType = expect.findTypeOf(value[key]);
-                if (valueKeyType.is('function')) {
+                if (valueKeyType.is('expect.it')) {
+                    return value[key](subject[key], expect.context);
+                } else if (valueKeyType.is('function')) {
                     return value[key](subject[key]);
                 } else {
                     return expect(subject[key], 'to [exhaustively] satisfy', value[key]);

--- a/lib/createWrappedExpectProto.js
+++ b/lib/createWrappedExpectProto.js
@@ -64,13 +64,13 @@ module.exports = function createWrappedExpectProto(unexpected) {
         diff: unexpected.diff,
         getType: unexpected.getType,
         output: unexpected.output,
-        outputFormat: unexpected.outputFormat,
+        outputFormat: unexpected.outputFormat.bind(unexpected),
         format: unexpected.format,
         withError: unexpected.withError,
 
         fail: function () {
             var args = arguments;
-            var expect = this._context.expect;
+            var expect = this.context.expect;
             this.callInNestedContext(function () {
                 expect.fail.apply(expect, args);
             });
@@ -92,7 +92,7 @@ module.exports = function createWrappedExpectProto(unexpected) {
         },
         callInNestedContext: function (callback) {
             var that = this;
-            var expect = that._context.expect;
+
             try {
                 var result = oathbreaker(callback());
                 if (isPendingPromise(result)) {
@@ -112,9 +112,6 @@ module.exports = function createWrappedExpectProto(unexpected) {
                 if (e && e._isUnexpected) {
                     var wrappedError = new UnexpectedError(that, e);
                     wrappedError.originalError = e.originalError;
-                    if (that._context.serializeErrorsFromWrappedExpect) {
-                        expect.setErrorMessage(wrappedError);
-                    }
                     throw wrappedError;
                 }
                 throw e;

--- a/test/api/hook.js
+++ b/test/api/hook.js
@@ -6,7 +6,7 @@ describe('hook', function () {
         clonedExpect.hook(function (next) {
             return function (context, args) {
                 called = true;
-                return next.call(this, context, args);
+                return next(context, args);
             };
         });
         expect(called, 'to be false');
@@ -23,7 +23,7 @@ describe('hook', function () {
             clonedExpect.hook(function (next) {
                 return function (context, args) {
                     called = true;
-                    return next.call(this, context, args);
+                    return next(context, args);
                 };
             });
             clonedClonedExpect(123, 'to equal', 123);
@@ -36,7 +36,7 @@ describe('hook', function () {
             clonedExpect.hook(function (next) {
                 return function (context, args) {
                     called = true;
-                    return next.call(this, context, args);
+                    return next(context, args);
                 };
             });
             var clonedClonedExpect = clonedExpect.clone();
@@ -54,7 +54,7 @@ describe('hook', function () {
             parentExpect.hook(function (next) {
                 return function (context, args) {
                     called = true;
-                    return next.call(this, context, args);
+                    return next(context, args);
                 };
             });
 
@@ -69,7 +69,7 @@ describe('hook', function () {
             parentExpect.hook(function (next) {
                 return function (context, args) {
                     called = true;
-                    return next.call(this, context, args);
+                    return next(context, args);
                 };
             });
 
@@ -85,7 +85,7 @@ describe('hook', function () {
         clonedExpect.hook(function (next) {
             return function (context, args) {
                 args[1] = 'to equal';
-                return next.call(this, context, args);
+                return next(context, args);
             };
         });
         clonedExpect(123, 'to foobarquux', 123);
@@ -96,7 +96,7 @@ describe('hook', function () {
         clonedExpect.hook(function (next) {
             return function (context, args) {
                 try {
-                    next.call(this, context, args);
+                    next(context, args);
                 } catch (e) {
                     return expect.promise.resolve();
                 }
@@ -112,13 +112,13 @@ describe('hook', function () {
         clonedExpect.hook(function (next) {
             return function (context, args) {
                 firstCalled = true;
-                return next.call(this, context, args);
+                return next(context, args);
             };
         });
         clonedExpect.hook(function (next) {
             return function (context, args) {
                 secondCalled = true;
-                return next.call(this, context, args);
+                return next(context, args);
             };
         });
         clonedExpect(123, 'to equal', 123);

--- a/test/api/hook.js
+++ b/test/api/hook.js
@@ -4,9 +4,9 @@ describe('hook', function () {
         var clonedExpect = expect.clone();
         var called = false;
         clonedExpect.hook(function (next) {
-            return function (subject, testDescriptionString) {
+            return function (context, args) {
                 called = true;
-                return next.apply(this, arguments);
+                return next.call(this, context, args);
             };
         });
         expect(called, 'to be false');
@@ -21,9 +21,9 @@ describe('hook', function () {
 
             var called = false;
             clonedExpect.hook(function (next) {
-                return function (subject, testDescriptionString) {
+                return function (context, args) {
                     called = true;
-                    return next.apply(this, arguments);
+                    return next.call(this, context, args);
                 };
             });
             clonedClonedExpect(123, 'to equal', 123);
@@ -34,9 +34,9 @@ describe('hook', function () {
             var clonedExpect = expect.clone();
             var called = false;
             clonedExpect.hook(function (next) {
-                return function (subject, testDescriptionString) {
+                return function (context, args) {
                     called = true;
-                    return next.apply(this, arguments);
+                    return next.call(this, context, args);
                 };
             });
             var clonedClonedExpect = clonedExpect.clone();
@@ -52,9 +52,9 @@ describe('hook', function () {
 
             var called = false;
             parentExpect.hook(function (next) {
-                return function (subject, testDescriptionString) {
+                return function (context, args) {
                     called = true;
-                    return next.apply(this, arguments);
+                    return next.call(this, context, args);
                 };
             });
 
@@ -67,9 +67,9 @@ describe('hook', function () {
 
             var called = false;
             parentExpect.hook(function (next) {
-                return function (subject, testDescriptionString) {
+                return function (context, args) {
                     called = true;
-                    return next.apply(this, arguments);
+                    return next.call(this, context, args);
                 };
             });
 
@@ -83,9 +83,9 @@ describe('hook', function () {
     it('should allow rewriting the assertion string', function () {
         var clonedExpect = expect.clone();
         clonedExpect.hook(function (next) {
-            return function () {
-                arguments[1] = 'to equal';
-                return next.apply(this, arguments);
+            return function (context, args) {
+                args[1] = 'to equal';
+                return next.call(this, context, args);
             };
         });
         clonedExpect(123, 'to foobarquux', 123);
@@ -94,9 +94,9 @@ describe('hook', function () {
     it('should allow suppressing the return value of the "next" expect', function () {
         var clonedExpect = expect.clone();
         clonedExpect.hook(function (next) {
-            return function () {
+            return function (context, args) {
                 try {
-                    next.apply(this, arguments);
+                    next.call(this, context, args);
                 } catch (e) {
                     return expect.promise.resolve();
                 }
@@ -110,15 +110,15 @@ describe('hook', function () {
         var secondCalled = false;
         var clonedExpect = expect.clone();
         clonedExpect.hook(function (next) {
-            return function () {
+            return function (context, args) {
                 firstCalled = true;
-                return next.apply(this, arguments);
+                return next.call(this, context, args);
             };
         });
         clonedExpect.hook(function (next) {
-            return function () {
+            return function (context, args) {
                 secondCalled = true;
-                return next.apply(this, arguments);
+                return next.call(this, context, args);
             };
         });
         clonedExpect(123, 'to equal', 123);

--- a/test/assertions/when-called-with.spec.js
+++ b/test/assertions/when-called-with.spec.js
@@ -21,4 +21,20 @@ describe('when called with assertion', function () {
             expect(sum, 'to equal', 7);
         });
     });
+
+    describe('when assertion is executed in context of another object', function () {
+        it('should call the function in the context of that object', function () {
+            function Greeter(prefix) {
+                this.prefix = prefix;
+            }
+
+            Greeter.prototype.greet = function (name) {
+                return this.prefix + name;
+            };
+
+            expect(new Greeter('Hello, '), 'to satisfy', {
+                greet: expect.it('when called with', ['John Doe'], 'to equal', 'Hello, John Doe')
+            });
+        });
+    });
 });

--- a/test/assertions/when-called.spec.js
+++ b/test/assertions/when-called.spec.js
@@ -46,4 +46,20 @@ describe('when called assertion', function () {
             );
         });
     });
+
+    describe('when assertion is executed in context of another object', function () {
+        it('should call the function in the context of that object', function () {
+            function Person(name) {
+                this.name = name;
+            }
+
+            Person.prototype.toString = function () {
+                return this.name;
+            };
+
+            expect(new Person('John Doe'), 'to satisfy', {
+                toString: expect.it('when called to equal', 'John Doe')
+            });
+        });
+    });
 });


### PR DESCRIPTION
This PR introduces the execution context as a first class concept that is available on wrapped expect's. I had to change the internal hook api slightly, so users of that api will break. What is cool, is that the hook api will be able to update the context, which provides a way for hooks to communicate with assertions. 

The second part of the PR is a nesting level count in the context  that is used to know when we should serialize `expect.it(...).or(...)` errors. This is the main motivation for this change, as it will make `or` dramatically faster. This is important when you do property based testing where `or` is much more used.

Sorry for piling everything into one commit, I can split it if you feel it is important.