### PR TITLE
Don't break when a function has its own custom #toString

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -760,7 +760,8 @@ module.exports = function (expect) {
             return a === b;
         },
         inspect: function (f, depth, output, inspect) {
-            var source = f.toString().replace(/\r\n?|\n\r?/g, '\n');
+            // Don't break when a function has its own custom #toString:
+            var source = Function.prototype.toString.call(f).replace(/\r\n?|\n\r?/g, '\n');
             var name = utils.getFunctionName(f) || '';
             var preamble;
             var body;

--- a/test/api/inspect.spec.js
+++ b/test/api/inspect.spec.js
@@ -328,23 +328,6 @@ describe('inspect', function () {
         });
     }
 
-    it('should output ellipsis when the toString method of a function returns something unparsable', function () {
-        function foo() {}
-        foo.toString = function () {
-            return 'quux';
-        };
-        expect(foo, 'to inspect as', 'function foo( /*...*/ ) { /*...*/ }');
-    });
-
-    it('should render a function within a nested structure ellipsis when the toString method of a function returns something unparsable', function () {
-        function foo() {}
-        foo.toString = function () {
-            return 'quux';
-        };
-        expect({ bar: { quux: foo } }, 'to inspect as',
-               '{ bar: { quux: function foo( /*...*/ ) { /*...*/ } } }');
-    });
-
     it('should bail out of removing the indentation of functions that use multiline string literals', function () {
         /*eslint-disable no-multi-str*/
         expect(function () {

--- a/test/types/function-type.spec.js
+++ b/test/types/function-type.spec.js
@@ -16,6 +16,16 @@ describe('function type', function () {
         );
     });
 
+    it('should inspect a function with a custom toString correctly', function () {
+        var fn = function foo() {};
+        fn.toString = 'breakage';
+        expect(
+            fn,
+            'to inspect as',
+            'function foo() {}'
+        );
+    });
+
     var isNodeJs3OrBelow = typeof process === 'object' && /^v[0123]\./.test(process.version);
     var isPhantomJs = typeof navigator !== 'undefined' && /phantom/i.test(navigator.userAgent);
     if (!isNodeJs3OrBelow && !isPhantomJs) {


### PR DESCRIPTION
I ran into a problem with chance-generators instances being inspected as `function ( /*...*/ ) { /*...*/ }`. Turns out it's because [chance-generators defines a custom `toString`](https://github.com/sunesimonsen/chance-generators/blob/dd59a69190ba8ee47fb2c1dede48261b8d8122f5/lib/chance-generators.js#L65-L67).

The enclosed fix handles that by getting the `toString` from `Function.prototype` instead.