### PR TITLE
added: plugin unexpected-date

### DIFF
--- a/documentation/plugins.md
+++ b/documentation/plugins.md
@@ -18,6 +18,7 @@ Here's a partial list of plugins for Unexpected:
   strings representing colors.
 * [unexpected-couchdb](https://github.com/alexjeffburke/unexpected-couchdb/):
   Run your tests against a mock CouchDB server initialized to a given state.
+* [unexpected-date](https://github.com/sushantdhiman/unexpected-date): Date/time assertions on Date object.
 * [unexpected-dom](https://github.com/munter/unexpected-dom/): Assertions for
   XML/HTML DOM and HTML/XML strings. Works in the browser and in node.js via
   [jsdom](https://github.com/tmpvar/jsdom).

--- a/documentation/plugins.md
+++ b/documentation/plugins.md
@@ -18,7 +18,7 @@ Here's a partial list of plugins for Unexpected:
   strings representing colors.
 * [unexpected-couchdb](https://github.com/alexjeffburke/unexpected-couchdb/):
   Run your tests against a mock CouchDB server initialized to a given state.
-* [unexpected-date](https://github.com/sushantdhiman/unexpected-date): Date/time assertions on Date object.
+* [unexpected-date](http://sushantdhiman.com/projects/unexpected-date/): Date/time assertions on Date object.
 * [unexpected-dom](https://github.com/munter/unexpected-dom/): Assertions for
   XML/HTML DOM and HTML/XML strings. Works in the browser and in node.js via
   [jsdom](https://github.com/tmpvar/jsdom).


### PR DESCRIPTION
As discussed in PR https://github.com/unexpectedjs/unexpected/pull/403#issuecomment-313482933, I have added a plugin which will cover various date/time assertions discussed.

Please add it to known plugin list.

https://github.com/sushantdhiman/unexpected-date
https://www.npmjs.com/package/unexpected-date

It supports 

- [not] to be after
- [not] to be before
- [not] to equal time
- [not] to equal date
- [not] to be same or after
- [not] to be same or before
- [not] to be between

I will expand this list to match my or community requirements 
