### PR TITLE
Alias for to be a date

### DIFF
--- a/documentation/assertions/any/to-be-a.md
+++ b/documentation/assertions/any/to-be-a.md
@@ -17,6 +17,7 @@ expect(/regex/, 'to be a', 'regexp');
 expect(/regex/, 'to be a', 'regex');
 expect(/regex/, 'to be a', 'regular expression');
 expect(new Error(), 'to be an', 'Error');
+expect(new Date(), 'to be a', 'date');
 ```
 
 The assertions also respect the inheritance chain:
@@ -38,6 +39,7 @@ expect([123], 'to be an array');
 expect(/regex/, 'to be a regexp');
 expect(/regex/, 'to be a regex');
 expect(/regex/, 'to be a regular expression');
+expect(new Date(), 'to be a date');
 ```
 
 If you provide a constructor as the type the assertion will use `instanceof`.

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -141,7 +141,7 @@ module.exports = function (expect) {
         expect(subject, '[not] to be an', expect.alternations[0]);
     });
 
-    expect.addAssertion('<any> [not] to be a (boolean|number|string|function|regexp|regex|regular expression)', function (expect, subject) {
+    expect.addAssertion('<any> [not] to be a (boolean|number|string|function|regexp|regex|regular expression|date)', function (expect, subject) {
         expect(subject, '[not] to be a', expect.alternations[0]);
     });
 

--- a/test/assertions/to-be-a.spec.js
+++ b/test/assertions/to-be-a.spec.js
@@ -32,6 +32,10 @@ describe('to be a/an assertion', function () {
         expect(expect, 'to be a', 'function');
         expect(expect, 'to be a function');
         expect(circular, 'to be an object');
+        expect(new Date(), 'to be a', 'date');
+        expect(new Date(), 'to be a date');
+        expect({}, 'not to be a date');
+        expect((new Date()).toISOString(), 'not to be a date');
     });
 
     it('should support type objects', function () {


### PR DESCRIPTION
This will close #324

Initially I wanted to add more assertions around date and time because I use them a lot in my projects. Primarily I am looking for something like

- `to equal date` , asserts if two dates have same day
- `to equal time` , asserts if two dates have same day + time (equality check basically)

It will be nice to have (like from [unexpected-moment](http://unexpected.js.org/unexpected-moment/assertions/any/to-be-a-moment/))

- `to be after`
- ` to be before`
- `to be between`
- `to be same or after`
- `to be same or before`

All these will work on date instance rather than moment.

Now I want to ask maintainers of this project if they will accept these changes in main repository OR should I add a plugin for these date/time assertions ?