### PR TITLE
implicit return multiline arrow function inspection

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -783,6 +783,9 @@ module.exports = function (expect) {
                     if (bodyIndent.length === 1) {
                         closingBrace = ' }';
                     }
+                    if (openingBrace && openingBrace.indexOf('{') === -1) {
+                        closingBrace = '';
+                    }
                 }
 
                 // Remove leading indentation unless the function is a one-liner or it uses multiline string literals
@@ -801,7 +804,7 @@ module.exports = function (expect) {
                     closingBrace = '}';
                 } else if (/^\s*$/.test(body)) {
                     body = '';
-                } else if (/^\s*[^\r\n]{1,30}\s*$/.test(body) && body.indexOf('//') === -1) {
+                } else if (/^\s*[^\r\n]{1,30}\s*$/.test(body) && body.indexOf('//') === -1 && openingBrace.indexOf('{') !== -1) {
                     body = ' ' + body.trim() + ' ';
                     closingBrace = '}';
                 } else {

--- a/lib/types.js
+++ b/lib/types.js
@@ -773,7 +773,7 @@ module.exports = function (expect) {
                     preamble = 'function ' + name + '()';
                 }
                 body = matchSource[2];
-                var matchBodyAndIndent = body.match(/^(\s*\{)([\s\S]*?)([ ]*)\}\s*$/);
+                var matchBodyAndIndent = body.match(/^(\s*\{?)([\s\S]*?)([ ]*)\}?\s*$/);
                 var openingBrace;
                 var closingBrace = '}';
                 if (matchBodyAndIndent) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -773,8 +773,9 @@ module.exports = function (expect) {
                     preamble = 'function ' + name + '()';
                 }
                 body = matchSource[2];
-                var matchBodyAndIndent = body.match(/^(\s*\{?)([\s\S]*?)([ ]*)\}?\s*$/);
+                var matchBodyAndIndent = body.match(/^(\s*\{)([\s\S]*?)([ ]*)\}\s*$/);
                 var openingBrace;
+                var isWrappedInBraces = true;
                 var closingBrace = '}';
                 if (matchBodyAndIndent) {
                     openingBrace = matchBodyAndIndent[1];
@@ -783,7 +784,15 @@ module.exports = function (expect) {
                     if (bodyIndent.length === 1) {
                         closingBrace = ' }';
                     }
-                    if (openingBrace && openingBrace.indexOf('{') === -1) {
+                } else {
+                    // Attempt to match an arrow function with an implicit return body.
+                    matchBodyAndIndent = body.match(/^(\s*)([\s\S]*?)([ ]*)\s*$/);
+
+                    if (matchBodyAndIndent) {
+                        openingBrace = matchBodyAndIndent[1];
+                        isWrappedInBraces = false;
+                        body = matchBodyAndIndent[2];
+                        bodyIndent = matchBodyAndIndent[3] || '';
                         closingBrace = '';
                     }
                 }
@@ -804,7 +813,7 @@ module.exports = function (expect) {
                     closingBrace = '}';
                 } else if (/^\s*$/.test(body)) {
                     body = '';
-                } else if (/^\s*[^\r\n]{1,30}\s*$/.test(body) && body.indexOf('//') === -1 && openingBrace.indexOf('{') !== -1) {
+                } else if (/^\s*[^\r\n]{1,30}\s*$/.test(body) && body.indexOf('//') === -1 && isWrappedInBraces) {
                     body = ' ' + body.trim() + ' ';
                     closingBrace = '}';
                 } else {

--- a/test/types/function-type.spec.js
+++ b/test/types/function-type.spec.js
@@ -161,6 +161,20 @@ describe('function type', function () {
     }
 
     // We can't complete this test if the runtime doesn't support arrow functions:
+    var implicitReturnMultilineArrowFunction;
+    try {
+        implicitReturnMultilineArrowFunction = new Function(
+            'return a => \n    a + 1;'
+        )();
+    } catch (e) {}
+
+    if (implicitReturnMultilineArrowFunction) {
+        it('should render an implicit return multiline arrow function', function () {
+            expect(implicitReturnMultilineArrowFunction, 'to inspect as', 'a => \n     a + 1');
+        });
+    }
+
+    // We can't complete this test if the runtime doesn't support arrow functions:
     var multiParamArrowFunction;
     try {
         multiParamArrowFunction = new Function('return (a, b) => a + b;')();

--- a/test/types/function-type.spec.js
+++ b/test/types/function-type.spec.js
@@ -175,6 +175,20 @@ describe('function type', function () {
     }
 
     // We can't complete this test if the runtime doesn't support arrow functions:
+    var evilImplicitReturnMultilineArrowFunction;
+    try {
+        evilImplicitReturnMultilineArrowFunction = new Function(
+            'return a => \n    a || {};'
+        )();
+    } catch (e) {}
+
+    if (evilImplicitReturnMultilineArrowFunction) {
+        it('should render an implicit return multiline arrow function with an evil alternation', function () {
+            expect(evilImplicitReturnMultilineArrowFunction, 'to inspect as', 'a => \n    a || {};');
+        });
+    }
+
+    // We can't complete this test if the runtime doesn't support arrow functions:
     var multiParamArrowFunction;
     try {
         multiParamArrowFunction = new Function('return (a, b) => a + b;')();

--- a/test/types/function-type.spec.js
+++ b/test/types/function-type.spec.js
@@ -170,7 +170,7 @@ describe('function type', function () {
 
     if (implicitReturnMultilineArrowFunction) {
         it('should render an implicit return multiline arrow function', function () {
-            expect(implicitReturnMultilineArrowFunction, 'to inspect as', 'a => \n     a + 1');
+            expect(implicitReturnMultilineArrowFunction, 'to inspect as', 'a => \n    a + 1');
         });
     }
 

--- a/test/types/function-type.spec.js
+++ b/test/types/function-type.spec.js
@@ -184,7 +184,7 @@ describe('function type', function () {
 
     if (evilImplicitReturnMultilineArrowFunction) {
         it('should render an implicit return multiline arrow function with an evil alternation', function () {
-            expect(evilImplicitReturnMultilineArrowFunction, 'to inspect as', 'a => \n    a || {};');
+            expect(evilImplicitReturnMultilineArrowFunction, 'to inspect as', 'a => \n    a || {}');
         });
     }
 


### PR DESCRIPTION
Before the fix, the added test would fail with the following error:

```js
expect(
  a =>
    a + 1,
  'to inspect as',
  'a => \n     a + 1'
);
```

```

  1) function type should render an implicit return multiline arrow function:
     TypeError: Cannot read property 'length' of undefined
      at Object.inspect (lib/types.js:790:70)
      at Object.extendedType.inspect (lib/Unexpected.js:738:36)
      at printOutput (lib/Unexpected.js:314:24)
      at Function.Unexpected.inspect (lib/Unexpected.js:328:12)
      at Function.<anonymous> (test/common.js:10:19)
      at executeExpect (lib/Unexpected.js:1205:50)
      at Unexpected.expect (lib/Unexpected.js:1209:22)
      at expect (lib/Unexpected.js:849:27)
      at Context.<anonymous> (test/types/function-type.spec.js:172:13)
```