### PR TITLE
 Fixed wrong error message seen in unexpected-dom

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -1042,8 +1042,15 @@ Unexpected.prototype.throwAssertionNotFoundError = function(
   testDescriptionString,
   args
 ) {
-  const candidateHandlers = this.assertions[testDescriptionString];
+  let candidateHandlers = this.assertions[testDescriptionString];
   const that = this;
+
+  let instance = this;
+  while (instance && !candidateHandlers) {
+    candidateHandlers = instance.assertions[testDescriptionString];
+    instance = instance.parent;
+  }
+
   if (candidateHandlers) {
     this.fail({
       message(output) {
@@ -1110,7 +1117,7 @@ Unexpected.prototype.throwAssertionNotFoundError = function(
 
   const assertionsWithScore = [];
   const assertionStrings = [];
-  let instance = this;
+  instance = this;
   while (instance) {
     assertionStrings.push(...Object.keys(instance.assertions));
     instance = instance.parent;

--- a/test/api/shift.spec.js
+++ b/test/api/shift.spec.js
@@ -352,4 +352,57 @@ describe('expect.shift', function() {
       }, 'executed inside an assertion');
     });
   });
+
+  it('fails when the given assertion does not accept the shifted subject type', () => {
+    var clonedExpect = expect
+      .clone()
+      .addAssertion('<number> when stringified <assertion>', function(
+        expect,
+        subject
+      ) {
+        expect.errorMode = 'nested';
+        return expect.shift(String(subject));
+      });
+
+    expect(
+      () => {
+        clonedExpect(666, 'when stringified', 'to be negative');
+      },
+      'to throw',
+      'expected 666 when stringified to be negative\n' +
+        "  expected '666' to be negative\n" +
+        '    The assertion does not have a matching signature for:\n' +
+        '      <string> to be negative\n' +
+        '    did you mean:\n' +
+        '      <number> [not] to be negative'
+    );
+  });
+
+  describe('when you shift to an assertion in the parent expect', () => {
+    it('fails when the given assertion does not accept the shifted subject type', () => {
+      var clonedExpect = expect
+        .clone()
+        .child()
+        .exportAssertion('<number> when stringified <assertion>', function(
+          expect,
+          subject
+        ) {
+          expect.errorMode = 'nested';
+          return expect.shift(String(subject));
+        });
+
+      expect(
+        () => {
+          clonedExpect(666, 'when stringified', 'to be negative');
+        },
+        'to throw',
+        'expected 666 when stringified to be negative\n' +
+          "  expected '666' to be negative\n" +
+          '    The assertion does not have a matching signature for:\n' +
+          '      <string> to be negative\n' +
+          '    did you mean:\n' +
+          '      <number> [not] to be negative'
+      );
+    });
+  });
 });

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -41,6 +41,39 @@ describe('unexpected', function() {
       );
     });
 
+    it('fails if the given assertion can not be found', () => {
+      expect(
+        () => {
+          expect(
+            ['foo', 'bar', 'baz'],
+            'to have entries satisfying',
+            expect.it('to be a string')
+          );
+        },
+        'to throw',
+        "Unknown assertion 'to have entries satisfying', did you mean: 'to have an item satisfying'"
+      );
+    });
+
+    it('fails if the given assertion is not defined for the provided parameters', () => {
+      expect(
+        () => {
+          expect(
+            'foo',
+            'to have items satisfying',
+            expect.it('to be a string')
+          );
+        },
+        'to throw',
+        "expected 'foo' to have items satisfying expect.it('to be a string')\n" +
+          '  The assertion does not have a matching signature for:\n' +
+          '    <string> to have items satisfying <expect.it>\n' +
+          '  did you mean:\n' +
+          '    <array-like> to have items [exhaustively] satisfying <any>\n' +
+          '    <array-like> to have items [exhaustively] satisfying <assertion>'
+      );
+    });
+
     describe('in a nested expect', function() {
       it('fails when given no parameters', function() {
         var clonedExpect = expect


### PR DESCRIPTION
This is the wrong error message:

```
Unknown assertion 'to be negative', did you mean: 'to be negative'
```