### PR TITLE
Remove user defined addAssertion handlers from stack

### DIFF
--- a/lib/UnexpectedError.js
+++ b/lib/UnexpectedError.js
@@ -241,21 +241,16 @@ UnexpectedError.prototype.serializeMessage = function (outputFormat) {
         }
 
         if (this.stack && !this.useFullStackTrace) {
-            var newStack = [];
-            var removedFrames = false;
             var lines = this.stack.split(/\n/);
-
             var stackStart = findStackStart(lines);
 
-            lines.forEach(function (line, i) {
-                if (stackStart <= i && (/node_modules\/unexpected(?:-[^\/]+)?\//).test(line)) {
-                    removedFrames = true;
-                } else {
-                    newStack.push(line);
-                }
-            });
+            var newStack = lines.filter((line, i) => (
+              i < stackStart ||
+                (!(/node_modules\/unexpected(?:-[^\/]+)?\//).test(line) &&
+                 !(/executeExpect.*node_modules\/unexpected\//).test(lines[i + 1]))
+            ));
 
-            if (removedFrames) {
+            if (newStack.length !== lines.length) {
                 var indentation = (/^(\s*)/).exec(lines[lines.length - 1])[1];
 
                 if (outputFormat === 'html') {

--- a/test/api/UnexpectedError.spec.js
+++ b/test/api/UnexpectedError.spec.js
@@ -65,6 +65,36 @@ describe('UnexpectedError', function () {
             });
         });
 
+        it('trims the stack for custom assertions in the consuming code', () => {
+            expect(function () {
+                expect.fail('wat');
+            }, 'to throw', function (err) {
+                err.useFullStackTrace = false;
+                err._hasSerializedErrorMessage = false;
+                err.stack =
+                    'wat\n' +
+                    '      at oathbreaker (node_modules/unexpected/lib/oathbreaker.js:46:19)\n' +
+                    '      at Function.Unexpected.withError (node_modules/unexpected-sinon/lib/unexpected-sinon.js:123:1)\n' +
+                    '      at Function.Unexpected.withError (node_modules/unexpected/lib/Unexpected.js:792:12)\n' +
+                    '      at Function.<anonymous> (node_modules/unexpected/lib/assertions.js:569:16)\n' +
+                    '      at functionCalledByCustomHandler (test/my.spec.js:42:666)\n' +
+                    '      at myCustomHandler (test/assertions.js:666:42)\n' +
+                    '      at executeExpect (node_modules/unexpected/lib/Unexpected.js:1103:50)\n' +
+                    '      at Unexpected.expect (node_modules/unexpected/lib/Unexpected.js:1111:22)\n' +
+                    '      at Context.<anonymous> (test/my.spec.js:48:17)';
+
+                err.serializeMessage('text');
+
+                expect(err, 'to satisfy', {
+                    stack:
+                        'wat\n' +
+                        '      at functionCalledByCustomHandler (test/my.spec.js:42:666)\n' +
+                        '      at Context.<anonymous> (test/my.spec.js:48:17)\n' +
+                        '      set UNEXPECTED_FULL_TRACE=true to see the full stack trace'
+                });
+            });
+        });
+
         describe('and the output format is set to html', function () {
             it('shows a helping message about how to turn of stack trace trimming', function () {
                 expect(function () {


### PR DESCRIPTION
This should fix the problem of the stack including references to user defined assertion handlers.
The reason this is important now, is that the newest Jest will show the top line in the stack trace below the error:

<img width="634" alt="screen shot 2018-01-29 at 21 37 50" src="https://user-images.githubusercontent.com/90802/35641649-1165c8f0-06c1-11e8-8a27-02a8217fd495.png">

But as you can see this points to a user defined assertion which doesn't make a lot of sense.

This is how it would look after this update:

<img width="616" alt="screen shot 2018-01-31 at 20 30 06" src="https://user-images.githubusercontent.com/90802/35643122-9b92aed6-06c5-11e8-975a-7617646af5a4.png">
