### PR TITLE
added: support for property descriptors

### DIFF
--- a/documentation/assertions/object/to-have-property.md
+++ b/documentation/assertions/object/to-have-property.md
@@ -31,6 +31,14 @@ expect(Object.create({ a: 'b' }), 'to have own property', 'a');
 expected {} to have own property 'a'
 ```
 
+You can assert for property descriptors too.
+
+```javascript
+expect({ a: 'b' }, 'to have enumerable property', 'a');
+expect({ a: 'b' }, 'to have configurable property', 'a');
+expect({ a: 'b' }, 'to have writable property', 'a');
+```
+
 This assertion can be negated using the `not` flag:
 
 ```javascript

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -196,18 +196,9 @@ module.exports = function (expect) {
         return subject[key];
     });
 
-    expect.addAssertion('<object|function> [not] to have enumerable property <string>', function (expect, subject, key) {
-        expect(Object.getOwnPropertyDescriptor(subject, key).enumerable, '[not] to be truthy');
-        return subject[key];
-    });
-
-    expect.addAssertion('<object|function> [not] to have configurable property <string>', function (expect, subject, key) {
-        expect(Object.getOwnPropertyDescriptor(subject, key).configurable, '[not] to be truthy');
-        return subject[key];
-    });
-
-    expect.addAssertion('<object|function> [not] to have writable property <string>', function (expect, subject, key) {
-        expect(Object.getOwnPropertyDescriptor(subject, key).writable, '[not] to be truthy');
+    expect.addAssertion('<object|function> [not] to have (enumerable|configurable|writable) property <string>', function (expect, subject, key) {
+        var descriptor = expect.alternations[0];
+        expect(Object.getOwnPropertyDescriptor(subject, key)[descriptor], '[not] to be truthy');
         return subject[key];
     });
 

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -196,6 +196,21 @@ module.exports = function (expect) {
         return subject[key];
     });
 
+    expect.addAssertion('<object|function> [not] to have enumerable property <string>', function (expect, subject, key) {
+        expect(Object.getOwnPropertyDescriptor(subject, key).enumerable, '[not] to be truthy');
+        return subject[key];
+    });
+
+    expect.addAssertion('<object|function> [not] to have configurable property <string>', function (expect, subject, key) {
+        expect(Object.getOwnPropertyDescriptor(subject, key).configurable, '[not] to be truthy');
+        return subject[key];
+    });
+
+    expect.addAssertion('<object|function> [not] to have writable property <string>', function (expect, subject, key) {
+        expect(Object.getOwnPropertyDescriptor(subject, key).writable, '[not] to be truthy');
+        return subject[key];
+    });
+
     expect.addAssertion('<object|function> [not] to have property <string>', function (expect, subject, key) {
         expect(subject[key], '[!not] to be undefined');
         return subject[key];

--- a/test/assertions/to-have-property.spec.js
+++ b/test/assertions/to-have-property.spec.js
@@ -12,6 +12,37 @@ describe('to have property assertion', function () {
         expect(function () {}, 'to have property', 'toString');
     });
 
+    describe('property descriptor', function () {
+        before(function () {
+            this.subject = { a: 'b' };
+
+            Object.defineProperty(this.subject, 'enumFalse', { enumerable: false, value: 't' });
+            Object.defineProperty(this.subject, 'configFalse', { configurable: false, value: 't' });
+            Object.defineProperty(this.subject, 'writableFalse', { writable: false, value: 't' });
+        });
+
+        it('asserts validity of property descriptor', function () {
+            expect(this.subject, 'to have enumerable property', 'a');
+            expect(this.subject, 'not to have enumerable property', 'enumFalse');
+            expect(this.subject, 'to have configurable property', 'a');
+            expect(this.subject, 'not to have configurable property', 'configFalse');
+            expect(this.subject, 'to have writable property', 'a');
+            expect(this.subject, 'not to have writable property', 'writableFalse');
+        });
+
+        it('throws when assertion fails', function () {
+            expect(function () {
+                expect(this.subject, 'to have enumerable property', 'enumFalse');
+            }.bind(this), 'to throw exception', "expected { a: 'b' } to have enumerable property 'enumFalse'");
+            expect(function () {
+                expect(this.subject, 'to have configurable property', 'configFalse');
+            }.bind(this), 'to throw exception', "expected { a: 'b' } to have configurable property 'configFalse'");
+            expect(function () {
+                expect(this.subject, 'to have writable property', 'writableFalse');
+            }.bind(this), 'to throw exception', "expected { a: 'b' } to have writable property 'writableFalse'");
+        });
+    });
+
     it('throws when the assertion fails', function () {
         expect(function () {
             expect({a: 'b'}, 'to have property', 'b');

--- a/test/assertions/to-have-property.spec.js
+++ b/test/assertions/to-have-property.spec.js
@@ -13,33 +13,30 @@ describe('to have property assertion', function () {
     });
 
     describe('property descriptor', function () {
-        before(function () {
-            this.subject = { a: 'b' };
-
-            Object.defineProperty(this.subject, 'enumFalse', { enumerable: false, value: 't' });
-            Object.defineProperty(this.subject, 'configFalse', { configurable: false, value: 't' });
-            Object.defineProperty(this.subject, 'writableFalse', { writable: false, value: 't' });
-        });
+        var subject = { a: 'b' };
+        Object.defineProperty(subject, 'enumFalse', { enumerable: false, value: 't' });
+        Object.defineProperty(subject, 'configFalse', { configurable: false, value: 't' });
+        Object.defineProperty(subject, 'writableFalse', { writable: false, value: 't' });
 
         it('asserts validity of property descriptor', function () {
-            expect(this.subject, 'to have enumerable property', 'a');
-            expect(this.subject, 'not to have enumerable property', 'enumFalse');
-            expect(this.subject, 'to have configurable property', 'a');
-            expect(this.subject, 'not to have configurable property', 'configFalse');
-            expect(this.subject, 'to have writable property', 'a');
-            expect(this.subject, 'not to have writable property', 'writableFalse');
+            expect(subject, 'to have enumerable property', 'a');
+            expect(subject, 'not to have enumerable property', 'enumFalse');
+            expect(subject, 'to have configurable property', 'a');
+            expect(subject, 'not to have configurable property', 'configFalse');
+            expect(subject, 'to have writable property', 'a');
+            expect(subject, 'not to have writable property', 'writableFalse');
         });
 
         it('throws when assertion fails', function () {
             expect(function () {
-                expect(this.subject, 'to have enumerable property', 'enumFalse');
-            }.bind(this), 'to throw exception', "expected { a: 'b' } to have enumerable property 'enumFalse'");
+                expect(subject, 'to have enumerable property', 'enumFalse');
+            }, 'to throw exception', "expected { a: 'b' } to have enumerable property 'enumFalse'");
             expect(function () {
-                expect(this.subject, 'to have configurable property', 'configFalse');
-            }.bind(this), 'to throw exception', "expected { a: 'b' } to have configurable property 'configFalse'");
+                expect(subject, 'to have configurable property', 'configFalse');
+            }, 'to throw exception', "expected { a: 'b' } to have configurable property 'configFalse'");
             expect(function () {
-                expect(this.subject, 'to have writable property', 'writableFalse');
-            }.bind(this), 'to throw exception', "expected { a: 'b' } to have writable property 'writableFalse'");
+                expect(subject, 'to have writable property', 'writableFalse');
+            }, 'to throw exception', "expected { a: 'b' } to have writable property 'writableFalse'");
         });
     });
 


### PR DESCRIPTION
Added support for asserting against property descriptors

- `enumerable`
- `configurable`
- `writable`

Closes #105