### PR TITLE
Avoid deferring to the base type for object equality.

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -154,44 +154,7 @@ module.exports = function(expect) {
           }
         : undefined,
     equal(a, b, equal) {
-      if (a === b) {
-        return true;
-      }
-
-      if (b.constructor !== a.constructor) {
-        return false;
-      }
-
-      const actualKeys = this.getKeys(a).filter(
-        key => typeof this.valueForKey(a, key) !== 'undefined'
-      );
-      const expectedKeys = this.getKeys(b).filter(
-        key => typeof this.valueForKey(b, key) !== 'undefined'
-      );
-
-      // having the same number of owned properties (keys incorporates hasOwnProperty)
-      if (actualKeys.length !== expectedKeys.length) {
-        return false;
-      }
-      //the same set of keys (although not necessarily the same order),
-      actualKeys.sort(this.keyComparator);
-      expectedKeys.sort(this.keyComparator);
-      // cheap key test
-      for (let i = 0; i < actualKeys.length; i += 1) {
-        if (actualKeys[i] !== expectedKeys[i]) {
-          return false;
-        }
-      }
-
-      //equivalent values for every corresponding key, and
-      // possibly expensive deep test
-      for (let j = 0; j < actualKeys.length; j += 1) {
-        const key = actualKeys[j];
-        if (!equal(this.valueForKey(a, key), this.valueForKey(b, key))) {
-          return false;
-        }
-      }
-      return true;
+      return utils.checkObjectEqualityUsingType(a, b, this, equal);
     },
     hasKey(obj, key) {
       return key in obj;
@@ -826,7 +789,9 @@ module.exports = function(expect) {
     },
     equal(a, b, equal) {
       return (
-        a === b || (equal(a.message, b.message) && this.baseType.equal(a, b))
+        a === b ||
+        (equal(a.message, b.message) &&
+          utils.checkObjectEqualityUsingType(a, b, this, equal))
       );
     },
     inspect(value, depth, output, inspect) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,6 +27,48 @@ const utils = (module.exports = {
       return a === b;
     }),
 
+  checkObjectEqualityUsingType(a, b, type, isEqual) {
+    if (a === b) {
+      return true;
+    }
+
+    if (b.constructor !== a.constructor) {
+      return false;
+    }
+
+    const actualKeys = type
+      .getKeys(a)
+      .filter(key => typeof type.valueForKey(a, key) !== 'undefined');
+    const expectedKeys = type
+      .getKeys(b)
+      .filter(key => typeof type.valueForKey(b, key) !== 'undefined');
+
+    // having the same number of owned properties (keys incorporates hasOwnProperty)
+    if (actualKeys.length !== expectedKeys.length) {
+      return false;
+    }
+
+    //the same set of keys (although not necessarily the same order),
+    actualKeys.sort(type.keyComparator);
+    expectedKeys.sort(type.keyComparator);
+    // cheap key test
+    for (let i = 0; i < actualKeys.length; i += 1) {
+      if (actualKeys[i] !== expectedKeys[i]) {
+        return false;
+      }
+    }
+
+    //equivalent values for every corresponding key, and
+    // possibly expensive deep test
+    for (let j = 0; j < actualKeys.length; j += 1) {
+      const key = actualKeys[j];
+      if (!isEqual(type.valueForKey(a, key), type.valueForKey(b, key))) {
+        return false;
+      }
+    }
+    return true;
+  },
+
   duplicateArrayLikeUsingType(obj, type) {
     const keys = type.getKeys(obj);
 

--- a/test/types/error-type.spec.js
+++ b/test/types/error-type.spec.js
@@ -140,4 +140,16 @@ describe('Error type', function() {
       });
     });
   });
+
+  describe('when comparing Error objects with differing enumarable keys', () => {
+    it('should not break', () => {
+      var e1 = new Error('foo');
+      var e2 = new Error();
+      e2.message = 'foo';
+
+      expect(() => {
+        expect(e1, 'to equal', e2);
+      }, 'not to throw');
+    });
+  });
 });


### PR DESCRIPTION
Move checking object equality into a separate common function
utils.checkObjectEqualityUsingType(). Use this within the base object
type but also when comparing Error keys - since this function accepts
the type, in the case of the Error type it ensures equality is
evaluated using the subtype getKeys() thus addressing the mismatching
keys issue.