### PR TITLE
Only compact the subject when there is a diff

### DIFF
--- a/documentation/assertions/array-like/to-have-an-item-satisfying.md
+++ b/documentation/assertions/array-like/to-have-an-item-satisfying.md
@@ -55,7 +55,8 @@ expect(
 ```
 
 ```output
-expected array to have an item satisfying to have an item satisfying to be a number
+expected [ [ '0', '1' ], [ '5', '6' ], [ '7', '8' ] ]
+to have an item satisfying to have an item satisfying to be a number
 ```
 
 Here a another example:

--- a/documentation/assertions/object/to-have-a-value-satisfying.md
+++ b/documentation/assertions/object/to-have-a-value-satisfying.md
@@ -54,7 +54,7 @@ expect(
 ```
 
 ```output
-expected object to have a value satisfying
+expected { foo: [ 10, 11, 12 ], bar: [ 14, 15, 16 ], baz: [ 17, 18, 19 ] } to have a value satisfying
 to have items satisfying expect.it('to be a number')
         .and('to be below', 8)
 ```

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1069,7 +1069,9 @@ module.exports = expect => {
           expect.fail({
             message(output) {
               output.append(
-                expect.standardErrorMessage(output.clone(), { compact: true })
+                expect.standardErrorMessage(output.clone(), {
+                  compact: err && err._isUnexpected && err.hasDiff()
+                })
               );
             },
             diff(output) {
@@ -1103,7 +1105,9 @@ module.exports = expect => {
           expect.fail({
             message(output) {
               output.append(
-                expect.standardErrorMessage(output.clone(), { compact: true })
+                expect.standardErrorMessage(output.clone(), {
+                  compact: err && err._isUnexpected && err.hasDiff()
+                })
               );
             },
             diff(output) {
@@ -1166,10 +1170,12 @@ module.exports = expect => {
             );
           })
         )
-        .caught(e =>
+        .caught(err =>
           expect.fail(output => {
             output.append(
-              expect.standardErrorMessage(output.clone(), { compact: true })
+              expect.standardErrorMessage(output.clone(), {
+                compact: err && err._isUnexpected && err.hasDiff()
+              })
             );
           })
         );
@@ -1192,7 +1198,9 @@ module.exports = expect => {
         err => {
           expect.fail(output => {
             output.append(
-              expect.standardErrorMessage(output.clone(), { compact: true })
+              expect.standardErrorMessage(output.clone(), {
+                compact: err && err._isUnexpected && err.hasDiff()
+              })
             );
           });
         }

--- a/test/assertions/to-have-an-item-satisfying.spec.js
+++ b/test/assertions/to-have-an-item-satisfying.spec.js
@@ -114,7 +114,11 @@ describe('to have an item satisfying assertion', function() {
         );
       },
       'to throw',
-      'expected array to have an item satisfying\n' +
+      'expected\n' +
+        '[\n' +
+        '  [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 ]\n' +
+        ']\n' +
+        'to have an item satisfying\n' +
         'function (item) {\n' +
         '  expect.fail(function (output) {\n' +
         "    output.text('foo').nl().text('bar');\n" +


### PR DESCRIPTION
Previously some of the assertions wouldn't provide the full context when there's no diff available.