### PR TITLE
addStyle & installTheme: Return the expect function rather than the magicpen instance (for chaining)

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -764,11 +764,13 @@ Unexpected.prototype.addType = function (type, childUnexpected) {
 };
 
 Unexpected.prototype.addStyle = function () { // ...
-    return this.output.addStyle.apply(this.output, arguments);
+    this.output.addStyle.apply(this.output, arguments);
+    return this.expect;
 };
 
 Unexpected.prototype.installTheme = function () { // ...
-    return this.output.installTheme.apply(this.output, arguments);
+    this.output.installTheme.apply(this.output, arguments);
+    return this.expect;
 };
 
 function getPluginName(plugin) {

--- a/test/api/addStyle.spec.js
+++ b/test/api/addStyle.spec.js
@@ -1,0 +1,13 @@
+/*global expect*/
+describe('addStyle', function () {
+    var clonedExpect;
+    beforeEach(function () {
+        clonedExpect = expect.clone();
+    });
+
+    it('is chainable (returns the expect function, not the magicpen instance)', function () {
+        clonedExpect
+            .addStyle('foo', function () {})
+            ('bar', 'to equal', 'bar');
+    });
+});

--- a/test/api/installTheme.spec.js
+++ b/test/api/installTheme.spec.js
@@ -1,0 +1,13 @@
+/*global expect*/
+describe('installTheme', function () {
+    var clonedExpect;
+    beforeEach(function () {
+        clonedExpect = expect.clone();
+    });
+
+    it('is chainable (returns the expect function, not the magicpen instance)', function () {
+        clonedExpect
+            .installTheme('html', { comment: 'gray' })
+            ('bar', 'to equal', 'bar');
+    });
+});


### PR DESCRIPTION
I noticed that `expect.addStyle(...).addAssertion(...)` didn't work, and it turns out that we return the magicpen instance instead of the expect function in a couple of cases.