### PR TITLE
Pass typing information for equality through Error.equal().

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -108,21 +108,36 @@ function Unexpected(options = {}) {
     ) ||
     (that.parent &&
       that.parent.findTypeOfWithParentType(obj, requiredParentType));
-  this.findCommonType = function(a, b) {
+  this.findAllTypesOf = (a, b) => {
     const aAncestorIndex = {};
-    let current = this.findTypeOf(a);
+    const aType = this.findTypeOf(a);
+    const bType = this.findTypeOf(b);
+    let current;
+
+    current = aType;
     while (current) {
       aAncestorIndex[current.name] = current;
       current = current.baseType;
     }
-    current = this.findTypeOf(b);
+
+    current = bType;
     while (current) {
       if (aAncestorIndex[current.name]) {
-        return current;
+        break;
       }
       current = current.baseType;
     }
+
+    return {
+      aType,
+      bType,
+      common: current
+    };
   };
+  this.findCommonType = (a, b) => {
+    return this.findAllTypesOf(a, b).common;
+  };
+
   this._wrappedExpectProto = createWrappedExpectProto(this);
 }
 
@@ -292,8 +307,6 @@ Unexpected.prototype.it = function(...args) {
 };
 
 Unexpected.prototype.equal = function(actual, expected, depth, seen) {
-  const that = this;
-
   depth = typeof depth === 'number' ? depth : 100;
   if (depth <= 0) {
     // detect recursive loops in the structure
@@ -304,8 +317,15 @@ Unexpected.prototype.equal = function(actual, expected, depth, seen) {
     seen.push(actual);
   }
 
-  return this.findCommonType(actual, expected).equal(actual, expected, (a, b) =>
-    that.equal(a, b, depth - 1, seen)
+  const equalityTypes = this.findAllTypesOf(actual, expected);
+
+  return equalityTypes.common.equal(
+    actual,
+    expected,
+    (a, b) => {
+      return this.equal(a, b, depth - 1, seen);
+    },
+    equalityTypes
   );
 };
 
@@ -819,8 +839,8 @@ Unexpected.prototype.addType = function(type, childUnexpected) {
     );
   };
 
-  extendedBaseType.equal = (actual, expected) =>
-    baseType.equal(actual, expected, that.equal.bind(that));
+  extendedBaseType.equal = (actual, expected, equalityTypes) =>
+    baseType.equal(actual, expected, this.equal.bind(this), equalityTypes);
 
   const extendedType = extend({}, baseType, type, {
     baseType: extendedBaseType

--- a/lib/createWrappedExpectProto.js
+++ b/lib/createWrappedExpectProto.js
@@ -49,15 +49,13 @@ module.exports = function createWrappedExpectProto(unexpected) {
   const wrappedExpectProto = {
     promise: makePromise,
     errorMode: 'default',
-
     equal: unexpected.equal,
     inspect: unexpected.inspect,
     createOutput: unexpected.createOutput.bind(unexpected),
-    findTypeOf: unexpected.findTypeOf.bind(unexpected),
-    findTypeOfWithParentType: unexpected.findTypeOfWithParentType.bind(
-      unexpected
-    ),
-    findCommonType: unexpected.findCommonType.bind(unexpected),
+    findTypeOf: unexpected.findTypeOf,
+    findTypeOfWithParentType: unexpected.findTypeOfWithParentType,
+    findAllTypesOf: unexpected.findAllTypesOf,
+    findCommonType: unexpected.findCommonType,
     it(...args) {
       if (typeof args[0] === 'string') {
         args[0] = utils.forwardFlags(args[0], this.flags);

--- a/lib/types.js
+++ b/lib/types.js
@@ -153,7 +153,13 @@ module.exports = function(expect) {
             return 0;
           }
         : undefined,
-    equal(a, b, equal) {
+    equal(a, b, equal, equalityTypes) {
+      // default to the type itself in the absence of specific type information
+      equalityTypes = equalityTypes || {
+        aType: this,
+        bType: this
+      };
+
       if (a === b) {
         return true;
       }
@@ -162,12 +168,12 @@ module.exports = function(expect) {
         return false;
       }
 
-      const actualKeys = this.getKeys(a).filter(
-        key => typeof this.valueForKey(a, key) !== 'undefined'
-      );
-      const expectedKeys = this.getKeys(b).filter(
-        key => typeof this.valueForKey(b, key) !== 'undefined'
-      );
+      const actualKeys = equalityTypes.aType
+        .getKeys(a)
+        .filter(key => typeof this.valueForKey(a, key) !== 'undefined');
+      const expectedKeys = equalityTypes.bType
+        .getKeys(b)
+        .filter(key => typeof this.valueForKey(b, key) !== 'undefined');
 
       // having the same number of owned properties (keys incorporates hasOwnProperty)
       if (actualKeys.length !== expectedKeys.length) {
@@ -824,9 +830,11 @@ module.exports = function(expect) {
         return result;
       }, {});
     },
-    equal(a, b, equal) {
+    equal(a, b, equal, equalityTypes) {
       return (
-        a === b || (equal(a.message, b.message) && this.baseType.equal(a, b))
+        a === b ||
+        (equal(a.message, b.message) &&
+          this.baseType.equal(a, b, equalityTypes))
       );
     },
     inspect(value, depth, output, inspect) {

--- a/test/types/error-type.spec.js
+++ b/test/types/error-type.spec.js
@@ -140,4 +140,16 @@ describe('Error type', function() {
       });
     });
   });
+
+  describe('when comparing error with differeing enumarable keys', () => {
+    it('should not break', () => {
+      var e1 = new Error('foo');
+      var e2 = new Error();
+      e2.message = 'foo';
+
+      expect(() => {
+        expect(e1, 'to equal', e2);
+      }, 'not to throw');
+    });
+  });
 });


### PR DESCRIPTION
This branch attempts to address https://github.com/unexpectedjs/unexpected/issues/439 by passing typing information through to the underlying baseType `.equal()` call. There is likely a concern around the performance of adding type evaluation within the base equality method given how many places defer to it hence this approach was chosen to minimise the impact.