### PR TITLE
Additional object type overrides

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -458,7 +458,8 @@ module.exports = expect => {
                     output
                       .i()
                       .block(function() {
-                        this.property(
+                        subjectType.property(
+                          this,
                           key,
                           inspect(subject[key]),
                           subjectIsArrayLike
@@ -1619,11 +1620,13 @@ module.exports = expect => {
                       } else {
                         return output.clone().block(function() {
                           if (type === 'moveSource') {
-                            this.property(
-                              diffItem.actualIndex,
-                              inspect(diffItem.value),
-                              true
-                            )
+                            subjectType
+                              .property(
+                                this,
+                                diffItem.actualIndex,
+                                inspect(diffItem.value),
+                                true
+                              )
                               .amend(delimiterOutput.sp())
                               .error('// should be moved');
                           } else if (type === 'insert') {
@@ -1635,30 +1638,43 @@ module.exports = expect => {
                               if (
                                 expect.findTypeOf(diffItem.value).is('function')
                               ) {
-                                this.error('missing: ').property(
+                                subjectType.property(
+                                  this,
                                   index,
-                                  output.clone().block(function() {
-                                    this.omitSubject = undefined;
-                                    const promise =
-                                      keyPromises[diffItem.expectedIndex];
-                                    if (promise.isRejected()) {
-                                      this.appendErrorMessage(promise.reason());
-                                    } else {
-                                      this.appendInspected(diffItem.value);
-                                    }
-                                  }),
+                                  output
+                                    .clone()
+                                    .error('missing: ')
+                                    .block(function() {
+                                      this.omitSubject = undefined;
+                                      const promise =
+                                        keyPromises[diffItem.expectedIndex];
+                                      if (promise.isRejected()) {
+                                        this.appendErrorMessage(
+                                          promise.reason()
+                                        );
+                                      } else {
+                                        this.appendInspected(diffItem.value);
+                                      }
+                                    }),
                                   true
                                 );
                               } else {
-                                this.error('missing ').property(
-                                  index,
-                                  inspect(diffItem.value),
-                                  true
+                                var propertyOutput = output
+                                  .clone()
+                                  .error('missing ');
+                                this.append(
+                                  subjectType.property(
+                                    propertyOutput,
+                                    index,
+                                    inspect(diffItem.value),
+                                    true
+                                  )
                                 );
                               }
                             });
                           } else {
-                            this.property(
+                            subjectType.property(
+                              this,
                               diffItem.actualIndex,
                               output.clone().block(function() {
                                 if (type === 'remove') {
@@ -1963,7 +1979,12 @@ module.exports = expect => {
                         valueOutput = output.clone().block(valueOutput);
                       }
 
-                      this.property(key, valueOutput, subjectIsArrayLike);
+                      subjectType.property(
+                        this,
+                        key,
+                        valueOutput,
+                        subjectIsArrayLike
+                      );
                     });
                 });
 

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1410,29 +1410,28 @@ module.exports = expect => {
     '<array-like> to [exhaustively] satisfy <array-like>',
     (expect, subject, value) => {
       expect.errorMode = 'bubble';
-      let i;
       const subjectType = expect.subjectType;
+      const subjectKeys = subjectType.getKeys(subject);
       const valueType = expect.argTypes[0];
       const valueKeys = valueType.getKeys(value).filter(
         key =>
           utils.numericalRegExp.test(key) ||
           typeof key === 'symbol' ||
           // include keys whose value is not undefined on either LHS or RHS
-          typeof value[key] !== 'undefined' ||
-          typeof subject[key] !== 'undefined'
+          typeof valueType.valueForKey(value, key) !== 'undefined' ||
+          typeof subjectType.valueForKey(subject, key) !== 'undefined'
       );
       const keyPromises = {};
-      valueKeys.forEach(valueKey => {
-        keyPromises[valueKey] = expect.promise(() => {
-          const valueKeyType = expect.findTypeOf(value[valueKey]);
+      valueKeys.forEach(function(keyInValue) {
+        keyPromises[keyInValue] = expect.promise(function() {
+          const subjectKey = subjectType.valueForKey(subject, keyInValue);
+          const valueKey = valueType.valueForKey(value, keyInValue);
+          const valueKeyType = expect.findTypeOf(valueKey);
+
           if (valueKeyType.is('function')) {
-            return value[valueKey](subject[valueKey]);
+            return valueKey(subjectKey);
           } else {
-            return expect(
-              subject[valueKey],
-              'to [exhaustively] satisfy',
-              value[valueKey]
-            );
+            return expect(subjectKey, 'to [exhaustively] satisfy', valueKey);
           }
         });
       });
@@ -1457,7 +1456,7 @@ module.exports = expect => {
               key =>
                 utils.numericalRegExp.test(key) ||
                 typeof key === 'symbol' ||
-                typeof subject[key] !== 'undefined' ||
+                typeof subjectType.valueForKey(subject, key) !== 'undefined' ||
                 remainingKeysInSubject[key] === 2
             );
             // key checking succeeds with no outstanding keys
@@ -1465,8 +1464,9 @@ module.exports = expect => {
           }),
           expect.promise.all(keyPromises)
         ])
-        .caught(() =>
-          expect.promise.settle(keyPromises).then(() => {
+        .caught(() => {
+          let i = 0;
+          return expect.promise.settle(keyPromises).then(() => {
             const toSatisfyMatrix = new Array(subject.length);
             for (i = 0; i < subject.length; i += 1) {
               toSatisfyMatrix[i] = new Array(value.length);
@@ -1508,16 +1508,20 @@ module.exports = expect => {
             }
 
             let isAsync = false;
+            const subjectElements = utils.duplicateArrayLikeUsingType(
+              subject,
+              subjectType
+            );
+            const valueElements = utils.duplicateArrayLikeUsingType(
+              value,
+              valueType
+            );
             const nonNumericalKeysAndSymbols =
               !subjectType.numericalPropertiesOnly &&
-              utils.uniqueNonNumericalStringsAndSymbols(
-                subjectType.getKeys(subject),
-                valueType.getKeys(value)
-              );
+              utils.uniqueNonNumericalStringsAndSymbols(subjectKeys, valueKeys);
 
             const changes = arrayChanges(
-              subject,
-              value,
+              subjectElements, valueElements,
               function equal(a, b, aIndex, bIndex) {
                 toSatisfyMatrix[aIndex] = toSatisfyMatrix[aIndex] || [];
                 const existingResult = toSatisfyMatrix[aIndex][bIndex];
@@ -1753,8 +1757,8 @@ module.exports = expect => {
                 }
               });
             }
-          })
-        );
+          });
+        });
     }
   );
 

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1788,18 +1788,16 @@ module.exports = expect => {
 
       keys.forEach((key, index) => {
         promiseByKey[key] = expect.promise(() => {
-          const valueKeyType = expect.findTypeOf(value[key]);
+          const subjectKey = subjectType.valueForKey(subject, key);
+          const valueKey = valueType.valueForKey(value, key);
+          const valueKeyType = expect.findTypeOf(valueKey);
           if (valueKeyType.is('expect.it')) {
             expect.context.thisObject = subject;
-            return value[key](subject[key], expect.context);
+            return valueKey(subjectKey, expect.context);
           } else if (valueKeyType.is('function')) {
-            return value[key](subject[key]);
+            return valueKey(subjectKey);
           } else {
-            return expect(
-              subject[key],
-              'to [exhaustively] satisfy',
-              value[key]
-            );
+            return expect(subjectKey, 'to [exhaustively] satisfy', valueKey);
           }
         });
       });
@@ -1814,10 +1812,11 @@ module.exports = expect => {
                   typeof subject[key] !== 'undefined'
               );
               const valueKeysWithDefinedValues = keys.filter(
-                key => typeof value[key] !== 'undefined'
+                key => typeof valueType.valueForKey(value, key) !== 'undefined'
               );
               const subjectKeysWithDefinedValues = subjectKeys.filter(
-                key => typeof subject[key] !== 'undefined'
+                key =>
+                  typeof subjectType.valueForKey(subject, key) !== 'undefined'
               );
               expect(
                 valueKeysWithDefinedValues.length -
@@ -1835,16 +1834,16 @@ module.exports = expect => {
               diff(output, diff, inspect, equal) {
                 output.inline = true;
                 const subjectIsArrayLike = subjectType.is('array-like');
-                const keys = utils
-                  .uniqueStringsAndSymbols(
-                    subjectKeys,
-                    valueType.getKeys(value)
-                  )
-                  .filter(
-                    (
-                      key // Skip missing keys expected to be missing so they don't get rendered in the diff
-                    ) => key in subject || typeof value[key] !== 'undefined'
-                  );
+                const valueKeys = valueType.getKeys(value);
+                const keys = subjectType
+                  .uniqueKeys(subjectKeys, valueKeys)
+                  .filter(key => {
+                    // Skip missing keys expected to be missing so they don't get rendered in the diff
+                    return (
+                      subjectType.hasKey(subject, key) ||
+                      typeof valueType.valueForKey(value, key) !== 'undefined'
+                    );
+                  });
                 const prefixOutput = subjectType.prefix(
                   output.clone(),
                   subject
@@ -1855,6 +1854,8 @@ module.exports = expect => {
                   output.indentLines();
                 }
                 keys.forEach((key, index) => {
+                  const subjectKey = subjectType.valueForKey(subject, key);
+                  const valueKey = valueType.valueForKey(value, key);
                   output
                     .nl(index > 0 ? 1 : 0)
                     .i()
@@ -1874,19 +1875,20 @@ module.exports = expect => {
                       }
 
                       const missingArrayIndex =
-                        subjectType.is('array-like') && !(key in subject);
+                        subjectType.is('array-like') &&
+                        !subjectType.hasKey(subject, key);
 
                       let isInlineDiff = true;
 
-                      output.omitSubject = subject[key];
-                      if (!(key in value)) {
+                      output.omitSubject = subjectKey;
+                      if (!valueType.hasKey(value, key)) {
                         if (expect.flags.exhaustively) {
                           annotation.error('should be removed');
                         } else {
                           conflicting = null;
                         }
-                      } else if (!(key in subject)) {
-                        if (expect.findTypeOf(value[key]).is('function')) {
+                      } else if (!subjectType.hasKey(subject, key)) {
+                        if (expect.findTypeOf(valueKey).is('function')) {
                           if (promiseByKey[key].isRejected()) {
                             output.error('// missing:').sp();
                             valueOutput = output
@@ -1902,7 +1904,7 @@ module.exports = expect => {
                           }
                         } else {
                           output.error('// missing').sp();
-                          valueOutput = inspect(value[key]);
+                          valueOutput = inspect(valueKey);
                         }
                       } else if (conflicting || missingArrayIndex) {
                         const keyDiff =
@@ -1913,7 +1915,7 @@ module.exports = expect => {
                         }
                         if (keyDiff && keyDiff.inline) {
                           valueOutput = keyDiff;
-                        } else if (typeof value[key] === 'function') {
+                        } else if (typeof valueKey === 'function') {
                           isInlineDiff = false;
                           annotation.appendErrorMessage(conflicting);
                         } else if (!keyDiff || (keyDiff && !keyDiff.inline)) {
@@ -1923,7 +1925,7 @@ module.exports = expect => {
                                 'should satisfy'
                             )
                             .sp()
-                            .block(inspect(value[key]));
+                            .block(inspect(valueKey));
 
                           if (keyDiff) {
                             annotation.nl(2).append(keyDiff);
@@ -1934,10 +1936,13 @@ module.exports = expect => {
                       }
 
                       if (!valueOutput) {
-                        if (missingArrayIndex || !(key in subject)) {
+                        if (
+                          missingArrayIndex ||
+                          !subjectType.hasKey(subject, key)
+                        ) {
                           valueOutput = output.clone();
                         } else {
-                          valueOutput = inspect(subject[key]);
+                          valueOutput = inspect(subjectKey);
                         }
                       }
 

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -122,7 +122,11 @@ module.exports = expect => {
       .jsString("'");
   });
 
-  expect.addStyle('property', function(key, inspectedValue, isArrayLike) {
+  expect.addStyle('propertyForObject', function(
+    key,
+    inspectedValue,
+    isArrayLike
+  ) {
     let keyOmitted = false;
     let isSymbol;
     isSymbol = typeof key === 'symbol';

--- a/lib/types.js
+++ b/lib/types.js
@@ -187,7 +187,7 @@ module.exports = function(expect) {
       // possibly expensive deep test
       for (let j = 0; j < actualKeys.length; j += 1) {
         const key = actualKeys[j];
-        if (!equal(a[key], b[key])) {
+        if (!equal(this.valueForKey(a, key), this.valueForKey(b, key))) {
           return false;
         }
       }
@@ -215,10 +215,8 @@ module.exports = function(expect) {
         let value;
         if (hasSetter && !hasGetter) {
           value = hasSetter;
-        } else if (typeof type.valueForKey === 'function') {
-          value = type.valueForKey(obj, key);
         } else {
-          value = obj[key];
+          value = type.valueForKey(obj, key);
         }
 
         let inspectedValue = inspect(value);
@@ -335,22 +333,17 @@ module.exports = function(expect) {
         output.indentLines();
       }
       const type = this;
-      const hasValueForKey = typeof type.valueForKey === 'function';
       keys.forEach((key, index) => {
         output
           .nl(index > 0 ? 1 : 0)
           .i()
           .block(function() {
-            var valueActual = hasValueForKey
-              ? type.valueForKey(actual, key)
-              : actual[key];
-            var valueExpected = hasValueForKey
-              ? type.valueForKey(expected, key)
-              : expected[key];
-            let valueOutput;
+            const valueActual = type.valueForKey(actual, key);
+            const valueExpected = type.valueForKey(expected, key);
             const annotation = output.clone();
             const conflicting = !equal(valueActual, valueExpected);
             let isInlineDiff = false;
+            let valueOutput;
             if (conflicting) {
               if (!(key in expected)) {
                 annotation.error('should be removed');
@@ -436,7 +429,9 @@ module.exports = function(expect) {
       });
     },
     uniqueKeys: utils.uniqueStringsAndSymbols,
-    valueForKey: null
+    valueForKey(obj, key) {
+      return obj[key];
+    }
   });
 
   expect.addType({

--- a/lib/types.js
+++ b/lib/types.js
@@ -163,10 +163,10 @@ module.exports = function(expect) {
       }
 
       const actualKeys = this.getKeys(a).filter(
-        key => typeof a[key] !== 'undefined'
+        key => typeof this.valueForKey(a, key) !== 'undefined'
       );
       const expectedKeys = this.getKeys(b).filter(
-        key => typeof b[key] !== 'undefined'
+        key => typeof this.valueForKey(b, key) !== 'undefined'
       );
 
       // having the same number of owned properties (keys incorporates hasOwnProperty)

--- a/lib/types.js
+++ b/lib/types.js
@@ -193,6 +193,9 @@ module.exports = function(expect) {
       }
       return true;
     },
+    hasKey(obj, key) {
+      return key in obj;
+    },
     inspect(obj, depth, output, inspect) {
       const keys = this.getKeys(obj);
       if (keys.length === 0) {
@@ -422,7 +425,7 @@ module.exports = function(expect) {
         Math.max(aKeys.length, bKeys.length) / 2
       );
       return aKeys.concat(bKeys).some(key => {
-        if (key in a && key in b) {
+        if (this.hasKey(a, key) && this.hasKey(b, key)) {
           numberOfSimilarKeys += 1;
         }
         return numberOfSimilarKeys >= requiredSimilarKeys;

--- a/lib/types.js
+++ b/lib/types.js
@@ -494,30 +494,36 @@ module.exports = function(expect) {
 
         // compare numerically indexed elements
         for (i = 0; i < a.length; i += 1) {
-          if (!equal(a[i], b[i])) {
+          if (!equal(this.valueForKey(a, i), this.valueForKey(b, i))) {
             return false;
           }
         }
 
         // compare non-numerical keys if enabled for the type
         if (!this.numericalPropertiesOnly) {
-          const aKeys = this.getKeysNonNumerical(a).filter(
-            (
-              key // include keys whose value is not undefined
-            ) => typeof a[key] !== 'undefined'
-          );
-          const bKeys = this.getKeysNonNumerical(b).filter(
-            (
-              key // include keys whose value is not undefined on either LHS or RHS
-            ) => typeof b[key] !== 'undefined' || typeof a[key] !== 'undefined'
-          );
+          const aKeys = this.getKeysNonNumerical(a).filter(key => {
+            // include keys whose value is not undefined
+            return typeof this.valueForKey(a, key) !== 'undefined';
+          });
+          const bKeys = this.getKeysNonNumerical(b).filter(key => {
+            // include keys whose value is not undefined on either LHS or RHS
+            return (
+              typeof this.valueForKey(b, key) !== 'undefined' ||
+              typeof this.valueForKey(a, key) !== 'undefined'
+            );
+          });
 
           if (aKeys.length !== bKeys.length) {
             return false;
           }
 
           for (i = 0; i < aKeys.length; i += 1) {
-            if (!equal(a[aKeys[i]], b[aKeys[i]])) {
+            if (
+              !equal(
+                this.valueForKey(a, aKeys[i]),
+                this.valueForKey(b, bKeys[i])
+              )
+            ) {
               return false;
             }
           }
@@ -551,8 +557,8 @@ module.exports = function(expect) {
 
       const inspectedItems = keys.map(key => {
         let inspectedValue;
-        if (key in arr) {
-          inspectedValue = inspect(arr[key]);
+        if (this.hasKey(arr, key)) {
+          inspectedValue = inspect(this.valueForKey(arr, key));
         } else if (utils.numericalRegExp.test(key)) {
           // Sparse array entry
           inspectedValue = output.clone();
@@ -637,17 +643,18 @@ module.exports = function(expect) {
         output.indentLines();
       }
 
-      const nonNumericalKeysAndSymbols =
+      var actualElements = utils.duplicateArrayLikeUsingType(actual, this);
+      var actualKeys = this.getKeys(actual);
+      var expectedElements = utils.duplicateArrayLikeUsingType(expected, this);
+      var expectedKeys = this.getKeys(expected);
+      var nonNumericalKeysAndSymbols =
         !this.numericalPropertiesOnly &&
-        utils.uniqueNonNumericalStringsAndSymbols(
-          this.getKeys(actual),
-          this.getKeys(expected)
-        );
+        utils.uniqueNonNumericalStringsAndSymbols(actualKeys, expectedKeys);
 
       const type = this;
       const changes = arrayChanges(
-        actual,
-        expected,
+        actualElements,
+        expectedElements,
         equal,
         (a, b) => type.similar(a, b),
         {

--- a/lib/types.js
+++ b/lib/types.js
@@ -78,7 +78,6 @@ module.exports = function(expect) {
     identify(obj) {
       return obj && typeof obj === 'object';
     },
-    propertyStyle: 'property',
     prefix(output, obj) {
       const constructor = obj.constructor;
       const constructorName =
@@ -90,6 +89,9 @@ module.exports = function(expect) {
         output.text(`${constructorName}(`);
       }
       return output.text('{');
+    },
+    property(output, key, inspectedValue, isArrayLike) {
+      return output.propertyForObject(key, inspectedValue, isArrayLike);
     },
     suffix(output, obj) {
       output.text('}');
@@ -223,7 +225,7 @@ module.exports = function(expect) {
         if (value && value._expectIt) {
           inspectedValue = output.clone().block(inspectedValue);
         }
-        propertyOutput[type.propertyStyle](key, inspectedValue);
+        type.property(propertyOutput, key, inspectedValue);
 
         propertyOutput.amend(
           type.delimiter(output.clone(), index, keys.length)
@@ -383,7 +385,7 @@ module.exports = function(expect) {
             if (!isInlineDiff) {
               valueOutput = output.clone().block(valueOutput);
             }
-            this[type.propertyStyle](key, valueOutput);
+            type.property(this, key, valueOutput);
             if (!annotation.isEmpty()) {
               this.sp().annotationBlock(annotation);
             }
@@ -560,7 +562,7 @@ module.exports = function(expect) {
           // Not present non-numerical property returned by getKeys
           inspectedValue = inspect(undefined);
         }
-        return output.clone().property(key, inspectedValue, true);
+        return this.property(output.clone(), key, inspectedValue, true);
       });
 
       const currentDepth = defaultDepth - Math.min(defaultDepth, depth);
@@ -578,9 +580,8 @@ module.exports = function(expect) {
           width += size.width;
           return width > maxLineLength;
         });
-      const type = this;
       inspectedItems.forEach((inspectedItem, index) => {
-        inspectedItem.amend(type.delimiter(output.clone(), index, keys.length));
+        inspectedItem.amend(this.delimiter(output.clone(), index, keys.length));
       });
       if (multipleLines) {
         output.append(prefixOutput);
@@ -674,11 +675,13 @@ module.exports = function(expect) {
           } else {
             return output.clone().block(function() {
               if (diffItem.type === 'moveSource') {
-                this.property(
-                  diffItem.actualIndex,
-                  inspect(diffItem.value),
-                  true
-                )
+                type
+                  .property(
+                    this,
+                    diffItem.actualIndex,
+                    inspect(diffItem.value),
+                    true
+                  )
                   .amend(delimiterOutput.sp())
                   .error('// should be moved');
               } else if (diffItem.type === 'insert') {
@@ -688,31 +691,37 @@ module.exports = function(expect) {
                       typeof diffItem.actualIndex !== 'undefined'
                         ? diffItem.actualIndex
                         : diffItem.expectedIndex;
-                    this.property(index, inspect(diffItem.value), true);
+                    type.property(this, index, inspect(diffItem.value), true);
                   });
                 });
               } else if (diffItem.type === 'remove') {
                 this.block(function() {
-                  this.property(
-                    diffItem.actualIndex,
-                    inspect(diffItem.value),
-                    true
-                  )
+                  type
+                    .property(
+                      this,
+                      diffItem.actualIndex,
+                      inspect(diffItem.value),
+                      true
+                    )
                     .amend(delimiterOutput.sp())
                     .error('// should be removed');
                 });
               } else if (diffItem.type === 'equal') {
                 this.block(function() {
-                  this.property(
-                    diffItem.actualIndex,
-                    inspect(diffItem.value),
-                    true
-                  ).amend(delimiterOutput);
+                  type
+                    .property(
+                      this,
+                      diffItem.actualIndex,
+                      inspect(diffItem.value),
+                      true
+                    )
+                    .amend(delimiterOutput);
                 });
               } else {
                 this.block(function() {
                   const valueDiff = diff(diffItem.value, diffItem.expected);
-                  this.property(
+                  type.property(
+                    this,
                     diffItem.actualIndex,
                     output.clone().block(function() {
                       if (valueDiff && valueDiff.inline) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -71,38 +71,6 @@ module.exports = function(expect) {
     });
   }
 
-  // If Symbol support is not detected, default to passing undefined to
-  // Array.prototype.sort, which means "natural" (asciibetical) sort.
-  let keyComparator;
-  if (typeof Symbol === 'function') {
-    // Comparator that puts symbols last:
-    keyComparator = (a, b) => {
-      let aIsSymbol, bIsSymbol;
-      let aString = a;
-      let bString = b;
-      aIsSymbol = typeof a === 'symbol';
-      bIsSymbol = typeof b === 'symbol';
-      if (aIsSymbol) {
-        if (bIsSymbol) {
-          aString = a.toString();
-          bString = b.toString();
-        } else {
-          return 1;
-        }
-      } else if (bIsSymbol) {
-        return -1;
-      }
-
-      if (aString < bString) {
-        return -1;
-      } else if (aString > bString) {
-        return 1;
-      }
-
-      return 0;
-    };
-  }
-
   expect.addType({
     name: 'object',
     indent: true,
@@ -110,6 +78,7 @@ module.exports = function(expect) {
     identify(obj) {
       return obj && typeof obj === 'object';
     },
+    propertyStyle: 'property',
     prefix(output, obj) {
       const constructor = obj.constructor;
       const constructorName =
@@ -152,6 +121,36 @@ module.exports = function(expect) {
           }
         }
       : Object.keys,
+    // If Symbol support is not detected default to undefined which, when
+    // passed to Array.prototype.sort, means "natural" (asciibetical) sort.
+    keyComparator:
+      typeof Symbol === 'function'
+        ? (a, b) => {
+            let aIsSymbol, bIsSymbol;
+            let aString = a;
+            let bString = b;
+            aIsSymbol = typeof a === 'symbol';
+            bIsSymbol = typeof b === 'symbol';
+            if (aIsSymbol) {
+              if (bIsSymbol) {
+                aString = a.toString();
+                bString = b.toString();
+              } else {
+                return 1;
+              }
+            } else if (bIsSymbol) {
+              return -1;
+            }
+
+            if (aString < bString) {
+              return -1;
+            } else if (aString > bString) {
+              return 1;
+            }
+
+            return 0;
+          }
+        : null,
     equal(a, b, equal) {
       if (a === b) {
         return true;
@@ -173,8 +172,8 @@ module.exports = function(expect) {
         return false;
       }
       //the same set of keys (although not necessarily the same order),
-      actualKeys.sort(keyComparator);
-      expectedKeys.sort(keyComparator);
+      actualKeys.sort(this.keyComparator);
+      expectedKeys.sort(this.keyComparator);
       // cheap key test
       for (let i = 0; i < actualKeys.length; i += 1) {
         if (actualKeys[i] !== expectedKeys[i]) {
@@ -211,13 +210,20 @@ module.exports = function(expect) {
           propertyOutput.text('set').sp();
         }
         // Inspect the setter function if there's no getter:
-        const value = hasSetter && !hasGetter ? hasSetter : obj[key];
+        let value;
+        if (hasSetter && !hasGetter) {
+          value = hasSetter;
+        } else if (typeof type.valueForKey === 'function') {
+          value = type.valueForKey(obj, key);
+        } else {
+          value = obj[key];
+        }
 
         let inspectedValue = inspect(value);
         if (value && value._expectIt) {
           inspectedValue = output.clone().block(inspectedValue);
         }
-        propertyOutput.property(key, inspectedValue);
+        propertyOutput[type.propertyStyle](key, inspectedValue);
 
         propertyOutput.amend(
           type.delimiter(output.clone(), index, keys.length)
@@ -318,10 +324,8 @@ module.exports = function(expect) {
 
       output.inline = true;
       const actualKeys = this.getKeys(actual);
-      const keys = utils.uniqueStringsAndSymbols(
-        actualKeys,
-        this.getKeys(expected)
-      );
+      const expectedKeys = this.getKeys(expected);
+      const keys = this.uniqueKeys(actualKeys, expectedKeys);
       const prefixOutput = this.prefix(output.clone(), actual);
       output.append(prefixOutput).nl(prefixOutput.isEmpty() ? 0 : 1);
 
@@ -329,14 +333,21 @@ module.exports = function(expect) {
         output.indentLines();
       }
       const type = this;
+      const hasValueForKey = typeof type.valueForKey === 'function';
       keys.forEach((key, index) => {
         output
           .nl(index > 0 ? 1 : 0)
           .i()
           .block(function() {
+            var valueActual = hasValueForKey
+              ? type.valueForKey(actual, key)
+              : actual[key];
+            var valueExpected = hasValueForKey
+              ? type.valueForKey(expected, key)
+              : expected[key];
             let valueOutput;
             const annotation = output.clone();
-            const conflicting = !equal(actual[key], expected[key]);
+            const conflicting = !equal(valueActual, valueExpected);
             let isInlineDiff = false;
             if (conflicting) {
               if (!(key in expected)) {
@@ -344,12 +355,12 @@ module.exports = function(expect) {
                 isInlineDiff = true;
               } else if (!(key in actual)) {
                 this.error('// missing').sp();
-                valueOutput = output.clone().appendInspected(expected[key]);
+                valueOutput = output.clone().appendInspected(valueExpected);
                 isInlineDiff = true;
               } else {
-                const keyDiff = diff(actual[key], expected[key]);
+                const keyDiff = diff(valueActual, valueExpected);
                 if (!keyDiff || (keyDiff && !keyDiff.inline)) {
-                  annotation.shouldEqualError(expected[key]);
+                  annotation.shouldEqualError(valueExpected);
                   if (keyDiff) {
                     annotation.nl(2).append(keyDiff);
                   }
@@ -363,7 +374,7 @@ module.exports = function(expect) {
             }
 
             if (!valueOutput) {
-              valueOutput = inspect(actual[key], conflicting ? Infinity : null);
+              valueOutput = inspect(valueActual, conflicting ? Infinity : null);
             }
 
             valueOutput.amend(
@@ -372,7 +383,7 @@ module.exports = function(expect) {
             if (!isInlineDiff) {
               valueOutput = output.clone().block(valueOutput);
             }
-            this.property(key, valueOutput);
+            this[type.propertyStyle](key, valueOutput);
             if (!annotation.isEmpty()) {
               this.sp().annotationBlock(annotation);
             }
@@ -385,7 +396,6 @@ module.exports = function(expect) {
       const suffixOutput = this.suffix(output.clone(), actual);
       return output.nl(suffixOutput.isEmpty() ? 0 : 1).append(suffixOutput);
     },
-
     similar(a, b) {
       if (a === null || b === null) {
         return false;
@@ -422,7 +432,9 @@ module.exports = function(expect) {
         }
         return numberOfSimilarKeys >= requiredSimilarKeys;
       });
-    }
+    },
+    uniqueKeys: utils.uniqueStringsAndSymbols,
+    valueForKey: null
   });
 
   expect.addType({

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,11 +30,13 @@ const utils = (module.exports = {
   duplicateArrayLikeUsingType(obj, type) {
     var arr = new Array(obj.length);
     for (var i = 0; i < obj.length; i += 1) {
-      arr[i] = type.valueForKey(obj, i);
+      arr[i] = type.hasKey(obj, i) ? type.valueForKey(obj, i) : undefined;
     }
     Object.keys(obj).forEach(function(key) {
       if (!utils.numericalRegExp.test(key)) {
-        arr[key] = type.valueForKey(obj, key);
+        arr[key] = type.hasKey(obj, key)
+          ? type.valueForKey(obj, key)
+          : undefined;
       }
     });
     if (Object.getOwnPropertySymbols) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,6 +27,24 @@ const utils = (module.exports = {
       return a === b;
     }),
 
+  duplicateArrayLikeUsingType(obj, type) {
+    var arr = new Array(obj.length);
+    for (var i = 0; i < obj.length; i += 1) {
+      arr[i] = type.valueForKey(obj, i);
+    }
+    Object.keys(obj).forEach(function(key) {
+      if (!utils.numericalRegExp.test(key)) {
+        arr[key] = type.valueForKey(obj, key);
+      }
+    });
+    if (Object.getOwnPropertySymbols) {
+      Object.getOwnPropertySymbols(obj).forEach(function(key) {
+        arr[key] = type.valueForKey(obj, key);
+      });
+    }
+    return arr;
+  },
+
   isArray(ar) {
     return Object.prototype.toString.call(ar) === '[object Array]';
   },

--- a/test/types/array-like-type.spec.js
+++ b/test/types/array-like-type.spec.js
@@ -374,6 +374,28 @@ describe('array-like type', function() {
     });
   });
 
+  describe('with a custom subtype that comes with its own hasKey', function() {
+    it('should honour the presence of a key within inspection', function() {
+      var clonedExpect = expect.clone().addType({
+        name: 'allExceptFoo',
+        base: 'array-like',
+        identify: Array.isArray,
+        numericalPropertiesOnly: false,
+        hasKey: function(obj, key) {
+          if (String(key).indexOf('foo') === 0) {
+            return false;
+          }
+          return obj[key];
+        }
+      });
+
+      var arr = ['a'];
+      arr.fooAndBar = true;
+
+      clonedExpect(arr, 'to inspect as', "[ 'a', fooAndBar: undefined ]");
+    });
+  });
+
   describe('with a custom subtype that comes with its own valueForKeys', function() {
     it('should process the elements in both inspection and diff in "to equal"', function() {
       var clonedExpect = expect.clone().addType({

--- a/test/types/array-like-type.spec.js
+++ b/test/types/array-like-type.spec.js
@@ -374,6 +374,38 @@ describe('array-like type', function() {
     });
   });
 
+  describe('with a custom subtype that comes with its own valueForKeys', function() {
+    it('should process the elements in both inspection and diff in "to equal"', function() {
+      var clonedExpect = expect.clone().addType({
+        name: 'firstElemUpper',
+        base: 'array-like',
+        identify: Array.isArray,
+        valueForKey: function(arr, key) {
+          var value = arr[key];
+          if (key === 0) {
+            return value.toUpperCase();
+          }
+          return value;
+        }
+      });
+      expect(
+        function() {
+          clonedExpect(['foobar', 'barbar'], 'to equal', ['foobar', 'barbaz']);
+        },
+        'to throw',
+        "expected [ 'FOOBAR', 'barbar' ] to equal [ 'FOOBAR', 'barbaz' ]\n" +
+          '\n' +
+          '[\n' +
+          "  'FOOBAR',\n" +
+          "  'barbar' // should equal 'barbaz'\n" +
+          '           //\n' +
+          '           // -barbar\n' +
+          '           // +barbaz\n' +
+          ']'
+      );
+    });
+  });
+
   it('should inspect as [...] at depth 2+', function() {
     expect(
       [[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]]],

--- a/test/types/object-type.spec.js
+++ b/test/types/object-type.spec.js
@@ -42,6 +42,46 @@ describe('object type', function() {
     });
   });
 
+  describe('#equal', function() {
+    it('should ignore undefined properties on the LHS', function() {
+      expect(function() {
+        expect({ lhs: undefined }, 'to equal', {});
+      }, 'not to throw');
+    });
+
+    it('should ignore undefined properties on the RHS', function() {
+      expect(function() {
+        expect({}, 'to equal', { rhs: undefined });
+      }, 'not to throw');
+    });
+  });
+
+  describe('#getKeys', function() {
+    var clonedExpect = expect.clone();
+
+    clonedExpect.addType({
+      name: 'fooObject',
+      base: 'object',
+      identify: function(obj) {
+        return obj && typeof 'object' && obj.foo;
+      },
+      getKeys: function(obj) {
+        return Object.keys(obj).filter(function(key) {
+          return key[0] !== '_';
+        });
+      }
+    });
+
+    it('should restrict the compared properties', function() {
+      expect(function() {
+        clonedExpect({ foo: true, _bar: true }, 'to equal', {
+          foo: true,
+          _bar: false
+        });
+      }, 'not to throw');
+    });
+  });
+
   describe('with a subtype that disables indentation', function() {
     var clonedExpect = expect.clone();
 

--- a/test/types/object-type.spec.js
+++ b/test/types/object-type.spec.js
@@ -195,4 +195,49 @@ describe('object type', function() {
       );
     });
   });
+
+  describe('with a custom subtype that overrides property()', function() {
+    it('should bar', function() {
+      var clonedExpect = expect.clone();
+      var customObject = { quux: 'xuuq', foobar: 'faz' };
+
+      clonedExpect.addStyle('xuuqProperty', function(key, inspectedValue) {
+        this.text('<')
+          .appendInspected(key)
+          .text('> --> ')
+          .append(inspectedValue);
+      });
+
+      clonedExpect.addType({
+        name: 'xuuq',
+        base: 'object',
+        identify: function(obj) {
+          return obj && typeof 'object' && obj.quux === 'xuuq';
+        },
+        property: function(output, key, inspectedValue) {
+          return output.xuuqProperty(key, inspectedValue);
+        }
+      });
+
+      expect(
+        function() {
+          clonedExpect(customObject, 'to equal', {
+            quux: 'xuuq',
+            foobar: 'baz'
+          });
+        },
+        'to throw',
+        "expected { <'quux'> --> 'xuuq', <'foobar'> --> 'faz' }\n" +
+          "to equal { <'quux'> --> 'xuuq', <'foobar'> --> 'baz' }\n" +
+          '\n' +
+          '{\n' +
+          "  <'quux'> --> 'xuuq',\n" +
+          "  <'foobar'> --> 'faz' // should equal 'baz'\n" +
+          '                       //\n' +
+          '                       // -faz\n' +
+          '                       // +baz\n' +
+          '}'
+      );
+    });
+  });
 });

--- a/test/types/object-type.spec.js
+++ b/test/types/object-type.spec.js
@@ -384,7 +384,7 @@ describe('object type', function() {
       }
     });
 
-    it('should process propeties in both inspection and diff', function() {
+    it('should process propeties in both inspection and diff in "to equal"', function() {
       expect(
         function() {
           clonedExpect({ nine: 9, zero: 1, foo: 'bAr' }, 'to equal', {
@@ -400,6 +400,28 @@ describe('object type', function() {
           '  nine: 9,\n' +
           '  zero: 1, // should equal 0\n' +
           "  foo: 'BAR'\n" +
+          '}'
+      );
+    });
+
+    it('should process propeties in both inspection and diff in "to satsify"', function() {
+      expect(
+        function() {
+          clonedExpect(
+            { nine: 9, zero: 1, foo: 'bAr', baz: undefined },
+            'to satisfy',
+            { nine: 9, zero: 0, foo: 'BaR', baz: expect.it('to be undefined') }
+          );
+        },
+        'to throw',
+        "expected { nine: 9, zero: 1, foo: 'BAR', baz: undefined }\n" +
+          "to satisfy { nine: 9, zero: 0, foo: 'BAR', baz: expect.it('to be undefined') }\n" +
+          '\n' +
+          '{\n' +
+          '  nine: 9,\n' +
+          '  zero: 1, // should equal 0\n' +
+          "  foo: 'BAR',\n" +
+          '  baz: undefined\n' +
           '}'
       );
     });

--- a/test/types/object-type.spec.js
+++ b/test/types/object-type.spec.js
@@ -196,8 +196,8 @@ describe('object type', function() {
     });
   });
 
-  describe('with a custom subtype that overrides property()', function() {
-    it('should bar', function() {
+  describe('with a subtype that overrides property()', function() {
+    it('should render correctly in both inspection and diff', function() {
       var clonedExpect = expect.clone();
       var customObject = { quux: 'xuuq', foobar: 'faz' };
 
@@ -236,6 +236,44 @@ describe('object type', function() {
           '                       //\n' +
           '                       // -faz\n' +
           '                       // +baz\n' +
+          '}'
+      );
+    });
+  });
+
+  describe('with a subtype that overrides valueForKey()', function() {
+    var clonedExpect = expect.clone();
+
+    clonedExpect.addType({
+      name: 'nineObject',
+      base: 'object',
+      identify: function(obj) {
+        return obj && typeof 'object' && obj.nine === 9;
+      },
+      valueForKey: function(obj, key) {
+        if (typeof obj[key] === 'string') {
+          return obj[key].toUpperCase();
+        }
+        return obj[key];
+      }
+    });
+
+    it('should process propeties in both inspection and diff', function() {
+      expect(
+        function() {
+          clonedExpect({ nine: 9, zero: 1, foo: 'bAr' }, 'to equal', {
+            nine: 9,
+            zero: 0,
+            foo: 'BaR'
+          });
+        },
+        'to throw',
+        "expected { nine: 9, zero: 1, foo: 'BAR' } to equal { nine: 9, zero: 0, foo: 'BAR' }\n" +
+          '\n' +
+          '{\n' +
+          '  nine: 9,\n' +
+          '  zero: 1, // should equal 0\n' +
+          "  foo: 'BAR'\n" +
           '}'
       );
     });

--- a/test/types/object-type.spec.js
+++ b/test/types/object-type.spec.js
@@ -112,6 +112,62 @@ describe('object type', function() {
     });
   });
 
+  describe('#similar', function() {
+    var clonedExpect = expect.clone();
+
+    clonedExpect.addType({
+      name: 'ignoreUnderscoresObject',
+      base: 'object',
+      identify(obj) {
+        return obj && typeof 'object' && obj.xuuq;
+      },
+      valueForKey(obj, key) {
+        if (key[0] === '_') {
+          return undefined;
+        }
+        return obj[key];
+      }
+    });
+
+    it('should pass with values overriding valueForKey()', function() {
+      expect(function() {
+        clonedExpect(
+          [{ xuuq: true, quux: 'foo', _bob: true }, 'foobar'],
+          'to equal',
+          [{ xuuq: true, quux: 'foo', _bob: false }, 'foobar']
+        );
+      }, 'not to throw');
+    });
+
+    it('should fail with values overriding valueForKey()', function() {
+      expect(
+        function() {
+          clonedExpect(
+            [{ xuuq: true, quux: 'bar', _bob: true }, 'foobar'],
+            'to equal',
+            ['foobar', { xuuq: true, quux: 'baz', _bob: false }]
+          );
+        },
+        'to throw',
+        "expected [ { xuuq: true, quux: 'bar', _bob: undefined }, 'foobar' ]\n" +
+          "to equal [ 'foobar', { xuuq: true, quux: 'baz', _bob: undefined } ]\n" +
+          '\n' +
+          '[\n' +
+          '┌─▷\n' +
+          '│   {\n' +
+          '│     xuuq: true,\n' +
+          "│     quux: 'bar', // should equal 'baz'\n" +
+          '│                  //\n' +
+          '│                  // -bar\n' +
+          '│                  // +baz\n' +
+          '│     _bob: undefined\n' +
+          '│   },\n' +
+          "└── 'foobar' // should be moved\n" +
+          ']'
+      );
+    });
+  });
+
   describe('with a subtype that disables indentation', function() {
     var clonedExpect = expect.clone();
 

--- a/test/types/object-type.spec.js
+++ b/test/types/object-type.spec.js
@@ -54,6 +54,36 @@ describe('object type', function() {
         expect({}, 'to equal', { rhs: undefined });
       }, 'not to throw');
     });
+
+    describe('with a subtype that overrides valueForKey()', function() {
+      var clonedExpect = expect.clone();
+
+      clonedExpect.addType({
+        name: 'undefinerObject',
+        base: 'object',
+        identify: function(obj) {
+          return obj && typeof 'object' && obj.xuuq;
+        },
+        valueForKey: function(obj, key) {
+          if (key !== 'xuuq') {
+            return undefined;
+          }
+          return obj[key];
+        }
+      });
+
+      it('should ignore undefined properties on the LHS', function() {
+        expect(function() {
+          expect({ xuuq: true, lhs: undefined }, 'to equal', { xuuq: true });
+        }, 'not to throw');
+      });
+
+      it('should ignore undefined properties on the RHS', function() {
+        expect(function() {
+          expect({ xuuq: true }, 'to equal', { xuuq: true, rhs: undefined });
+        }, 'not to throw');
+      });
+    });
   });
 
   describe('#getKeys', function() {


### PR DESCRIPTION
Hey,

The changes in this commit are a sort of minimal set of overrides allowing the Map type to share inspect and diff code with the base object plugin. If you want to see how they are used, I split out the Map code itself into a separate repo https://github.com/alexjeffburke/unexpected-map.

My hope is what's here strikes a decent balance between re-use while avoiding invasive changes to other areas that might require other approaches (i.e. "to satisfy"). I'm more than willing to iterate on this and the main reason for sharing it now is to get agreement on the approach and early feedback.

Look forward to hearing your thoughts!