### PR TITLE
Reformat code snippets in the documentation

### DIFF
--- a/documentation/api/UnexpectedError.md
+++ b/documentation/api/UnexpectedError.md
@@ -25,25 +25,30 @@ output.appendErrorMessage(error);
 This is useful if you want to combine multiple errors in one assertion:
 
 ```js
-expect.addAssertion("<array> to have item satisfying <any+>", function (expect, subject) {
+expect.addAssertion('<array> to have item satisfying <any+>', function(
+  expect,
+  subject
+) {
   var args = Array.prototype.slice.call(arguments, 2);
-  var promises = subject.map(function (item) {
-    return expect.promise(function () {
+  var promises = subject.map(function(item) {
+    return expect.promise(function() {
       return expect.apply(expect, [item].concat(args));
     });
   });
 
-  return expect.promise.settle(promises).then(function () {
-    var failed = promises.every(function (promise) {
+  return expect.promise.settle(promises).then(function() {
+    var failed = promises.every(function(promise) {
       return promise.isRejected();
     });
 
     if (failed) {
       expect.fail({
-        diff: function (output, diff, inspect, equal) {
+        diff: function(output, diff, inspect, equal) {
           output.inline = true;
-          promises.forEach(function (promise, index) {
-            if (index > 0) { output.nl(2); }
+          promises.forEach(function(promise, index) {
+            if (index > 0) {
+              output.nl(2);
+            }
             var error = promise.reason();
             // the error is connected to the current scope
             // but we are just interested in the nested error
@@ -92,16 +97,23 @@ We could for example change the error mode for all the errors in the
 chain to `nested`:
 
 ```js
-expect.addAssertion('<any> detailed to be <any>', function (expect, subject, value) {
+expect.addAssertion('<any> detailed to be <any>', function(
+  expect,
+  subject,
+  value
+) {
   expect.errorMode = 'bubble';
-  expect.withError(function () {
-    expect(subject, 'to be', value);
-  }, function (err) {
-    err.getParents().forEach(function (e) {
-      e.errorMode = 'nested';
-    });
-    expect.fail(err);
-  });
+  expect.withError(
+    function() {
+      expect(subject, 'to be', value);
+    },
+    function(err) {
+      err.getParents().forEach(function(e) {
+        e.errorMode = 'nested';
+      });
+      expect.fail(err);
+    }
+  );
 });
 
 expect('f00!', 'detailed to be', 'foo!');
@@ -145,18 +157,27 @@ create the diff. Now you can delegate to that method from
 `expect.fail`:
 
 ```js
-expect.addAssertion('<any> to be completely custom', function (expect, subject) {
-  return expect.withError(function () {
-    expect(subject, 'to satisfy', { custom: true });
-  }, function (err) {
-    var createDiff = err.getDiffMethod();
-    expect.fail({
-      diff: function (output, diff, inspect, equal) {
-        output.text('~~~~~~~~~~~~~~').sp().success('custom').sp().text('~~~~~~~~~~~~~~').nl();
-        return createDiff(output, diff, inspect, equal);
-      }
-    });
-  });
+expect.addAssertion('<any> to be completely custom', function(expect, subject) {
+  return expect.withError(
+    function() {
+      expect(subject, 'to satisfy', { custom: true });
+    },
+    function(err) {
+      var createDiff = err.getDiffMethod();
+      expect.fail({
+        diff: function(output, diff, inspect, equal) {
+          output
+            .text('~~~~~~~~~~~~~~')
+            .sp()
+            .success('custom')
+            .sp()
+            .text('~~~~~~~~~~~~~~')
+            .nl();
+          return createDiff(output, diff, inspect, equal);
+        }
+      });
+    }
+  );
 });
 
 expect({ custom: false }, 'to be completely custom');

--- a/documentation/api/addAssertion.md
+++ b/documentation/api/addAssertion.md
@@ -11,20 +11,25 @@ New assertions can be added to Unexpected the following way.
 
 ```js
 var errorMode = 'default'; // use to control the error mode later in the example
-expect.addAssertion('<array> [not] to be (sorted|ordered) <function?>', function (expect, subject, cmp) {
-  expect.errorMode = errorMode;
-  expect(subject, '[not] to equal', [].concat(subject).sort(cmp));
-});
+expect.addAssertion(
+  '<array> [not] to be (sorted|ordered) <function?>',
+  function(expect, subject, cmp) {
+    expect.errorMode = errorMode;
+    expect(subject, '[not] to equal', [].concat(subject).sort(cmp));
+  }
+);
 ```
 
 The above assertion definition makes the following expects possible:
 
 ```js
-expect([1,2,3], 'to be sorted');
-expect([1,2,3], 'to be ordered');
-expect([2,1,3], 'not to be sorted');
-expect([2,1,3], 'not to be ordered');
-expect([3,2,1], 'to be sorted', function (x, y) { return y - x; });
+expect([1, 2, 3], 'to be sorted');
+expect([1, 2, 3], 'to be ordered');
+expect([2, 1, 3], 'not to be sorted');
+expect([2, 1, 3], 'not to be ordered');
+expect([3, 2, 1], 'to be sorted', function(x, y) {
+  return y - x;
+});
 ```
 
 Let's dissect the different parts of the custom assertion we just
@@ -88,14 +93,25 @@ an output function on the assertion.
 Here is a few examples:
 
 ```js
-expect.addAssertion('<number> to be contained by <number> <number>', function (expect, subject, start, finish) {
-    expect.subjectOutput = function (output) {
-        output.text('point ').jsNumber(subject);
-    };
-    expect.argsOutput = function (output) {
-        output.text('interval ').text('[').appendInspected(start).text(';').appendInspected(finish).text(']');
-    };
-    expect(subject >= start && subject <= finish, '[not] to be truthy');
+expect.addAssertion('<number> to be contained by <number> <number>', function(
+  expect,
+  subject,
+  start,
+  finish
+) {
+  expect.subjectOutput = function(output) {
+    output.text('point ').jsNumber(subject);
+  };
+  expect.argsOutput = function(output) {
+    output
+      .text('interval ')
+      .text('[')
+      .appendInspected(start)
+      .text(';')
+      .appendInspected(finish)
+      .text(']');
+  };
+  expect(subject >= start && subject <= finish, '[not] to be truthy');
 });
 
 expect(4, 'to be contained by', 8, 10);
@@ -106,14 +122,22 @@ expected point 4 to be contained by interval [8;10]
 ```
 
 ```js
-expect.addAssertion('<number> to be similar to <number> <number?>', function (expect, subject, value, epsilon) {
-    if (typeof epsilon !== 'number') {
-        epsilon = 1e-9;
-    }
-    expect.argsOutput[2] = function (output) {
-        output.text('(epsilon: ').jsNumber(epsilon.toExponential()).text(')')
-    }
-    expect(Math.abs(subject - value), 'to be less than or equal to', epsilon);
+expect.addAssertion('<number> to be similar to <number> <number?>', function(
+  expect,
+  subject,
+  value,
+  epsilon
+) {
+  if (typeof epsilon !== 'number') {
+    epsilon = 1e-9;
+  }
+  expect.argsOutput[2] = function(output) {
+    output
+      .text('(epsilon: ')
+      .jsNumber(epsilon.toExponential())
+      .text(')');
+  };
+  expect(Math.abs(subject - value), 'to be less than or equal to', epsilon);
 });
 
 expect(4, 'to be similar to', 4.0001);
@@ -130,7 +154,7 @@ message for the custom assertion will be used. In the case of our
 _sorted_ assertion fails, the output will be:
 
 ```js
-expect([ 1, 3, 2, 4 ], 'to be sorted');
+expect([1, 3, 2, 4], 'to be sorted');
 ```
 
 ```output
@@ -154,7 +178,7 @@ If we change the error mode to _bubble_, we get the following output:
 
 ```js
 errorMode = 'bubble';
-expect([ 1, 3, 2, 4 ], 'to be sorted');
+expect([1, 3, 2, 4], 'to be sorted');
 ```
 
 ```output
@@ -176,7 +200,7 @@ If we change the error mode to _nested_, we get the following output:
 
 ```js
 errorMode = 'nested';
-expect([ 1, 3, 2, 4 ], 'to be sorted');
+expect([1, 3, 2, 4], 'to be sorted');
 ```
 
 ```output
@@ -199,7 +223,7 @@ If we change the error mode to _defaultOrNested_, we get the following output:
 
 ```js
 errorMode = 'defaultOrNested';
-expect([ 1, 3, 2, 4 ], 'to be sorted');
+expect([1, 3, 2, 4], 'to be sorted');
 ```
 
 ```output
@@ -221,7 +245,7 @@ If we change the error mode to _diff_, we get the following output:
 
 ```js
 errorMode = 'diff';
-expect([ 1, 3, 2, 4 ], 'to be sorted');
+expect([1, 3, 2, 4], 'to be sorted');
 ```
 
 ```output
@@ -233,7 +257,6 @@ expect([ 1, 3, 2, 4 ], 'to be sorted');
     4
 ]
 ```
-
 
 ### Asynchronous assertions
 
@@ -250,9 +273,9 @@ function Timelock(value, delay) {
   this.delay = delay;
 }
 
-Timelock.prototype.getValue = function (cb) {
+Timelock.prototype.getValue = function(cb) {
   var that = this;
-  setTimeout(function () {
+  setTimeout(function() {
     cb(that.value);
   }, this.delay);
 };
@@ -272,21 +295,27 @@ First we need to define a [type](../addType/) for handling the `Timelock`:
 ```js
 expect.addType({
   name: 'Timelock',
-  identify: function (value) {
+  identify: function(value) {
     return value && value instanceof Timelock;
   },
-  inspect: function (value, depth, output) {
+  inspect: function(value, depth, output) {
     output.jsFunctionName('Timelock');
   }
 });
 ```
 
 ```js
-expect.addAssertion('<Timelock> to satisfy <any>', function (expect, subject, spec) {
-  return expect.promise(function (run) {
-    subject.getValue(run(function (value) {
-      return expect(value, 'to satisfy', spec);
-    }));
+expect.addAssertion('<Timelock> to satisfy <any>', function(
+  expect,
+  subject,
+  spec
+) {
+  return expect.promise(function(run) {
+    subject.getValue(
+      run(function(value) {
+        return expect(value, 'to satisfy', spec);
+      })
+    );
   });
 });
 ```

--- a/documentation/api/addStyle.md
+++ b/documentation/api/addStyle.md
@@ -9,20 +9,20 @@ See the documentation there.
 Example:
 
 ```js
-expect.addStyle('jsString', function (text, rainbowColors) {
-    rainbowColors = rainbowColors || [
-        'gray',
-        'red',
-        'green',
-        'yellow',
-        'blue',
-        'magenta',
-        'cyan'
-    ];
-    for (var i = 0; i < text.length; i += 1) {
-        var color = rainbowColors[i % rainbowColors.length];
-        this.text(text[i], color);
-    }
+expect.addStyle('jsString', function(text, rainbowColors) {
+  rainbowColors = rainbowColors || [
+    'gray',
+    'red',
+    'green',
+    'yellow',
+    'blue',
+    'magenta',
+    'cyan'
+  ];
+  for (var i = 0; i < text.length; i += 1) {
+    var color = rainbowColors[i % rainbowColors.length];
+    this.text(text[i], color);
+  }
 });
 
 expect('foobar', 'to equal', 'foo bar');

--- a/documentation/api/addStyle.md
+++ b/documentation/api/addStyle.md
@@ -1,0 +1,36 @@
+# expect.addStyle(...)
+
+Install a single [MagicPen](https://github.com/sunesimonsen/magicpen) style into the
+`expect` instance, so that it's used when rendering error messages and diffs.
+
+Proxies through to [magicPen.addStyle](https://github.com/sunesimonsen/magicpen#addstylestyle-handler).
+See the documentation there.
+
+Example:
+
+```js
+expect.addStyle('jsString', function (text, rainbowColors) {
+    rainbowColors = rainbowColors || [
+        'gray',
+        'red',
+        'green',
+        'yellow',
+        'blue',
+        'magenta',
+        'cyan'
+    ];
+    for (var i = 0; i < text.length; i += 1) {
+        var color = rainbowColors[i % rainbowColors.length];
+        this.text(text[i], color);
+    }
+});
+
+expect('foobar', 'to equal', 'foo bar');
+```
+
+```output
+expected 'foobar' to equal 'foo bar'
+
+-foobar
++foo bar
+```

--- a/documentation/api/addType.md
+++ b/documentation/api/addType.md
@@ -18,8 +18,8 @@ implement the required parts of the following interface:
 
 Required members:
 
-* __name__: `String` - the name of the type.
-* __identify__: `boolean function(value)` - a function deciding if the type
+* **name**: `String` - the name of the type.
+* **identify**: `boolean function(value)` - a function deciding if the type
   should be used for the given value.
 
 Note that your type has the option to take precedence over all the built-in
@@ -29,14 +29,14 @@ first, so `identify` functions should take care not to break with `undefined`,
 
 Optional members:
 
-* __base__: `String` - the name of the base type. Defaults to `any`.
-* __equal__: `boolean function(a, b, equal)` -
+* **base**: `String` - the name of the base type. Defaults to `any`.
+* **equal**: `boolean function(a, b, equal)` -
   a function capable of comparing two values of this type for
   equality. If not specified it is inherited from the base type.
-* __inspect__: `function(value, depth, output, inspect)` -
+* **inspect**: `function(value, depth, output, inspect)` -
   a function capable of inspecting a value of this type. If not
   specified it is inherited from the base type.
-* __diff__: `comparison function(actual, expected, output, diff, inspect)` -
+* **diff**: `comparison function(actual, expected, output, diff, inspect)` -
   a function producing a comparison between two values of this
   type. If not specified it is inherited from the base type.
 
@@ -45,10 +45,10 @@ Optional members:
 Adding new types to the system is best explained by an example. Let's
 say we wanted to add first class support for a `Person` type:
 
-```javascript
+```js
 function Person(name, age) {
-    this.name = name;
-    this.age = age;
+  this.name = name;
+  this.age = age;
 }
 ```
 
@@ -57,13 +57,13 @@ instances. The name of the type should be `Person` and it should
 inherit from the built-in `object` type. Furthermore we add an
 `identify` method that will recognize `Person` instances.
 
-```javascript
+```js
 expect.addType({
-    name: 'Person',
-    base: 'object',
-    identify: function (value) {
-        return value instanceof Person;
-    }
+  name: 'Person',
+  base: 'object',
+  identify: function(value) {
+    return value instanceof Person;
+  }
 });
 ```
 
@@ -73,7 +73,7 @@ didn't implement. In this case we inherited the methods `equal`,
 
 Imagine that we make a failing expectation on a `Person` instance:
 
-```javascript
+```js
 expect(new Person('John Doe', 42), 'to equal', new Person('Jane Doe', 24));
 ```
 
@@ -94,7 +94,7 @@ That is already quite helpful, but it would be even nicer if the
 stringification of `Person` instances could read as valid calls to the
 constructor. We can fix that by implementing an `inspect` method on the type.
 
-```javascript#freshExpect:true
+```js#freshExpect:true
 expect.addType({
     name: 'Person',
     base: 'object',
@@ -113,7 +113,7 @@ expect.addType({
 
 Now we get the following output:
 
-```javascript
+```js
 expect(new Person('John Doe', 42), 'to equal', new Person('Jane Doe', 24));
 ```
 
@@ -138,7 +138,7 @@ inspect members. The output is an instance of
 number of [styles](https://github.com/unexpectedjs/unexpected/blob/master/lib/styles.js).
 
 We write `new Person(` without styling, then we append the inspected
-`name`, write a `, `, inspect the `age` and finish with the closing
+`name`, write a `,`, inspect the `age` and finish with the closing
 parenthesis. When `inspect` is called without a depth parameter it
 defaults to `depth-1`. Values inspected with depth zero will be
 inspected as `...`. In this case we always want the name so we forward the
@@ -147,7 +147,7 @@ same depth to the `inspect` function.
 Let's say we wanted `Person` instances only to be compared by name and not by
 age. Then we need to override the `equal` method:
 
-```javascript#freshExpect:true
+```js#freshExpect:true
 expect.addType({
     name: 'Person',
     base: 'object',
@@ -171,7 +171,7 @@ This will produce the same output as above, but that means the diff if
 wrong. It states that the age should be changed. We can fix that the
 following way:
 
-```javascript#freshExpect:true
+```js#freshExpect:true
 expect.addType({
     name: 'Person',
     base: 'object',
@@ -194,7 +194,7 @@ expect.addType({
 });
 ```
 
-```javascript
+```js
 expect(new Person('John Doe', 42), 'to equal', new Person('Jane Doe', 24));
 ```
 
@@ -218,7 +218,7 @@ on the base directly when you know it is the one you need.
 
 You could also do something really custom as seen below:
 
-```javascript#freshExpect:true
+```js#freshExpect:true
 var inlineDiff = true; // used to change inlining in a later example
 
 expect.addType({
@@ -270,7 +270,7 @@ expect.addType({
 
 That would produce the following output.
 
-```javascript
+```js
 expect(new Person('John Doe', 42), 'to equal', new Person('Jane Doe', 24));
 ```
 
@@ -295,12 +295,18 @@ into the parent; otherwise the diff will be inserted in an annotation
 block. The outputs below shows the contrast between setting the
 `Person` diff to inline or not.
 
-```javascript
+```js
 inlineDiff = true;
 expect(
-  {'John Doe': new Person('John Doe', 42), 'Jane Doe': new Person('Janie Doe', 24)},
+  {
+    'John Doe': new Person('John Doe', 42),
+    'Jane Doe': new Person('Janie Doe', 24)
+  },
   'to equal',
-  {'John Doe': new Person('John Doe', 42), 'Jane Doe': new Person('Jane Doe', 24)}
+  {
+    'John Doe': new Person('John Doe', 42),
+    'Jane Doe': new Person('Jane Doe', 24)
+  }
 );
 ```
 
@@ -327,12 +333,18 @@ to equal
 }
 ```
 
-```javascript
+```js
 inlineDiff = false;
 expect(
-  {'John Doe': new Person('John Doe', 42), 'Jane Doe': new Person('Janie Doe', 24)},
+  {
+    'John Doe': new Person('John Doe', 42),
+    'Jane Doe': new Person('Janie Doe', 24)
+  },
   'to equal',
-  {'John Doe': new Person('John Doe', 42), 'Jane Doe': new Person('Jane Doe', 24)}
+  {
+    'John Doe': new Person('John Doe', 42),
+    'Jane Doe': new Person('Jane Doe', 24)
+  }
 );
 ```
 
@@ -365,9 +377,12 @@ Now that we have implemented a type, we can start adding assertions to
 it. These assertions will only work on this type or types inheriting
 from the type.
 
-```javascript
-expect.addAssertion('<Person> to be above legal age', function (expect, subject) {
-    expect(subject.age, 'to be greater than or equal to', 18);
+```js
+expect.addAssertion('<Person> to be above legal age', function(
+  expect,
+  subject
+) {
+  expect(subject.age, 'to be greater than or equal to', 18);
 });
 
 expect(new Person('Jane Doe', 24), 'to be above legal age');
@@ -376,11 +391,11 @@ expect(new Person('Jane Doe', 24), 'to be above legal age');
 Because `Person` inherits from `object` you can use all assertion
 defined for `object` or any of its ancestors. Here is an example:
 
-```javascript
+```js
 expect(new Person('Jane Doe', 24), 'to have keys', 'name', 'age');
 expect(new Person('Jane Doe', 24), 'to satisfy', {
-    name: expect.it('to be a string').and('not to be empty'),
-    age: expect.it('to be a number').and('not to be negative')
+  name: expect.it('to be a string').and('not to be empty'),
+  age: expect.it('to be a number').and('not to be negative')
 });
 ```
 

--- a/documentation/api/child.md
+++ b/documentation/api/child.md
@@ -21,14 +21,17 @@ and `addStyle`, respectively, but affect the parent `expect`:
 var childExpect = expect.child();
 
 // Only available in childExpect:
-childExpect.addAssertion('<string> to begin with foo', function (expect, subject) {
-    expect(subject, 'to begin with', 'foo');
+childExpect.addAssertion('<string> to begin with foo', function(
+  expect,
+  subject
+) {
+  expect(subject, 'to begin with', 'foo');
 });
 
 // Available in parentExpect, but has access to "to begin with foo" internally:
-childExpect.exportAssertion('<string> to foobar', function (expect, subject) {
-    expect.errorMode = 'nested';
-    expect(subject, 'to begin with foo').and('to end with', 'bar');
+childExpect.exportAssertion('<string> to foobar', function(expect, subject) {
+  expect.errorMode = 'nested';
+  expect(subject, 'to begin with foo').and('to end with', 'bar');
 });
 
 expect('fo0bar', 'to foobar');
@@ -50,14 +53,17 @@ In other words, this won't work:
 var childExpect = expect.child();
 
 childExpect.addType({
-    name: 'foosomething',
-    identify: function (value) {
-        return /^foo/.test(String(value));
-    }
+  name: 'foosomething',
+  identify: function(value) {
+    return /^foo/.test(String(value));
+  }
 });
 
-childExpect.exportAssertion('<foosomething> to end with bar', function (expect, subject) {
-    expect(subject, 'to end with', 'bar');
+childExpect.exportAssertion('<foosomething> to end with bar', function(
+  expect,
+  subject
+) {
+  expect(subject, 'to end with', 'bar');
 });
 ```
 

--- a/documentation/api/clone.md
+++ b/documentation/api/clone.md
@@ -10,10 +10,12 @@ original instance:
 ```js
 var originalExpect = expect;
 
-expect = expect.clone().addAssertion('to be an integer', function (expect, subject) {
-  expect(subject, 'to be a number');
-  expect(Math.round(subject), 'to be', subject);
-});
+expect = expect
+  .clone()
+  .addAssertion('to be an integer', function(expect, subject) {
+    expect(subject, 'to be a number');
+    expect(Math.round(subject), 'to be', subject);
+  });
 
 expect(42, 'to be an integer');
 ```

--- a/documentation/api/expect.md
+++ b/documentation/api/expect.md
@@ -5,7 +5,7 @@ Perform an assertion about `subject`.
 The `expect` function will throw an `UnexpectedError` if the assertion can be
 decided synchronously and isn't fulfilled:
 
-```javascript
+```js
 expect(123, 'to equal', 456);
 ```
 
@@ -26,7 +26,7 @@ does some unholy trickery so it also works in Jasmine.
 Note that if the assertion is asynchronous, you'll have to return the promise
 to the `it` block:
 
-```javascript#eval:false
+```js#eval:false
 it('should call the callback', function () {
     return expect(setImmediate, 'to call the callback');
 });
@@ -40,20 +40,19 @@ and make the test fail synchronously. This will uncover some extremely nasty
 bugs where the test suite succeeds when it should actually fail. However, this
 feature only works in Mocha and Jasmine.
 
-
 ## expect(...).and(assertionName, [value, ...])
 
 The returned promise will be augmented with an `and` method that allows you to
 perform more assertions on the same subject:
 
-```javascript
+```js
 expect('abc', 'to be a string').and('to have length', 3);
 ```
 
 Again, note that you need to return the value returned by `expect` to your `it`
 block if any of the assertions are asynchronous:
 
-```javascript#eval:false
+```js#eval:false
 it('should do the right thing', function () {
     return expect(setImmediate, 'to be a function').and('to call the callback');
 });

--- a/documentation/api/fail.md
+++ b/documentation/api/fail.md
@@ -45,9 +45,11 @@ When you want to build a completely custom output, you can call
 output can be written to.
 
 ```js
-expect.fail(function (output) {
-  'You have been a very bad boy!'.split(/ /).forEach(function (word, index) {
-    if (index > 0) { output.sp(); }
+expect.fail(function(output) {
+  'You have been a very bad boy!'.split(/ /).forEach(function(word, index) {
+    if (index > 0) {
+      output.sp();
+    }
     var style = index % 2 === 0 ? 'jsPrimitive' : 'jsString';
     output[style](word);
   });
@@ -63,15 +65,20 @@ If you want to build an error containing a diff you can call
 
 ```js
 expect.fail({
-  message: function (output) {
-    'You have been a very bad boy!'.split(/ /).forEach(function (word, index) {
-      if (index > 0) { output.sp(); }
+  message: function(output) {
+    'You have been a very bad boy!'.split(/ /).forEach(function(word, index) {
+      if (index > 0) {
+        output.sp();
+      }
       var style = index % 2 === 0 ? 'jsPrimitive' : 'jsString';
       output[style](word);
     });
   },
-  diff: function (output, diff, inspect, equal) {
-    return diff('You have been a very bad boy!', 'You have been a very mad boy!');
+  diff: function(output, diff, inspect, equal) {
+    return diff(
+      'You have been a very bad boy!',
+      'You have been a very mad boy!'
+    );
   }
 });
 ```

--- a/documentation/api/freeze.md
+++ b/documentation/api/freeze.md
@@ -1,0 +1,15 @@
+# expect.freeze()
+
+Prevents further assertions, types, styles, plugins, and themes from being added to the instance.
+Once frozen, the [`addAssertion`](../addAssertion/), [`addType`](../addType/),
+[`addStyle`](../addStyle/), [`installTheme`](../installTheme/), and [`use`](../use/) methods will
+throw an exception.
+
+[Cloning](../clone/) a frozen instance is allowed, and clones will not be frozen initially.
+Creating a [child](../child/) is also possible, but the child won't support `exportAssertion`,
+`exportType`, and `exportStyle` because the parent `expect` is frozen. This means that some
+plugins cannot be installed into the child. To get around that, create a clone first.
+
+The plan is to make the top-level `expect` (the main export of `require('unexpected')`)
+frozen as of Unexpected 11. The idea behind that is to help prevent multiple files in a
+test suite from affecting each other by forcing each file to create its own isolated clone.

--- a/documentation/api/installTheme.md
+++ b/documentation/api/installTheme.md
@@ -9,10 +9,10 @@ Example:
 
 ```js
 expect.installTheme({
-    styles: {
-        ugliness: 'yellow',
-        jsKeyword: 'ugliness'
-    }
+  styles: {
+    ugliness: 'yellow',
+    jsKeyword: 'ugliness'
+  }
 });
 
 expect(function foo() {}, 'to throw', 'bar');

--- a/documentation/api/installTheme.md
+++ b/documentation/api/installTheme.md
@@ -1,0 +1,25 @@
+# expect.installTheme(...)
+
+Install a [MagicPen](https://github.com/sunesimonsen/magicpen) theme into the expect instance,
+so that it's used when rendering error messages and diffs.
+
+Proxies through to [magicPen.installTheme](https://github.com/sunesimonsen/magicpen#installthemetheme-installthemeformat-theme-installthemeformats-theme). See the documentation there.
+
+Example:
+
+```js
+expect.installTheme({
+    styles: {
+        ugliness: 'yellow',
+        jsKeyword: 'ugliness'
+    }
+});
+
+expect(function foo() {}, 'to throw', 'bar');
+```
+
+```output
+expected function foo() {} to throw 'bar'
+  expected function foo() {} to throw
+    did not throw
+```

--- a/documentation/api/promise-all.md
+++ b/documentation/api/promise-all.md
@@ -15,11 +15,17 @@ This method is usually used in combination with
 Let's make an asynchronous assertion that we can use for the examples:
 
 ```js
-expect.addAssertion('to be a number after a short delay', function (expect, subject) {
-  return expect.promise(function (run) {
-    setTimeout(run(function () {
+expect.addAssertion('to be a number after a short delay', function(
+  expect,
+  subject
+) {
+  return expect.promise(function(run) {
+    setTimeout(
+      run(function() {
         expect(subject, 'to be a number');
-    }), 1);
+      }),
+      1
+    );
   });
 });
 ```

--- a/documentation/api/promise-any.md
+++ b/documentation/api/promise-any.md
@@ -12,11 +12,17 @@ rejected with the errors.
 Let's make an asynchronous assertion that we can use for the examples:
 
 ```js
-expect.addAssertion('to be a number after a short delay', function (expect, subject) {
-  return expect.promise(function (run) {
-    setTimeout(run(function () {
+expect.addAssertion('to be a number after a short delay', function(
+  expect,
+  subject
+) {
+  return expect.promise(function(run) {
+    setTimeout(
+      run(function() {
         expect(subject, 'to be a number');
-    }), 0);
+      }),
+      0
+    );
   });
 });
 ```

--- a/documentation/api/promise-settle.md
+++ b/documentation/api/promise-settle.md
@@ -13,11 +13,17 @@ on each of the promises to read their values.
 Let's make an asynchronous assertion that we can use for the examples:
 
 ```js
-expect.addAssertion('to be a number after a short delay', function (expect, subject) {
-  return expect.promise(function (run) {
-    setTimeout(run(function () {
+expect.addAssertion('to be a number after a short delay', function(
+  expect,
+  subject
+) {
+  return expect.promise(function(run) {
+    setTimeout(
+      run(function() {
         expect(subject, 'to be a number');
-    }), 1);
+      }),
+      1
+    );
   });
 });
 ```

--- a/documentation/api/shift.md
+++ b/documentation/api/shift.md
@@ -5,9 +5,12 @@ the `<assertion>` type, you can use `expect.shift` to invoke that assertion,
 optionally replacing the subject with an alternative one.
 
 ```js
-expect.addAssertion('<string> when parsed as an integer <assertion>', function (expect, subject) {
-    expect(subject, 'to match', /^[1-9][0-9]*$/);
-    return expect.shift(parseInt(subject, 10));
+expect.addAssertion('<string> when parsed as an integer <assertion>', function(
+  expect,
+  subject
+) {
+  expect(subject, 'to match', /^[1-9][0-9]*$/);
+  return expect.shift(parseInt(subject, 10));
 });
 
 expect('42', 'when parsed as an integer', 'to be greater than', 10);
@@ -49,18 +52,27 @@ sure to gather up the return values and use `expect.promise.all` or a similar
 construct to resolve them all, for example:
 
 ```js
-expect.addAssertion('<number> up to [and including] <number> <assertion?>', function (expect, subject, value) {
+expect.addAssertion(
+  '<number> up to [and including] <number> <assertion?>',
+  function(expect, subject, value) {
     expect.errorMode = 'nested';
     var numbers = [];
-    for (var i = subject ; i < (expect.flags['and including'] ? value + 1 : value) ; i += 1) {
-        numbers.push(i);
+    for (
+      var i = subject;
+      i < (expect.flags['and including'] ? value + 1 : value);
+      i += 1
+    ) {
+      numbers.push(i);
     }
-    return expect.promise.all(numbers.map(function (number) {
-        return expect.promise(function () {
-            return expect.shift(number);
+    return expect.promise.all(
+      numbers.map(function(number) {
+        return expect.promise(function() {
+          return expect.shift(number);
         });
-    }));
-});
+      })
+    );
+  }
+);
 
 expect(5, 'up to and including', 100, 'to be greater than', 4);
 ```

--- a/documentation/api/use.md
+++ b/documentation/api/use.md
@@ -9,13 +9,13 @@ Unexpected plugins are functions or objects that adhere to the following interfa
 
 Optional properties:
 
-* __name__: `String` - the name of the plugin.
-* __version__: `String` - the semver version of the plugin (string).
-* __dependencies__: `String array` - a list of dependencies.
+* **name**: `String` - the name of the plugin.
+* **version**: `String` - the semver version of the plugin (string).
+* **dependencies**: `String array` - a list of dependencies.
 
 Required:
 
-* __installInto__: `function(expect)` - a function that will update the given expect instance.
+* **installInto**: `function(expect)` - a function that will update the given expect instance.
 
 If you pass a function to `use`, it will be used as the `installInto`
 function, and the name of the function will be used as the name of the plugin,
@@ -59,21 +59,26 @@ Now we will define an example plugin that will add support for this type:
 ```js
 expect.use({
   name: 'unexpected-integer-intervals',
-  installInto: function (expect) {
-      expect.addType({
-        name: 'IntegerInterval',
-        base: 'object',
-        identify: function (value) {
-          return value && value instanceof IntegerInterval;
-        },
-        inspect: function (value, depth, output) {
-          output.text('[').jsNumber(value.from).text(',').jsNumber(value.to).text(']');
-        }
-      });
+  installInto: function(expect) {
+    expect.addType({
+      name: 'IntegerInterval',
+      base: 'object',
+      identify: function(value) {
+        return value && value instanceof IntegerInterval;
+      },
+      inspect: function(value, depth, output) {
+        output
+          .text('[')
+          .jsNumber(value.from)
+          .text(',')
+          .jsNumber(value.to)
+          .text(']');
+      }
+    });
 
-     expect.addAssertion('[not] to contain', function (expect, subject, value) {
-       expect(value, '[not] to be within', subject.from, subject.to);
-     });
+    expect.addAssertion('[not] to contain', function(expect, subject, value) {
+      expect(value, '[not] to be within', subject.from, subject.to);
+    });
   }
 });
 ```

--- a/documentation/api/withError.md
+++ b/documentation/api/withError.md
@@ -15,29 +15,40 @@ function Person(options) {
   this.gender = options.gender;
 }
 
-Person.prototype.genderSign = function () {
+Person.prototype.genderSign = function() {
   switch (this.gender) {
-  case 'female': return '♀';
-  case 'male': return '♂';
-  default: return '⚧';
+    case 'female':
+      return '♀';
+    case 'male':
+      return '♂';
+    default:
+      return '⚧';
   }
 };
 
-expect.addAssertion('to have same gender as', function (expect, subject, value) {
-  expect.withError(function () {
-    expect(subject.gender, 'to be', value.gender);
-  }, function (e) {
-    expect.fail({
-      diff: function (output) {
-        return output.bold(subject.genderSign()).text(' ≠ ').bold(value.genderSign());
-      }
-    });
-  });
+expect.addAssertion('to have same gender as', function(expect, subject, value) {
+  expect.withError(
+    function() {
+      expect(subject.gender, 'to be', value.gender);
+    },
+    function(e) {
+      expect.fail({
+        diff: function(output) {
+          return output
+            .bold(subject.genderSign())
+            .text(' ≠ ')
+            .bold(value.genderSign());
+        }
+      });
+    }
+  );
 });
 
-expect(new Person({ name: 'John Doe', gender: 'male' }),
-       'to have same gender as',
-       new Person({ name: 'Jane Doe', gender: 'female' }));
+expect(
+  new Person({ name: 'John Doe', gender: 'male' }),
+  'to have same gender as',
+  new Person({ name: 'Jane Doe', gender: 'female' })
+);
 ```
 
 ```output

--- a/documentation/assertions/Error/to-have-message.md
+++ b/documentation/assertions/Error/to-have-message.md
@@ -1,12 +1,12 @@
 Asserts that an Error instance the given message.
 
-```javascript
+```js
 expect(new Error('foobar'), 'to have message', 'foobar');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(new Error('foobar'), 'to have message', 'barfoo');
 ```
 
@@ -20,6 +20,6 @@ expected Error('foobar') to have message 'barfoo'
 
 The assertion uses `to satisfy` semantics, so you can also provide a regexp:
 
-```javascript
+```js
 expect(new Error('foobar'), 'to have message', /bar$/);
 ```

--- a/documentation/assertions/Promise/to-be-fulfilled-with-value-satisfying.md
+++ b/documentation/assertions/Promise/to-be-fulfilled-with-value-satisfying.md
@@ -1,18 +1,21 @@
 Asserts that a promise is fulfilled with a specific value:
 
-```javascript#async:true
-var promiseThatWillBeFulfilledWithAValue = new Promise(function (resolve, reject) {
-    setTimeout(function () {
-        resolve({
-            foo: 'bar'
-        });
-    }, 1);
+```js#async:true
+var promiseThatWillBeFulfilledWithAValue = new Promise(function(
+  resolve,
+  reject
+) {
+  setTimeout(function() {
+    resolve({
+      foo: 'bar'
+    });
+  }, 1);
 });
 
 return expect(
-    promiseThatWillBeFulfilledWithAValue,
-    'to be fulfilled with value satisfying',
-    { foo: 'bar' }
+  promiseThatWillBeFulfilledWithAValue,
+  'to be fulfilled with value satisfying',
+  { foo: 'bar' }
 );
 ```
 
@@ -20,21 +23,21 @@ The expected value will be matched against the value with
 [to satisfy](/assertions/any/to-satisfy/) semantics, so you can pass any of the
 values supported by `to satisfy`:
 
-```javascript#async:true
+```js#async:true
 return expect(
-    Promise.resolve('abc'),
-    'to be fulfilled with value satisfying',
-    /b/
+  Promise.resolve('abc'),
+  'to be fulfilled with value satisfying',
+  /b/
 );
 ```
 
 You get a nice diff if the assertion fails:
 
-```javascript#async:true
+```js#async:true
 return expect(
-    Promise.resolve('abc'),
-    'to be fulfilled with value satisfying',
-    'def'
+  Promise.resolve('abc'),
+  'to be fulfilled with value satisfying',
+  'def'
 );
 ```
 
@@ -49,16 +52,16 @@ expected Promise to be fulfilled with value satisfying 'def'
 You can use the `exhaustively` flag to use strict
 [to satisfy](/assertions/any/to-satisfy/) semantics:
 
-```javascript#async:true
+```js#async:true
 return expect(
-    Promise.resolve({
-        foo: 'foo',
-        bar: 'bar'
-    }),
-    'to be fulfilled with value exhaustively satisfying',
-    {
-        foo: 'foo'
-    }
+  Promise.resolve({
+    foo: 'foo',
+    bar: 'bar'
+  }),
+  'to be fulfilled with value exhaustively satisfying',
+  {
+    foo: 'foo'
+  }
 );
 ```
 

--- a/documentation/assertions/Promise/to-be-fulfilled-with.md
+++ b/documentation/assertions/Promise/to-be-fulfilled-with.md
@@ -1,26 +1,33 @@
 Asserts that a promise is fulfilled with a specific value:
 
-```javascript#async:true
-var promiseThatWillBeFulfilledWithAValue = new Promise(function (resolve, reject) {
-    setTimeout(function () {
-        resolve('abc');
-    }, 1);
+```js#async:true
+var promiseThatWillBeFulfilledWithAValue = new Promise(function(
+  resolve,
+  reject
+) {
+  setTimeout(function() {
+    resolve('abc');
+  }, 1);
 });
 
-return expect(promiseThatWillBeFulfilledWithAValue, 'to be fulfilled with', 'abc');
+return expect(
+  promiseThatWillBeFulfilledWithAValue,
+  'to be fulfilled with',
+  'abc'
+);
 ```
 
 The expected value will be matched against the value with
 [to satisfy](/assertions/any/to-satisfy/) semantics, so you can pass any of the
 values supported by `to satisfy`:
 
-```javascript#async:true
+```js#async:true
 return expect(Promise.resolve('abc'), 'to be fulfilled with', /b/);
 ```
 
 You get a nice diff if the assertion fails:
 
-```javascript#async:true
+```js#async:true
 return expect(Promise.resolve('abc'), 'to be fulfilled with', 'def');
 ```
 

--- a/documentation/assertions/Promise/to-be-fulfilled.md
+++ b/documentation/assertions/Promise/to-be-fulfilled.md
@@ -1,8 +1,8 @@
 Asserts that a promise is fulfilled.
 
-```javascript#async:true
-var promiseThatWillBeFulfilled = new Promise(function (resolve, reject) {
-    setTimeout(resolve, 1);
+```js#async:true
+var promiseThatWillBeFulfilled = new Promise(function(resolve, reject) {
+  setTimeout(resolve, 1);
 });
 
 return expect(promiseThatWillBeFulfilled, 'to be fulfilled');
@@ -10,11 +10,11 @@ return expect(promiseThatWillBeFulfilled, 'to be fulfilled');
 
 If the promise is rejected, the assertion will fail with the following output:
 
-```javascript#async:true
-var rejectedPromise = new Promise(function (resolve, reject) {
-    setTimeout(function () {
-        reject(new Error('argh'));
-    }, 1);
+```js#async:true
+var rejectedPromise = new Promise(function(resolve, reject) {
+  setTimeout(function() {
+    reject(new Error('argh'));
+  }, 1);
 });
 
 return expect(rejectedPromise, 'to be fulfilled');

--- a/documentation/assertions/Promise/to-be-rejected-with-error-satisfying.md
+++ b/documentation/assertions/Promise/to-be-rejected-with-error-satisfying.md
@@ -1,16 +1,19 @@
 Asserts that a promise is rejected with a specific reason (error):
 
-```javascript#async:true
-var promiseThatWillBeRejectedWithAReason = new Promise(function (resolve, reject) {
-    setTimeout(function () {
-        reject(new Error('Oh dear'));
-    }, 10);
+```js#async:true
+var promiseThatWillBeRejectedWithAReason = new Promise(function(
+  resolve,
+  reject
+) {
+  setTimeout(function() {
+    reject(new Error('Oh dear'));
+  }, 10);
 });
 
 return expect(
-    promiseThatWillBeRejectedWithAReason,
-    'to be rejected with error satisfying',
-    new Error('Oh dear')
+  promiseThatWillBeRejectedWithAReason,
+  'to be rejected with error satisfying',
+  new Error('Oh dear')
 );
 ```
 
@@ -18,34 +21,39 @@ The expected reason will be matched against the rejection reason with
 [to satisfy](/assertions/any/to-satisfy/) semantics, so you can pass any of the
 values supported by `to satisfy`:
 
-
-```javascript#async:true
-var promiseThatWillBeRejectedWithAReason = new Promise(function (resolve, reject) {
-    setTimeout(function () {
-        reject(new Error('Oh dear'));
-    }, 10);
+```js#async:true
+var promiseThatWillBeRejectedWithAReason = new Promise(function(
+  resolve,
+  reject
+) {
+  setTimeout(function() {
+    reject(new Error('Oh dear'));
+  }, 10);
 });
 
 return expect(
-    promiseThatWillBeRejectedWithAReason,
-    'to be rejected with error satisfying',
-    /dear/
+  promiseThatWillBeRejectedWithAReason,
+  'to be rejected with error satisfying',
+  /dear/
 );
 ```
 
 You get a nice diff if the assertion fails:
 
-```javascript#async:true
-var promiseThatWillBeRejectedWithAReason = new Promise(function (resolve, reject) {
-    setTimeout(function () {
-        reject(new Error('Oh dear'));
-    }, 10);
+```js#async:true
+var promiseThatWillBeRejectedWithAReason = new Promise(function(
+  resolve,
+  reject
+) {
+  setTimeout(function() {
+    reject(new Error('Oh dear'));
+  }, 10);
 });
 
 return expect(
-    promiseThatWillBeRejectedWithAReason,
-    'to be rejected with error satisfying',
-    new Error('bugger')
+  promiseThatWillBeRejectedWithAReason,
+  'to be rejected with error satisfying',
+  new Error('bugger')
 );
 ```
 
@@ -64,13 +72,13 @@ expected Promise to be rejected with error satisfying Error('bugger')
 You can use the `exhaustively` flag to use strict
 [to satisfy](/assertions/any/to-satisfy/) semantics:
 
-```javascript#async:true
+```js#async:true
 var error = new Error('Oh dear');
 error.data = { foo: 'bar' };
 return expect(
-    Promise.reject(error),
-    'to be rejected with error exhaustively satisfying',
-    new Error('Oh dear')
+  Promise.reject(error),
+  'to be rejected with error exhaustively satisfying',
+  new Error('Oh dear')
 );
 ```
 

--- a/documentation/assertions/Promise/to-be-rejected-with.md
+++ b/documentation/assertions/Promise/to-be-rejected-with.md
@@ -1,40 +1,60 @@
 Asserts that a promise is rejected with a specific reason (error):
 
-```javascript#async:true
-var promiseThatWillBeRejectedWithAReason = new Promise(function (resolve, reject) {
-    setTimeout(function () {
-        reject(new Error('Oh dear'));
-    }, 10);
+```js#async:true
+var promiseThatWillBeRejectedWithAReason = new Promise(function(
+  resolve,
+  reject
+) {
+  setTimeout(function() {
+    reject(new Error('Oh dear'));
+  }, 10);
 });
 
-return expect(promiseThatWillBeRejectedWithAReason, 'to be rejected with', new Error('Oh dear'));
+return expect(
+  promiseThatWillBeRejectedWithAReason,
+  'to be rejected with',
+  new Error('Oh dear')
+);
 ```
 
 The expected reason will be matched against the rejection reason with
 [to satisfy](/assertions/any/to-satisfy/) semantics, so you can pass any of the
 values supported by `to satisfy`:
 
-
-```javascript#async:true
-var promiseThatWillBeRejectedWithAReason = new Promise(function (resolve, reject) {
-    setTimeout(function () {
-        reject(new Error('Oh dear'));
-    }, 10);
+```js#async:true
+var promiseThatWillBeRejectedWithAReason = new Promise(function(
+  resolve,
+  reject
+) {
+  setTimeout(function() {
+    reject(new Error('Oh dear'));
+  }, 10);
 });
 
-return expect(promiseThatWillBeRejectedWithAReason, 'to be rejected with', /dear/);
+return expect(
+  promiseThatWillBeRejectedWithAReason,
+  'to be rejected with',
+  /dear/
+);
 ```
 
 You get a nice diff if the assertion fails:
 
-```javascript#async:true
-var promiseThatWillBeRejectedWithAReason = new Promise(function (resolve, reject) {
-    setTimeout(function () {
-        reject(new Error('Oh dear'));
-    }, 10);
+```js#async:true
+var promiseThatWillBeRejectedWithAReason = new Promise(function(
+  resolve,
+  reject
+) {
+  setTimeout(function() {
+    reject(new Error('Oh dear'));
+  }, 10);
 });
 
-return expect(promiseThatWillBeRejectedWithAReason, 'to be rejected with', new Error('bugger'));
+return expect(
+  promiseThatWillBeRejectedWithAReason,
+  'to be rejected with',
+  new Error('bugger')
+);
 ```
 
 ```output

--- a/documentation/assertions/Promise/to-be-rejected.md
+++ b/documentation/assertions/Promise/to-be-rejected.md
@@ -1,8 +1,8 @@
 Asserts that a promise is rejected.
 
-```javascript#async:true
-var promiseThatWillBeRejected = new Promise(function (resolve, reject) {
-    setTimeout(reject, 1);
+```js#async:true
+var promiseThatWillBeRejected = new Promise(function(resolve, reject) {
+  setTimeout(reject, 1);
 });
 
 return expect(promiseThatWillBeRejected, 'to be rejected');
@@ -10,9 +10,9 @@ return expect(promiseThatWillBeRejected, 'to be rejected');
 
 If the promise is fulfilled, the assertion will fail with the following output:
 
-```javascript#async:true
-var fulfilledPromise = new Promise(function (resolve, reject) {
-    setTimeout(resolve, 1);
+```js#async:true
+var fulfilledPromise = new Promise(function(resolve, reject) {
+  setTimeout(resolve, 1);
 });
 
 return expect(fulfilledPromise, 'to be rejected');

--- a/documentation/assertions/Promise/when-fulfilled.md
+++ b/documentation/assertions/Promise/when-fulfilled.md
@@ -1,10 +1,10 @@
 Wait for a promise to be fulfilled, then delegate the value to another assertion.
 
-```javascript#async:true
-var fulfilledPromise = new Promise(function (resolve, reject) {
-    setTimeout(function () {
-        resolve(123);
-    }, 1);
+```js#async:true
+var fulfilledPromise = new Promise(function(resolve, reject) {
+  setTimeout(function() {
+    resolve(123);
+  }, 1);
 });
 
 return expect(fulfilledPromise, 'when fulfilled', 'to equal', 123);
@@ -12,17 +12,21 @@ return expect(fulfilledPromise, 'when fulfilled', 'to equal', 123);
 
 It works with any assertion or `expect.it` construct:
 
-```javascript#async:true
-return expect(Promise.resolve(123), 'when fulfilled', expect.it('to be greater than', 100));
+```js#async:true
+return expect(
+  Promise.resolve(123),
+  'when fulfilled',
+  expect.it('to be greater than', 100)
+);
 ```
 
 If the response is rejected, the assertion fails with the following output:
 
-```javascript#async:true
-var rejectedPromise = new Promise(function (resolve, reject) {
-    setTimeout(function () {
-        reject(new Error('argh'));
-    }, 1);
+```js#async:true
+var rejectedPromise = new Promise(function(resolve, reject) {
+  setTimeout(function() {
+    reject(new Error('argh'));
+  }, 1);
 });
 
 return expect(rejectedPromise, 'when fulfilled', 'to equal', 123);

--- a/documentation/assertions/Promise/when-rejected.md
+++ b/documentation/assertions/Promise/when-rejected.md
@@ -1,10 +1,10 @@
 Wait for a promise to be rejected, then delegate the reason to another assertion.
 
-```javascript#async:true
-var rejectedPromise = new Promise(function (resolve, reject) {
-    setTimeout(function () {
-        reject(new Error('argh'));
-    }, 1);
+```js#async:true
+var rejectedPromise = new Promise(function(resolve, reject) {
+  setTimeout(function() {
+    reject(new Error('argh'));
+  }, 1);
 });
 
 return expect(rejectedPromise, 'when rejected', 'to equal', new Error('argh'));
@@ -12,13 +12,17 @@ return expect(rejectedPromise, 'when rejected', 'to equal', new Error('argh'));
 
 It works with any assertion or `expect.it` construct:
 
-```javascript#async:true
-return expect(Promise.reject(new Error('argh')), 'when rejected', expect.it('to have message', 'argh'));
+```js#async:true
+return expect(
+  Promise.reject(new Error('argh')),
+  'when rejected',
+  expect.it('to have message', 'argh')
+);
 ```
 
 If the response is fulfilled, the assertion fails with the following output:
 
-```javascript#async:true
+```js#async:true
 return expect(Promise.resolve(123), 'when rejected', 'to have message', 'argh');
 ```
 

--- a/documentation/assertions/any/to-be-a.md
+++ b/documentation/assertions/any/to-be-a.md
@@ -6,12 +6,12 @@ its name (as a string).
 
 For more information abort the type system see: [Types](/api/addType/)
 
-```javascript
+```js
 expect(true, 'to be a', 'boolean');
 expect(5, 'to be a', 'number');
 expect('abc', 'to be a', 'string');
 expect(expect, 'to be a', 'function');
-expect({foo: 123}, 'to be an', 'object');
+expect({ foo: 123 }, 'to be an', 'object');
 expect([123], 'to be an', 'array');
 expect(/regex/, 'to be a', 'regexp');
 expect(/regex/, 'to be a', 'regex');
@@ -22,19 +22,19 @@ expect(new Date(), 'to be a', 'date');
 
 The assertions also respect the inheritance chain:
 
-```javascript
+```js
 expect(/foo/, 'to be an', 'object');
 expect(/foo/, 'to be an', 'any');
 ```
 
 Aliases are provided for common types:
 
-```javascript
+```js
 expect(true, 'to be a boolean');
 expect(5, 'to be a number');
 expect('abc', 'to be a string');
 expect(expect, 'to be a function');
-expect({foo: 123}, 'to be an object');
+expect({ foo: 123 }, 'to be an object');
 expect([123], 'to be an array');
 expect(/regex/, 'to be a regexp');
 expect(/regex/, 'to be a regex');
@@ -44,9 +44,9 @@ expect(new Date(), 'to be a date');
 
 If you provide a constructor as the type the assertion will use `instanceof`.
 
-```javascript
+```js
 function Person(name) {
-    this.name = name;
+  this.name = name;
 }
 expect(new Person('John Doe'), 'to be a', Person);
 expect(new Person('John Doe'), 'to be an', Object);
@@ -54,7 +54,7 @@ expect(new Person('John Doe'), 'to be an', Object);
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect({ 0: 'foo', 1: 'bar', 2: 'baz' }, 'to be an array');
 ```
 
@@ -62,10 +62,9 @@ expect({ 0: 'foo', 1: 'bar', 2: 'baz' }, 'to be an array');
 expected { 0: 'foo', 1: 'bar', 2: 'baz' } to be an array
 ```
 
-
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(true, 'not to be an object');
 expect('5', 'not to be a', 'number');
 expect('abc', 'not to be an', Object);
@@ -73,8 +72,14 @@ expect('abc', 'not to be an', Object);
 
 In case of a failing expectation you get the following output:
 
-```javascript
-expect(function () { return 'wat'; }, 'not to be an', Object);
+```js
+expect(
+  function() {
+    return 'wat';
+  },
+  'not to be an',
+  Object
+);
 ```
 
 ```output

--- a/documentation/assertions/any/to-be-defined.md
+++ b/documentation/assertions/any/to-be-defined.md
@@ -1,13 +1,13 @@
 Asserts that the value is defined.
 
-```javascript
+```js
 expect('Hello world!', 'to be defined');
 expect({ foo: { bar: 'baz' } }, 'to be defined');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(undefined, 'to be defined');
 ```
 

--- a/documentation/assertions/any/to-be-falsy.md
+++ b/documentation/assertions/any/to-be-falsy.md
@@ -1,6 +1,6 @@
 Asserts that the value is _falsy_.
 
-```javascript
+```js
 expect(0, 'to be falsy');
 expect(false, 'to be falsy');
 expect('', 'to be falsy');
@@ -10,7 +10,7 @@ expect(null, 'to be falsy');
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect({}, 'to be falsy');
 ```
 
@@ -20,7 +20,7 @@ expected {} to be falsy
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(1, 'not to be falsy');
 expect(true, 'not to be falsy');
 expect({}, 'not to be falsy');
@@ -30,7 +30,7 @@ expect(/foo/, 'not to be falsy');
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('', 'not to be falsy');
 ```
 

--- a/documentation/assertions/any/to-be-null.md
+++ b/documentation/assertions/any/to-be-null.md
@@ -1,12 +1,12 @@
 Asserts that the value is `null`.
 
-```javascript
+```js
 expect(null, 'to be null');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect({ foo: { bar: 'baz' } }, 'to be null');
 ```
 
@@ -16,14 +16,14 @@ expected { foo: { bar: 'baz' } } to be null
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect({ foo: { bar: 'baz' } }, 'not to be null');
 expect('Hello world!', 'not to be null');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(null, 'not to be null');
 ```
 

--- a/documentation/assertions/any/to-be-ok.md
+++ b/documentation/assertions/any/to-be-ok.md
@@ -2,7 +2,7 @@ Asserts that the value is _truthy_.
 
 Alias for [to be truthy](../to-be-truthy).
 
-```javascript
+```js
 expect(1, 'to be ok');
 expect(true, 'to be ok');
 expect({}, 'to be ok');
@@ -12,7 +12,7 @@ expect(/foo/, 'to be ok');
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('', 'to be ok');
 ```
 
@@ -22,7 +22,7 @@ expected '' to be ok
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(0, 'not to be ok');
 expect(false, 'not to be ok');
 expect('', 'not to be ok');
@@ -32,7 +32,7 @@ expect(null, 'not to be ok');
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect({}, 'not to be ok');
 ```
 

--- a/documentation/assertions/any/to-be-one-of.md
+++ b/documentation/assertions/any/to-be-one-of.md
@@ -1,6 +1,6 @@
 Asserts that the subject equals one of the given items
 
-```javascript
+```js
 expect(true, 'to be one of', [true, false]);
 expect(1, 'to be one of', [0, 1, 2]);
 ```
@@ -9,7 +9,7 @@ Aliases are provided for common types:
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(42, 'to be one of', [0, 1]);
 ```
 
@@ -17,9 +17,8 @@ expect(42, 'to be one of', [0, 1]);
 expected 42 to be one of [ 0, 1 ]
 ```
 
-
 This assertion can be negated using the `not` flag:
 
-```javascript
-expect(true, 'not to be one of', [ 1, 2 ]);
+```js
+expect(true, 'not to be one of', [1, 2]);
 ```

--- a/documentation/assertions/any/to-be-truthy.md
+++ b/documentation/assertions/any/to-be-truthy.md
@@ -1,6 +1,6 @@
 Asserts that the value is _truthy_.
 
-```javascript
+```js
 expect(1, 'to be truthy');
 expect(true, 'to be truthy');
 expect({}, 'to be truthy');
@@ -10,7 +10,7 @@ expect(/foo/, 'to be truthy');
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('', 'to be truthy');
 ```
 
@@ -20,7 +20,7 @@ expected '' to be truthy
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(0, 'not to be truthy');
 expect(false, 'not to be truthy');
 expect('', 'not to be truthy');
@@ -30,7 +30,7 @@ expect(null, 'not to be truthy');
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect({}, 'not to be truthy');
 ```
 

--- a/documentation/assertions/any/to-be-undefined.md
+++ b/documentation/assertions/any/to-be-undefined.md
@@ -1,12 +1,12 @@
 Asserts that the value is `undefined`.
 
-```javascript
+```js
 expect(undefined, 'to be undefined');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('Hello world', 'to be undefined');
 ```
 
@@ -16,14 +16,14 @@ expected 'Hello world' to be undefined
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect('Hello world!', 'not to be undefined');
 expect({ foo: { bar: 'baz' } }, 'not to be undefined');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(undefined, 'not to be undefined');
 ```
 

--- a/documentation/assertions/any/to-be.md
+++ b/documentation/assertions/any/to-be.md
@@ -1,6 +1,6 @@
 Asserts equality using `Object.is`/the [SameValue](http://ecma-international.org/ecma-262/5.1/#sec-9.12) algorithm.
 
-```javascript
+```js
 var obj = {};
 expect(obj, 'to be', obj);
 expect(1, 'to be', 1);
@@ -12,15 +12,17 @@ expect(true, 'to be', !false);
 The SameValue/`Object.is` algorithm has some subtle differences compared to the `===` operator, which makes it more suitable for an assertion lib:
 
 <!-- evaluate -->
-```javascript
+
+```js
 expect(NaN, 'to be', NaN);
 expect(-0, 'not to be', 0);
 ```
+
 <!-- /evaluate -->
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('1', 'to be', 1);
 ```
 
@@ -30,7 +32,7 @@ expected '1' to be 1
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect({}, 'not to be', {});
 expect(1, 'not to be', true);
 expect('1', 'not to be', 1);
@@ -43,7 +45,7 @@ expect(true, 'not to be', 'false');
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(1, 'not to be', 1);
 ```
 

--- a/documentation/assertions/any/to-equal.md
+++ b/documentation/assertions/any/to-equal.md
@@ -1,6 +1,6 @@
 Asserts deep equality.
 
-```javascript
+```js
 expect({ a: 'b' }, 'to equal', { a: 'b' });
 var now = new Date();
 expect(now, 'to equal', now);
@@ -13,7 +13,7 @@ diff. Below you can see some examples of the diffs.
 
 An object diff containing a string diff:
 
-```javascript
+```js
 expect({ text: 'foo!' }, 'to equal', { text: 'f00!' });
 ```
 
@@ -30,8 +30,13 @@ expected { text: 'foo!' } to equal { text: 'f00!' }
 
 A diff between objects with different keys.
 
-```javascript
-expect({ one: 1, two: 2, four: 4, five: 5 }, 'to equal', { one: 1, two: 2, three: 3, four: 4 });
+```js
+expect({ one: 1, two: 2, four: 4, five: 5 }, 'to equal', {
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4
+});
 ```
 
 ```output
@@ -49,8 +54,8 @@ to equal { one: 1, two: 2, three: 3, four: 4 }
 
 A diff between two arrays.
 
-```javascript
-expect([ 0, 2, 1, 4 ], 'to equal', [ 0, 1, 2, 3, 4 ])
+```js
+expect([0, 2, 1, 4], 'to equal', [0, 1, 2, 3, 4]);
 ```
 
 ```output
@@ -68,7 +73,7 @@ expected [ 0, 2, 1, 4 ] to equal [ 0, 1, 2, 3, 4 ]
 
 A diff between two buffers.
 
-```javascript#skipBrowser:true
+```js#skipBrowser:true
 expect(
     new Buffer('\x00\x01\x02Here is the thing I was talking about', 'utf-8'),
     'to equal',
@@ -88,7 +93,7 @@ to equal Buffer([0x00, 0x01, 0x02, 0x48, 0x65, 0x72, 0x65, 0x20, 0x69, 0x73, 0x2
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(1, 'not to equal', '1');
 expect({ one: 1 }, 'not to equal', { one: '1' });
 expect(null, 'not to equal', '1');
@@ -100,8 +105,8 @@ expect({ time: now }, 'not to equal', { time: later });
 
 In case of a failing expectation you get the following output:
 
-```javascript
-expect({ a: { b: 'd'} }, 'not to equal', { a: { b: 'd'} });
+```js
+expect({ a: { b: 'd' } }, 'not to equal', { a: { b: 'd' } });
 ```
 
 ```output

--- a/documentation/assertions/any/to-satisfy.md
+++ b/documentation/assertions/any/to-satisfy.md
@@ -3,27 +3,29 @@ Asserts that a value matches a given specification.
 All properties and nested objects mentioned in the right-hand side object are
 required to be present. Primitive values are compared with `to equal` semantics:
 
-```javascript
+```js
 expect({ hey: { there: true } }, 'to satisfy', { hey: {} });
 ```
 
 To disallow additional properties in the subject, use `to exhaustively satisfy`:
 
-```javascript
-expect({ hey: { there: true } }, 'to exhaustively satisfy', { hey: { there: true } });
+```js
+expect({ hey: { there: true } }, 'to exhaustively satisfy', {
+  hey: { there: true }
+});
 ```
 
 Regular expressions and functions in the right-hand side object will be run
 against the corresponding values in the subject:
 
-```javascript
+```js
 expect({ bar: 'quux', baz: true }, 'to satisfy', { bar: /QU*X/i });
 ```
 
 Arrays in the right-hand side will require all the items to be present:
 
-```javascript
-expect([0,1,2], 'to satisfy', [0,1]);
+```js
+expect([0, 1, 2], 'to satisfy', [0, 1]);
 ```
 
 ```output
@@ -39,8 +41,8 @@ expected [ 0, 1, 2 ] to satisfy [ 0, 1 ]
 If you want to make assertions about the individual indexes in an array, you can
 do it the following way:
 
-```javascript
-expect([0,1,2,3], 'to satisfy', {1: 2, 2: 1});
+```js
+expect([0, 1, 2, 3], 'to satisfy', { 1: 2, 2: 1 });
 ```
 
 ```output
@@ -57,27 +59,29 @@ expected [ 0, 1, 2, 3 ] to satisfy { 1: 2, 2: 1 }
 `to satisfy` can be combined with `expect.it` or functions to create complex
 specifications that delegate to existing assertions:
 
-```javascript
-expect({foo: 123, bar: 'bar', baz: 'bogus', qux: 42}, 'to satisfy', {
-    foo: expect.it('to be a number').and('to be greater than', 10),
-    baz: expect.it('not to match', /^boh/),
-    qux: expect.it('to be a string')
-                  .and('not to be empty')
-               .or('to be a number')
-                  .and('to be positive')
+```js
+expect({ foo: 123, bar: 'bar', baz: 'bogus', qux: 42 }, 'to satisfy', {
+  foo: expect.it('to be a number').and('to be greater than', 10),
+  baz: expect.it('not to match', /^boh/),
+  qux: expect
+    .it('to be a string')
+    .and('not to be empty')
+    .or('to be a number')
+    .and('to be positive')
 });
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
-expect({foo: 9, bar: 'bar', baz: 'bogus', qux: 42}, 'to satisfy', {
-    foo: expect.it('to be a number').and('to be greater than', 10),
-    baz: expect.it('not to match', /^bog/),
-    qux: expect.it('to be a string')
-                  .and('not to be empty')
-               .or('to be a number')
-                  .and('to be positive')
+```js
+expect({ foo: 9, bar: 'bar', baz: 'bogus', qux: 42 }, 'to satisfy', {
+  foo: expect.it('to be a number').and('to be greater than', 10),
+  baz: expect.it('not to match', /^bog/),
+  qux: expect
+    .it('to be a string')
+    .and('not to be empty')
+    .or('to be a number')
+    .and('to be positive')
 });
 ```
 

--- a/documentation/assertions/any/when-passed-as-parameter-to.md
+++ b/documentation/assertions/any/when-passed-as-parameter-to.md
@@ -2,7 +2,7 @@ Apply a function to the subject, then delegate the return value to another asser
 
 ```js
 function increment(n) {
-    return n + 1;
+  return n + 1;
 }
 
 expect(1, 'when passed as parameter to', increment, 'to equal', 2);

--- a/documentation/assertions/array-like/to-be-empty.md
+++ b/documentation/assertions/array-like/to-be-empty.md
@@ -2,14 +2,14 @@ Asserts that an array (or array-like object) is empty.
 
 Aliases: `to be the empty array`, `to be an empty array`
 
-```javascript
+```js
 expect([], 'to be empty');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
-expect([1,2,3], 'to be empty');
+```js
+expect([1, 2, 3], 'to be empty');
 ```
 
 ```output
@@ -18,13 +18,13 @@ expected [ 1, 2, 3 ] to be empty
 
 This assertion can be negated using the `not` flag:
 
-```javascript
-expect([1,2,3], 'not to be empty');
+```js
+expect([1, 2, 3], 'not to be empty');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect([], 'not to be empty');
 ```
 

--- a/documentation/assertions/array-like/to-be-non-empty.md
+++ b/documentation/assertions/array-like/to-be-non-empty.md
@@ -1,17 +1,18 @@
 ---
 title: to be non-empty
 ---
+
 Asserts that an array (or array-like object) is empty.
 
 Aliases: `not to be empty`
 
-```javascript
+```js
 expect([1, 2, 3], 'to be non-empty');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect([], 'to be non-empty');
 ```
 

--- a/documentation/assertions/array-like/to-contain.md
+++ b/documentation/assertions/array-like/to-contain.md
@@ -1,17 +1,20 @@
 Asserts an array (or array-like object) contains one or more items.
 
-```javascript
+```js
 expect([0, 1, 2], 'to contain', 1);
-expect([ { name: 'John Doe' }, { name: 'Jane Doe' } ], 'to contain', { name: 'Jane Doe' });
+expect([{ name: 'John Doe' }, { name: 'Jane Doe' }], 'to contain', {
+  name: 'Jane Doe'
+});
 expect([0, 1, 2], 'to contain', 0, 2);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
-expect([ { name: 'John Doe' }, { name: 'Jane Doe' } ], 'to contain', { name: 'Jonnie Doe' });
+```js
+expect([{ name: 'John Doe' }, { name: 'Jane Doe' }], 'to contain', {
+  name: 'Jonnie Doe'
+});
 ```
-
 
 ```output
 expected [ { name: 'John Doe' }, { name: 'Jane Doe' } ]
@@ -20,14 +23,18 @@ to contain { name: 'Jonnie Doe' }
 
 This assertion can be negated using the `not` flag:
 
-```javascript
-expect([ { name: 'John Doe' }, { name: 'Jane Doe' } ], 'not to contain', { name: 'Jonnie Doe' });
+```js
+expect([{ name: 'John Doe' }, { name: 'Jane Doe' }], 'not to contain', {
+  name: 'Jonnie Doe'
+});
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
-expect([ { name: 'John Doe' }, { name: 'Jane Doe' } ], 'not to contain', { name: 'Jane Doe' });
+```js
+expect([{ name: 'John Doe' }, { name: 'Jane Doe' }], 'not to contain', {
+  name: 'Jane Doe'
+});
 ```
 
 ```output

--- a/documentation/assertions/array-like/to-have-an-item-satisfying.md
+++ b/documentation/assertions/array-like/to-have-an-item-satisfying.md
@@ -3,26 +3,26 @@ a given value, function or other assertion.
 
 Note that this assertion fails if passed an empty array as the subject.
 
-```javascript
-expect([ { a: 1 },  { b: 2 } ], 'to have an item satisfying',  { a: 1 } );
+```js
+expect([{ a: 1 }, { b: 2 }], 'to have an item satisfying', { a: 1 });
 
 expect([0, 1, 2, 3, 4], 'to have an item satisfying', 'to be a number');
 
-expect([0, 1, 2, 3, 4], 'to have an item satisfying', function (item, index) {
-    expect(item, 'to be a number');
+expect([0, 1, 2, 3, 4], 'to have an item satisfying', function(item, index) {
+  expect(item, 'to be a number');
 });
 
 expect(
-    [[1], ['foo']],
-    'to have an item satisfying',
-    'to have an item satisfying',
-    'to be a number'
+  [[1], ['foo']],
+  'to have an item satisfying',
+  'to have an item satisfying',
+  'to be a number'
 );
 
 expect(
-    [-1, -2, 3],
-    'to have an item satisfying',
-    expect.it('to be a number').and('to be positive')
+  [-1, -2, 3],
+  'to have an item satisfying',
+  expect.it('to be a number').and('to be positive')
 );
 ```
 
@@ -31,12 +31,12 @@ The expected value will be matched against the value with
 values supported by `to satisfy`. To use strict `to satisfy` semantics, you can
 use the "exhaustively" flag:
 
-```javascript
-expect([ { a: 1, b: 2 } ], 'to have a value satisfying', { a: 1 });
+```js
+expect([{ a: 1, b: 2 }], 'to have a value satisfying', { a: 1 });
 ```
 
-```javascript
-expect([ { a: 1, b: 2 } ], 'to have a value exhaustively satisfying', { a: 1 });
+```js
+expect([{ a: 1, b: 2 }], 'to have a value exhaustively satisfying', { a: 1 });
 ```
 
 ```output
@@ -45,12 +45,12 @@ expected [ { a: 1, b: 2 } ] to have a value exhaustively satisfying { a: 1 }
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(
-    [ ['0', '1'], ['5', '6'], ['7', '8'] ],
-    'to have an item satisfying',
-    'to have an item satisfying',
-    'to be a number'
+  [['0', '1'], ['5', '6'], ['7', '8']],
+  'to have an item satisfying',
+  'to have an item satisfying',
+  'to be a number'
 );
 ```
 
@@ -61,11 +61,11 @@ to have an item satisfying to have an item satisfying to be a number
 
 Here a another example:
 
-```javascript
+```js
 expect(
-    [0, -1, -2, -3, -4],
-    'to have an item satisfying',
-    expect.it('to be a number').and('to be positive')
+  [0, -1, -2, -3, -4],
+  'to have an item satisfying',
+  expect.it('to be a number').and('to be positive')
 );
 ```
 
@@ -77,11 +77,11 @@ expect.it('to be a number')
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(
-    [0, -1, -2, -3, -4],
-    'not to have an item satisfying',
-    expect.it('to be a number').and('to be negative')
+  [0, -1, -2, -3, -4],
+  'not to have an item satisfying',
+  expect.it('to be a number').and('to be negative')
 );
 ```
 

--- a/documentation/assertions/array-like/to-have-items-satisfying.md
+++ b/documentation/assertions/array-like/to-have-items-satisfying.md
@@ -4,27 +4,36 @@ Alias: `to be an array whose items satisfy`.
 
 Notice this assertion fails when given an empty array.
 
-```javascript
-expect([0, 1, 2, 3, 4], 'to have items satisfying', function (item, index) {
-    expect(item, 'to be a number');
+```js
+expect([0, 1, 2, 3, 4], 'to have items satisfying', function(item, index) {
+  expect(item, 'to be a number');
 });
 
 expect([0, 1, 2, 3, 4], 'to have items satisfying', 'to be a number');
 
-expect([[1], [2]], 'to have items satisfying',
-       'to have items satisfying', 'to be a number');
+expect(
+  [[1], [2]],
+  'to have items satisfying',
+  'to have items satisfying',
+  'to be a number'
+);
 
-expect([1, 2, 3, 4], 'to have items satisfying',
-  expect.it('to be a number').and('to be positive'));
+expect(
+  [1, 2, 3, 4],
+  'to have items satisfying',
+  expect.it('to be a number').and('to be positive')
+);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
-expect([ [0, 1, 2], [4, '5', '6'], [7, '8', 9] ],
+```js
+expect(
+  [[0, 1, 2], [4, '5', '6'], [7, '8', 9]],
   'to have items satisfying',
   'to have items satisfying',
-  'to be a number');
+  'to be a number'
+);
 ```
 
 ```output
@@ -47,9 +56,12 @@ expected array to have items satisfying to have items satisfying to be a number
 
 Here a another example:
 
-```javascript
-expect([0, 1, 2, 3, 4], 'to have items satisfying',
-  expect.it('to be a number').and('to be positive'));
+```js
+expect(
+  [0, 1, 2, 3, 4],
+  'to have items satisfying',
+  expect.it('to be a number').and('to be positive')
+);
 ```
 
 ```output

--- a/documentation/assertions/array-like/to-have-length.md
+++ b/documentation/assertions/array-like/to-have-length.md
@@ -1,13 +1,13 @@
 Asserts that an array (or array-like object) has the specified length.
 
-```javascript
-expect([1,2,3], 'to have length', 3);
+```js
+expect([1, 2, 3], 'to have length', 3);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
-expect([1,2,3], 'to have length', 4);
+```js
+expect([1, 2, 3], 'to have length', 4);
 ```
 
 ```output
@@ -17,14 +17,14 @@ expected [ 1, 2, 3 ] to have length 4
 
 This assertion can be negated using the `not` flag:
 
-```javascript
-expect([1,2,3], 'not to have length', 4);
+```js
+expect([1, 2, 3], 'not to have length', 4);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
-expect([1,2,3], 'not to have length', 3);
+```js
+expect([1, 2, 3], 'not to have length', 3);
 ```
 
 ```output

--- a/documentation/assertions/array-like/when-passed-as-parameters-to.md
+++ b/documentation/assertions/array-like/when-passed-as-parameters-to.md
@@ -2,7 +2,7 @@ Apply a function to the subject array (or array-like object), then delegate the 
 
 ```js
 function add(a, b) {
-    return a + b;
+  return a + b;
 }
 
 expect([1, 2], 'when passed as parameters to', add, 'to equal', 3);
@@ -24,14 +24,20 @@ To call an node-style async function, use the `async` flag to automatically
 add a callback to the parameter list and do further assertions on the value it
 passes to the callback.
 
-```javascript#async:true
+```js#async:true
 function delayedAdd(a, b, cb) {
-    setTimeout(function () {
-        cb(null, a + b);
-    }, 1);
+  setTimeout(function() {
+    cb(null, a + b);
+  }, 1);
 }
 
-return expect([1, 2], 'when passed as parameters to async', delayedAdd, 'to equal', 3);
+return expect(
+  [1, 2],
+  'when passed as parameters to async',
+  delayedAdd,
+  'to equal',
+  3
+);
 ```
 
 The assertion will fail if the async function passes an error to the callback.
@@ -39,9 +45,9 @@ The assertion will fail if the async function passes an error to the callback.
 You can also use the `constructor` flag to create an instance of a constructor
 function (using the `new` operator):
 
-```javascript
+```js
 function Foo(value) {
-    this.value = value;
+  this.value = value;
 }
 
 expect([123], 'when passed as parameters to constructor', Foo, 'to be a', Foo);
@@ -51,7 +57,7 @@ If you don't provide an assertion to delegate to, the return value will be provi
 as the fulfillment value of the promise:
 
 ```js#async:true
-return expect([1, 3], 'passed as parameters to', add).then(function (result) {
-    expect(result, 'to equal', 4);
+return expect([1, 3], 'passed as parameters to', add).then(function(result) {
+  expect(result, 'to equal', 4);
 });
 ```

--- a/documentation/assertions/array-like/when-sorted-by.md
+++ b/documentation/assertions/array-like/when-sorted-by.md
@@ -2,17 +2,29 @@ Sort the subject array by a compare function that defines the sort order then
 delegate the return value to another assertion.
 
 ```js
-expect([2, 1, 3], 'when sorted by', function (a, b) {
+expect(
+  [2, 1, 3],
+  'when sorted by',
+  function(a, b) {
     return a - b;
-}, 'to equal', [1, 2, 3]);
+  },
+  'to equal',
+  [1, 2, 3]
+);
 ```
 
 In case of a failing expectation you get the following output:
 
 ```js
-expect([2, 1, 3], 'when sorted by', function (a, b) {
+expect(
+  [2, 1, 3],
+  'when sorted by',
+  function(a, b) {
     return a - b;
-}, 'to equal', [3, 2, 1]);
+  },
+  'to equal',
+  [3, 2, 1]
+);
 ```
 
 ```output

--- a/documentation/assertions/boolean/to-be-false.md
+++ b/documentation/assertions/boolean/to-be-false.md
@@ -1,12 +1,12 @@
 Asserts that the value is `false`.
 
-```javascript
+```js
 expect(false, 'to be false');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(true, 'to be false');
 ```
 

--- a/documentation/assertions/boolean/to-be-true.md
+++ b/documentation/assertions/boolean/to-be-true.md
@@ -1,12 +1,12 @@
 Asserts that the value is `true`.
 
-```javascript
+```js
 expect(true, 'to be true');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(false, 'to be true');
 ```
 

--- a/documentation/assertions/function/to-call-the-callback-with-error.md
+++ b/documentation/assertions/function/to-call-the-callback-with-error.md
@@ -1,36 +1,48 @@
 Asserts that a node.js-style asynchronous function taking a single callback
 will call it with a truthy value as the first parameter.
 
-```javascript
+```js
 function myFailingAsyncFunction(cb) {
-    setTimeout(function () {
-        cb(new Error('Oh dear'));
-    }, 0);
+  setTimeout(function() {
+    cb(new Error('Oh dear'));
+  }, 0);
 }
 ```
 
-```javascript#async:true
+```js#async:true
 return expect(myFailingAsyncFunction, 'to call the callback with error');
 ```
 
 You can assert the error message is a given string if you provide a
 string as the second parameter.
 
-```javascript#async:true
-return expect(myFailingAsyncFunction, 'to call the callback with error', 'Oh dear');
+```js#async:true
+return expect(
+  myFailingAsyncFunction,
+  'to call the callback with error',
+  'Oh dear'
+);
 ```
 
 A regular expression, Error instance, or an object will also work, as the
 matching uses [to satisfy](/assertions/any/to-satisfy/) semantics:
 
-```javascript#async:true
-return expect(myFailingAsyncFunction, 'to call the callback with error', /dear/);
+```js#async:true
+return expect(
+  myFailingAsyncFunction,
+  'to call the callback with error',
+  /dear/
+);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript#async:true
-return expect(myFailingAsyncFunction, 'to call the callback with error', new Error('foo'));
+```js#async:true
+return expect(
+  myFailingAsyncFunction,
+  'to call the callback with error',
+  new Error('foo')
+);
 ```
 
 ```output
@@ -54,12 +66,12 @@ to call the callback with error Error('foo')
 The error passed to the callback is also provided as the fulfillment value of
 the returned promise, so you can do further assertions like this:
 
-```javascript#async:true
+```js#async:true
 function asyncFn(cb) {
-    cb(new Error('yikes'));
+  cb(new Error('yikes'));
 }
 
-return expect(asyncFn, 'to call the callback with error').then(function (err) {
-    // err will be new Error('yikes')
+return expect(asyncFn, 'to call the callback with error').then(function(err) {
+  // err will be new Error('yikes')
 });
 ```

--- a/documentation/assertions/function/to-call-the-callback-without-error.md
+++ b/documentation/assertions/function/to-call-the-callback-without-error.md
@@ -1,9 +1,9 @@
 Asserts that a node.js-style asynchronous function taking a single callback
 will call it without passing a truthy value as the first parameter.
 
-```javascript#async:true
+```js#async:true
 function mySuccessfulAsyncFunction(cb) {
-    setTimeout(cb, 0);
+  setTimeout(cb, 0);
 }
 
 return expect(mySuccessfulAsyncFunction, 'to call the callback without error');
@@ -11,11 +11,11 @@ return expect(mySuccessfulAsyncFunction, 'to call the callback without error');
 
 In case of a failing expectation you get the following output:
 
-```javascript#async:true
+```js#async:true
 function myFailingAsyncFunction(cb) {
-    setTimeout(function () {
-        cb(new Error('Oh dear'));
-    }, 0);
+  setTimeout(function() {
+    cb(new Error('Oh dear'));
+  }, 0);
 }
 
 return expect(myFailingAsyncFunction, 'to call the callback without error');
@@ -36,21 +36,26 @@ The parameters passed to the callback (excluding the falsy error) are also
 provided as the value of the returned promise, so you can do further
 assertions like this:
 
-```javascript#async:true
+```js#async:true
 function asyncFn(cb) {
-    cb(null, 123, 456);
+  cb(null, 123, 456);
 }
 
-return expect(asyncFn, 'to call the callback without error').then(function (args) {
-    // args will be [123, 456];
+return expect(asyncFn, 'to call the callback without error').then(function(
+  args
+) {
+  // args will be [123, 456];
 });
 ```
 
 Or using the Bluebird-specific `.spread` extension:
 
-```javascript#async:true
-return expect(asyncFn, 'to call the callback without error').spread(function (result1, result2) {
-    // result1 will be 123
-    // result2 will be 456
+```js#async:true
+return expect(asyncFn, 'to call the callback without error').spread(function(
+  result1,
+  result2
+) {
+  // result1 will be 123
+  // result2 will be 456
 });
 ```

--- a/documentation/assertions/function/to-call-the-callback.md
+++ b/documentation/assertions/function/to-call-the-callback.md
@@ -1,11 +1,11 @@
 Asserts that a node.js-style asynchronous function taking a single callback
 will call it.
 
-```javascript#async:true
+```js#async:true
 function mySuccessfulAsyncFunction(cb) {
-    setTimeout(function () {
-        cb();
-    });
+  setTimeout(function() {
+    cb();
+  });
 }
 
 return expect(mySuccessfulAsyncFunction, 'to call the callback');
@@ -15,9 +15,9 @@ If the callback is never called, it will hang until your test framework marks
 it as timed out. So the assertion itself only ever fails if the function
 throws an exception synchronously:
 
-```javascript#async:true
+```js#async:true
 function errorOut(cb) {
-    throw new Error('ugh');
+  throw new Error('ugh');
 }
 return expect(errorOut, 'to call the callback');
 ```
@@ -38,25 +38,25 @@ you might be able to use the
 The parameters passed to the callback are also provided as the value of the returned promise,
 so you can do further assertions like this:
 
-```javascript
+```js
 function asyncFn(cb) {
-    setTimeout(function () {
-        cb(null, 'foo');
-    });
+  setTimeout(function() {
+    cb(null, 'foo');
+  });
 }
 ```
 
-```javascript#async:true
-return expect(asyncFn, 'to call the callback').then(function (args) {
-    // args will be [null, 'foo'];
+```js#async:true
+return expect(asyncFn, 'to call the callback').then(function(args) {
+  // args will be [null, 'foo'];
 });
 ```
 
 Or using the Bluebird-specific `.spread` extension:
 
-```javascript#async:true
-return expect(asyncFn, 'to call the callback').spread(function (err, result) {
-    // err will be null
-    // result will be 'foo'
+```js#async:true
+return expect(asyncFn, 'to call the callback').spread(function(err, result) {
+  // err will be null
+  // result will be 'foo'
 });
 ```

--- a/documentation/assertions/function/to-error.md
+++ b/documentation/assertions/function/to-error.md
@@ -1,25 +1,25 @@
 Asserts that the function throws an error, or returns a promise that
 is rejected.
 
-```javascript
+```js
 function willBeRejected() {
-    return new Promise(function (resolve, reject) {
-        reject(new Error('The reject message'));
-    });
+  return new Promise(function(resolve, reject) {
+    reject(new Error('The reject message'));
+  });
 }
 ```
 
-```javascript#async:true
+```js#async:true
 return expect(willBeRejected, 'to error');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript#async:true
+```js#async:true
 function willNotBeRejected() {
-    return new Promise(function (resolve, reject) {
-        resolve('Hello world');
-    });
+  return new Promise(function(resolve, reject) {
+    resolve('Hello world');
+  });
 }
 
 return expect(willNotBeRejected, 'to error');
@@ -38,11 +38,11 @@ to error
 You can assert the error message is a given string if you provide a
 string as the second parameter.
 
-```javascript#async:true
+```js#async:true
 return expect(willBeRejected, 'to error', 'The reject message');
 ```
 
-```javascript#async:true
+```js#async:true
 return expect(willBeRejected, 'to error', 'The error message');
 ```
 
@@ -63,13 +63,13 @@ to error 'The error message'
 By providing a regular expression as the second parameter you can
 assert the error message matches the given regular expression.
 
-```javascript#async:true
+```js#async:true
 return expect(willBeRejected, 'to error', /reject message/);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript#async:true
+```js#async:true
 return expect(willBeRejected, 'to error', /error message/);
 ```
 
@@ -87,13 +87,13 @@ to error /error message/
 You can also negate the check, and verify that the function will not
 error out. When negating the assertion, you cannot provide a message.
 
-```javascript#async:true
+```js#async:true
 return expect(willNotBeRejected, 'not to error');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript#async:true
+```js#async:true
 return expect(willBeRejected, 'not to error');
 ```
 
@@ -111,38 +111,38 @@ not to error
 You can pass in a function instead of the error message, and do more
 assertions on the error.
 
-```javascript#async:true
+```js#async:true
 function willBeRejectedAsync() {
-    return new Promise(function (resolve, reject) {
-        setTimeout(function () {
-            reject(new Error('async error'));
-        }, 1);
-    });
+  return new Promise(function(resolve, reject) {
+    setTimeout(function() {
+      reject(new Error('async error'));
+    }, 1);
+  });
 }
 
-return expect(willBeRejectedAsync, 'to error', function (e) {
-    return expect(e.message, 'to equal', 'async error');
+return expect(willBeRejectedAsync, 'to error', function(e) {
+  return expect(e.message, 'to equal', 'async error');
 });
 ```
 
 You can even do async assertions in the function that you pass in.
 
-```javascript#async:true
+```js#async:true
 var errorCount = 0;
 function willBeRejectedAsync() {
-    return new Promise(function (resolve, reject) {
-        setTimeout(function () {
-            var error = new Error('async error');
-            errorCount += 1;
-            error.errorCount = errorCount;
-            reject(error);
-        }, 1);
-    });
+  return new Promise(function(resolve, reject) {
+    setTimeout(function() {
+      var error = new Error('async error');
+      errorCount += 1;
+      error.errorCount = errorCount;
+      reject(error);
+    }, 1);
+  });
 }
 
-return expect(willBeRejectedAsync, 'to error', function (e) {
-    return expect(willBeRejectedAsync, 'to error', function (e2) {
-        return expect(e2.errorCount, 'to be greater than', e.errorCount);
-    });
+return expect(willBeRejectedAsync, 'to error', function(e) {
+  return expect(willBeRejectedAsync, 'to error', function(e2) {
+    return expect(e2.errorCount, 'to be greater than', e.errorCount);
+  });
 });
 ```

--- a/documentation/assertions/function/to-have-arity.md
+++ b/documentation/assertions/function/to-have-arity.md
@@ -1,16 +1,20 @@
 Asserts that the function takes the given number of arguments.
 
-```javascript
+```js
 expect(Math.max, 'to have arity', 2);
 expect('wat'.substring, 'to have arity', 2);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
-expect(function wat(foo, bar) {
-  return foo + bar;
-}, 'to have arity', 3);
+```js
+expect(
+  function wat(foo, bar) {
+    return foo + bar;
+  },
+  'to have arity',
+  3
+);
 ```
 
 ```output

--- a/documentation/assertions/function/to-throw-a.md
+++ b/documentation/assertions/function/to-throw-a.md
@@ -1,6 +1,6 @@
 Asserts that the function throws an instance of a specific constructor.
 
-```javascript
+```js
 function willThrow() {
   throw new SyntaxError('The error message');
 }
@@ -9,7 +9,7 @@ expect(willThrow, 'to throw a', SyntaxError);
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(willThrow, 'to throw a', RangeError);
 ```
 
@@ -24,7 +24,7 @@ to throw a RangeError
 
 The assertion also fails if the function doesn't throw at all:
 
-```javascript
+```js
 function willNotThrow() {}
 
 expect(willNotThrow, 'to throw a', RangeError);
@@ -38,12 +38,16 @@ expected function willNotThrow() {} to throw a RangeError
 
 To test functions that require input wrap the function invocation in an anonymous function:
 
-```javascript
+```js
 function willThrow(input) {
-  if(input) throw new SyntaxError('The error message');
+  if (input) throw new SyntaxError('The error message');
   return input;
 }
-expect(function() {
-    willThrow('input.here')
-}, 'to throw a', SyntaxError);
+expect(
+  function() {
+    willThrow('input.here');
+  },
+  'to throw a',
+  SyntaxError
+);
 ```

--- a/documentation/assertions/function/to-throw.md
+++ b/documentation/assertions/function/to-throw.md
@@ -1,6 +1,6 @@
 Asserts that the function throws an error when called.
 
-```javascript
+```js
 function willThrow() {
   throw new Error('The error message');
 }
@@ -11,7 +11,7 @@ expect(willThrow, 'to throw exception');
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(function willNotThrow() {}, 'to throw');
 ```
 
@@ -23,15 +23,19 @@ expected function willNotThrow() {} to throw
 You can assert the error message is a given string if you provide a
 string as the second parameter.
 
-```javascript
-expect(function () {
-  throw new Error('The error message');
-}, 'to throw', 'The error message');
+```js
+expect(
+  function() {
+    throw new Error('The error message');
+  },
+  'to throw',
+  'The error message'
+);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript#skipPhantom:true
+```js#skipPhantom:true
 expect(function () {
   throw new Error('The error message!');
 }, 'to throw', 'The error message');
@@ -52,15 +56,19 @@ to throw 'The error message'
 By providing a regular expression as the second parameter you can
 assert the error message matches the given regular expression.
 
-```javascript
-expect(function () {
-  throw new Error('The error message');
-}, 'to throw', /error message/);
+```js
+expect(
+  function() {
+    throw new Error('The error message');
+  },
+  'to throw',
+  /error message/
+);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript#skipPhantom:true
+```js#skipPhantom:true
 expect(function () {
   throw new Error('The error message!');
 }, 'to throw', /catastrophic failure/);
@@ -78,17 +86,21 @@ to throw /catastrophic failure/
 You can also provide a function as the second parameter to do
 arbitrary assertions on the error.
 
-```javascript
-expect(function () {
-  this.foo.bar();
-}, 'to throw', function (e) {
-  expect(e, 'to be a', TypeError);
-});
+```js
+expect(
+  function() {
+    this.foo.bar();
+  },
+  'to throw',
+  function(e) {
+    expect(e, 'to be a', TypeError);
+  }
+);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript#skipPhantom:true
+```js#skipPhantom:true
 expect(function () {
   throw new Error('Another error');
 }, 'to throw', function (e) {
@@ -113,15 +125,19 @@ Actually what happens is, that the thrown error is checked
 parameter. That means you could also just supply an error object to
 validate against:
 
-```javascript
-expect(function () {
-  throw new TypeError('Invalid syntax');
-}, 'to throw', new TypeError('Invalid syntax'));
+```js
+expect(
+  function() {
+    throw new TypeError('Invalid syntax');
+  },
+  'to throw',
+  new TypeError('Invalid syntax')
+);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript#skipPhantom:true
+```js#skipPhantom:true
 expect(function () {
   throw new Error('Another error');
 }, 'to throw', new TypeError('Invalid syntax'));
@@ -136,15 +152,15 @@ to throw TypeError('Invalid syntax')
   expected Error('Another error') to satisfy TypeError('Invalid syntax')
 ```
 
-```javascript
-expect(function () {
+```js
+expect(function() {
   // Do some work that should not throw
 }, 'not to throw');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript#skipPhantom:true
+```js#skipPhantom:true
 expect(function () {
   throw new Error('threw anyway');
 }, 'not to throw');
@@ -161,12 +177,16 @@ not to throw
 
 To test functions that require input wrap the function invocation in an anonymous function:
 
-```javascript
+```js
 function willThrow(input) {
-  if(input) throw new SyntaxError('The error message');
+  if (input) throw new SyntaxError('The error message');
   return input;
 }
-expect(function() {
-    willThrow('input.here')
-}, 'to throw', new SyntaxError('The error message'));
+expect(
+  function() {
+    willThrow('input.here');
+  },
+  'to throw',
+  new SyntaxError('The error message')
+);
 ```

--- a/documentation/assertions/function/when-called-with.md
+++ b/documentation/assertions/function/when-called-with.md
@@ -2,7 +2,7 @@ Apply the subject function to an array of parameters, then delegate the return v
 
 ```js
 function add(a, b) {
-    return a + b;
+  return a + b;
 }
 
 expect(add, 'when called with', [1, 2], 'to equal', 3);
@@ -33,19 +33,21 @@ we make sure that `this` is bound correctly:
 
 ```js
 function Greeter(prefix) {
-    this.prefix = prefix;
+  this.prefix = prefix;
 }
 
-Greeter.prototype.greet = function (name) {
-    return this.prefix + name;
+Greeter.prototype.greet = function(name) {
+  return this.prefix + name;
 };
 
-var helloGreeter = new Greeter('Hello, ')
+var helloGreeter = new Greeter('Hello, ');
 
 expect(helloGreeter, 'to satisfy', {
-    greet: expect.it(
-      'when called with', ['John Doe'],
-      'to equal', 'Hello, John Doe'
-    )
+  greet: expect.it(
+    'when called with',
+    ['John Doe'],
+    'to equal',
+    'Hello, John Doe'
+  )
 });
 ```

--- a/documentation/assertions/function/when-called.md
+++ b/documentation/assertions/function/when-called.md
@@ -2,7 +2,7 @@ Call the subject function without arguments, then delegate the return value to a
 
 ```js
 function giveMeFive() {
-    return 5;
+  return 5;
 }
 
 expect(giveMeFive, 'when called', 'to equal', 5);
@@ -33,14 +33,14 @@ we make sure that `this` is bound correctly:
 
 ```js
 function Person(name) {
-    this.name = name;
+  this.name = name;
 }
 
-Person.prototype.toString = function () {
-    return this.name;
+Person.prototype.toString = function() {
+  return this.name;
 };
 
 expect(new Person('John Doe'), 'to satisfy', {
-    toString: expect.it('when called to equal', 'John Doe')
+  toString: expect.it('when called to equal', 'John Doe')
 });
 ```

--- a/documentation/assertions/number/to-be-NaN.md
+++ b/documentation/assertions/number/to-be-NaN.md
@@ -1,12 +1,12 @@
 Asserts that the value is `NaN`.
 
-```javascript
+```js
 expect(NaN, 'to be NaN');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(2, 'to be NaN');
 ```
 
@@ -16,13 +16,13 @@ expected 2 to be NaN
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(2, 'not to be NaN');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(NaN, 'not to be NaN');
 ```
 

--- a/documentation/assertions/number/to-be-close-to.md
+++ b/documentation/assertions/number/to-be-close-to.md
@@ -1,14 +1,14 @@
 Asserts that the difference between two numbers is less than a given epsilon.
 Epsilon defaults to `1e-9` if omitted.
 
-```javascript
+```js
 expect(1.5, 'to be close to', 1.500001, 1e-5);
-expect(1.5, 'to be close to', 1.5000000001)
+expect(1.5, 'to be close to', 1.5000000001);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(1.5, 'to be close to', 1.50001, 1e-5);
 ```
 
@@ -18,14 +18,14 @@ expected 1.5 to be close to 1.50001 (epsilon: 1e-5)
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(1.5, 'not to be close to', 1.499, 1e-4);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
-expect(1.5, 'not to be close to', 1.5000000001)
+```js
+expect(1.5, 'not to be close to', 1.5000000001);
 ```
 
 ```output

--- a/documentation/assertions/number/to-be-finite.md
+++ b/documentation/assertions/number/to-be-finite.md
@@ -1,12 +1,12 @@
 Asserts that a number is finite.
 
-```javascript
+```js
 expect(123, 'to be finite');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(Infinity, 'to be finite');
 ```
 
@@ -16,14 +16,14 @@ expected Infinity to be finite
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(Infinity, 'not to be finite');
 expect(-Infinity, 'not to be finite');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(123, 'not to be finite');
 ```
 

--- a/documentation/assertions/number/to-be-greater-than-or-equal-to.md
+++ b/documentation/assertions/number/to-be-greater-than-or-equal-to.md
@@ -1,14 +1,13 @@
 Asserts that a number is greater than or equal to another number using
 the `>=` operator.
 
-
-```javascript
+```js
 expect(3, 'to be greater than or equal to', 3);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(1, 'to be greater than or equal to', 2);
 ```
 
@@ -18,13 +17,13 @@ expected 1 to be greater than or equal to 2
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(1, 'not to be greater than or equal to', 2);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(2, 'not to be greater than or equal to', 2);
 ```
 

--- a/documentation/assertions/number/to-be-greater-than.md
+++ b/documentation/assertions/number/to-be-greater-than.md
@@ -1,15 +1,14 @@
 Asserts that a number is greater than another number using the `>`
 operator.
 
-
-```javascript
+```js
 expect(3, 'to be greater than', 2);
 expect(1, 'to be above', 0);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(2, 'to be greater than', 2);
 ```
 
@@ -19,14 +18,14 @@ expected 2 to be greater than 2
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(2, 'not to be greater than', 2);
 expect(0, 'not to be above', 1);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(3, 'not to be greater than', 2);
 ```
 

--- a/documentation/assertions/number/to-be-infinite.md
+++ b/documentation/assertions/number/to-be-infinite.md
@@ -1,13 +1,13 @@
 Asserts that a number is infinite.
 
-```javascript
+```js
 expect(Infinity, 'to be infinite');
 expect(-Infinity, 'to be infinite');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(123, 'to be infinite');
 ```
 
@@ -17,13 +17,13 @@ expected 123 to be infinite
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(123, 'not to be infinite');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(Infinity, 'not to be infinite');
 ```
 

--- a/documentation/assertions/number/to-be-less-than-or-equal-to.md
+++ b/documentation/assertions/number/to-be-less-than-or-equal-to.md
@@ -1,14 +1,13 @@
 Asserts that a number is less than or equal to another number using
 the `<=` operator.
 
-
-```javascript
+```js
 expect(3, 'to be less than or equal to', 3);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(2, 'to be less than or equal to', 1);
 ```
 
@@ -18,13 +17,13 @@ expected 2 to be less than or equal to 1
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(2, 'not to be less than or equal to', 1);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(2, 'not to be less than or equal to', 2);
 ```
 

--- a/documentation/assertions/number/to-be-less-than.md
+++ b/documentation/assertions/number/to-be-less-than.md
@@ -1,15 +1,14 @@
 Asserts that a number is less than another number using the `<`
 operator.
 
-
-```javascript
+```js
 expect(2, 'to be less than', 3);
 expect(0, 'to be below', 1);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(2, 'to be less than', 2);
 ```
 
@@ -19,14 +18,14 @@ expected 2 to be less than 2
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(2, 'not to be less than', 2);
 expect(1, 'not to be below', 0);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(2, 'not to be less than', 3);
 ```
 

--- a/documentation/assertions/number/to-be-negative.md
+++ b/documentation/assertions/number/to-be-negative.md
@@ -1,12 +1,12 @@
 Asserts that the number is negative.
 
-```javascript
+```js
 expect(-42, 'to be negative');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(0, 'to be negative');
 ```
 
@@ -16,14 +16,14 @@ expected 0 to be negative
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(0, 'not to be negative');
 expect(42, 'not to be negative');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(-1, 'not to be negative');
 ```
 

--- a/documentation/assertions/number/to-be-positive.md
+++ b/documentation/assertions/number/to-be-positive.md
@@ -1,12 +1,12 @@
 Asserts that the number is positive.
 
-```javascript
+```js
 expect(42, 'to be positive');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(0, 'to be positive');
 ```
 
@@ -16,14 +16,14 @@ expected 0 to be positive
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(0, 'not to be positive');
 expect(-42, 'not to be positive');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(1, 'not to be positive');
 ```
 

--- a/documentation/assertions/number/to-be-within.md
+++ b/documentation/assertions/number/to-be-within.md
@@ -1,6 +1,6 @@
 Asserts that a number is within a range.
 
-```javascript
+```js
 expect(0, 'to be within', 0, 4);
 expect(1, 'to be within', 0, 4);
 expect(2.5, 'to be within', 0, 4);
@@ -9,7 +9,7 @@ expect(4, 'to be within', 0, 4);
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(-1, 'to be within', 0, 4);
 ```
 
@@ -19,14 +19,14 @@ expected -1 to be within 0..4
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect(-1, 'not to be within', 0, 4);
 expect(5, 'not to be within', 0, 4);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(0, 'not to be within', 0, 4);
 ```
 

--- a/documentation/assertions/object/to-be-canonical.md
+++ b/documentation/assertions/object/to-be-canonical.md
@@ -1,14 +1,14 @@
 Asserts that an object has its properties defined in sorted order at
 all levels.
 
-```javascript
+```js
 expect({ a: 123, b: 456 }, 'to be canonical');
 expect([456, { a: 123 }], 'to be canonical');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect([456, { b: 456, a: 123 }], 'to be canonical');
 ```
 

--- a/documentation/assertions/object/to-be-empty.md
+++ b/documentation/assertions/object/to-be-empty.md
@@ -1,12 +1,12 @@
 Asserts that an object is empty.
 
-```javascript
+```js
 expect({}, 'to be empty');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect({ a: 'a', b: 'b' }, 'to be empty');
 ```
 
@@ -21,13 +21,13 @@ expected { a: 'a', b: 'b' } to be empty
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect({ a: 'a', b: 'b' }, 'not to be empty');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect({}, 'not to be empty');
 ```
 

--- a/documentation/assertions/object/to-have-a-value-satisfying.md
+++ b/documentation/assertions/object/to-have-a-value-satisfying.md
@@ -3,25 +3,25 @@ value, function or other assertion.
 
 Note that this assertion fails if passed an empty object as the subject.
 
-```javascript
+```js
 expect(
-    { foo: { a: 1 }, bar: { b: 2 }, baz: { c: 3 }, qux: { d: 4} },
-    'to have a value satisfying',
-    { a: 1 }
+  { foo: { a: 1 }, bar: { b: 2 }, baz: { c: 3 }, qux: { d: 4 } },
+  'to have a value satisfying',
+  { a: 1 }
 );
 
 expect(
-    { foo: 0, bar: 1, baz: 2, qux: 3 },
-    'to have a value satisfying',
-    function (value, index) {
-        expect(value, 'to be a number');
-    }
+  { foo: 0, bar: 1, baz: 2, qux: 3 },
+  'to have a value satisfying',
+  function(value, index) {
+    expect(value, 'to be a number');
+  }
 );
 
 expect(
-    { foo: 0, bar: 1, baz: 2, qux: 3 },
-    'to have a value satisfying',
-    'to be a number'
+  { foo: 0, bar: 1, baz: 2, qux: 3 },
+  'to have a value satisfying',
+  'to be a number'
 );
 ```
 
@@ -30,12 +30,14 @@ The expected value will be matched against the value with
 values supported by `to satisfy`. To use strict `to satisfy` semantics, you can
 use the "exhaustively" flag:
 
-```javascript
+```js
 expect({ foo: { a: 1, b: 2 } }, 'to have a value satisfying', { a: 1 });
 ```
 
-```javascript
-expect({ foo: { a: 1, b: 2 } }, 'to have a value exhaustively satisfying', { a: 1 });
+```js
+expect({ foo: { a: 1, b: 2 } }, 'to have a value exhaustively satisfying', {
+  a: 1
+});
 ```
 
 ```output
@@ -44,12 +46,12 @@ expected { foo: { a: 1, b: 2 } } to have a value exhaustively satisfying { a: 1 
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(
-    { foo: [10, 11, 12], bar: [14, 15, 16], baz: [17, 18, 19] },
-    'to have a value satisfying',
-    'to have items satisfying',
-    expect.it('to be a number').and('to be below', 8)
+  { foo: [10, 11, 12], bar: [14, 15, 16], baz: [17, 18, 19] },
+  'to have a value satisfying',
+  'to have items satisfying',
+  expect.it('to be a number').and('to be below', 8)
 );
 ```
 
@@ -61,7 +63,7 @@ to have items satisfying expect.it('to be a number')
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect({ foo: { a: 1, b: 2 } }, 'not to have a value satisfying', { a: 1 });
 ```
 

--- a/documentation/assertions/object/to-have-key.md
+++ b/documentation/assertions/object/to-have-key.md
@@ -2,20 +2,20 @@ Asserts the presence of a key.
 
 Alias for [to be have keys](../to-have-keys).
 
-```javascript
+```js
 expect({ a: 'a', b: 'b', c: 'c' }, 'to have key', 'a');
 ```
 
 Using the `only` flag you can assert that the object only have the
 specified key.
 
-```javascript
+```js
 expect({ a: 'a' }, 'to only have key', 'a');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect({ a: 'a', b: 'b' }, 'to have key', 'c');
 ```
 
@@ -25,7 +25,7 @@ expected { a: 'a', b: 'b' } to have key 'c'
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect({ a: 'a', b: 'b' }, 'not to have key', 'c');
 expect(Object.create({ a: 'a', b: 'b' }), 'not to have key', 'a');
 ```
@@ -33,13 +33,13 @@ expect(Object.create({ a: 'a', b: 'b' }), 'not to have key', 'a');
 Using the `only` flag you can assert that the object not only have the
 specified key.
 
-```javascript
+```js
 expect({ a: 'a', b: 'b' }, 'to not only have key', 'a');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect({ a: 'a', b: 'b' }, 'to not have key', 'a');
 ```
 

--- a/documentation/assertions/object/to-have-keys-satisfying.md
+++ b/documentation/assertions/object/to-have-keys-satisfying.md
@@ -5,23 +5,30 @@ Notice this assertion fails when given an empty object.
 Aliases: `to be a map whose keys satisfy`,
 `to be an object whose keys satisfy`, `to be a hash whose keys satisfy`.
 
-```javascript
-expect({ foo: 0, bar: 1, baz: 2, qux: 3 },
-       'to have keys satisfying', function (key) {
-    expect(key, 'to match', /^[a-z]{3}$/);
+```js
+expect({ foo: 0, bar: 1, baz: 2, qux: 3 }, 'to have keys satisfying', function(
+  key
+) {
+  expect(key, 'to match', /^[a-z]{3}$/);
 });
 
-expect({ foo: 0, bar: 1, baz: 2, qux: 3 },
-       'to have keys satisfying',
-       'to match', /^[a-z]{3}$/);
+expect(
+  { foo: 0, bar: 1, baz: 2, qux: 3 },
+  'to have keys satisfying',
+  'to match',
+  /^[a-z]{3}$/
+);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
-expect({ foo: 0, bar: 1, baz: 2, qux: 3, quux: 4 },
-       'to have keys satisfying',
-       'to match', /^[a-z]{3}$/);
+```js
+expect(
+  { foo: 0, bar: 1, baz: 2, qux: 3, quux: 4 },
+  'to have keys satisfying',
+  'to match',
+  /^[a-z]{3}$/
+);
 ```
 
 ```output

--- a/documentation/assertions/object/to-have-keys.md
+++ b/documentation/assertions/object/to-have-keys.md
@@ -1,6 +1,6 @@
 Asserts the presence of a list of keys.
 
-```javascript
+```js
 expect({ a: 'a', b: 'b', c: 'c' }, 'to have keys', 'a', 'c');
 expect({ a: 'a', b: 'b', c: 'c' }, 'to have keys', ['a', 'c']);
 ```
@@ -8,13 +8,13 @@ expect({ a: 'a', b: 'b', c: 'c' }, 'to have keys', ['a', 'c']);
 Using the `only` flag you can assert that the object only have the
 specified keys.
 
-```javascript
+```js
 expect({ a: 'a', b: 'b', c: 'c' }, 'to only have keys', ['a', 'c', 'b']);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect({ a: 'a', b: 'b', c: 'c' }, 'to have keys', 'c', 'd');
 ```
 
@@ -24,7 +24,7 @@ expected { a: 'a', b: 'b', c: 'c' } to have keys 'c', 'd'
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect({ a: 'a', b: 'b', c: 'c' }, 'not to have keys', 'd', 'e');
 expect(Object.create({ a: 'a', b: 'b', c: 'c' }), 'not to have keys', 'a', 'b');
 ```
@@ -32,13 +32,13 @@ expect(Object.create({ a: 'a', b: 'b', c: 'c' }), 'not to have keys', 'a', 'b');
 Using the `only` flag you can assert that the object not only have the
 specified keys.
 
-```javascript
+```js
 expect({ a: 'a', b: 'b', c: 'c' }, 'to not only have keys', 'a', 'b');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect({ a: 'a', b: 'b', c: 'c' }, 'to not only have keys', 'a', 'b', 'c');
 ```
 

--- a/documentation/assertions/object/to-have-properties.md
+++ b/documentation/assertions/object/to-have-properties.md
@@ -1,30 +1,30 @@
 Assert presence of properties in an object.
 
-```javascript
+```js
 expect({ a: 'a', b: { c: 'c' }, d: 'd' }, 'to have properties', ['a', 'b']);
 expect({ a: 'a', b: { c: 'c' }, d: 'd' }, 'to have properties', {
-    a: 'a',
-    b: { c: 'c' }
+  a: 'a',
+  b: { c: 'c' }
 });
-expect([ 'a', { c: 'c' }, 'd' ], 'to have properties', {
-    1: { c: 'c' },
-    2: 'd'
+expect(['a', { c: 'c' }, 'd'], 'to have properties', {
+  1: { c: 'c' },
+  2: 'd'
 });
 ```
 
 Using the `own` flag, you can assert presence of an own properties.
 
-```javascript
+```js
 expect({ a: 'a', b: { c: 'c' }, d: 'd' }, 'to have own properties', ['a', 'b']);
 expect({ a: 'a', b: { c: 'c' }, d: 'd' }, 'to have own properties', {
-    a: 'a',
-    b: { c: 'c' }
+  a: 'a',
+  b: { c: 'c' }
 });
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect({ a: 'f00', b: 'bar' }, 'to have own properties', {
   a: 'foo',
   c: 'baz'
@@ -46,14 +46,17 @@ expected { a: 'f00', b: 'bar' } to have own properties { a: 'foo', c: 'baz' }
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect({ a: 'a', b: { c: 'c' }, d: 'd' }, 'not to have properties', ['k', 'l']);
-expect(Object.create({ a: 'a', b: 'b' }), 'not to have own properties', ['a', 'b']);
+expect(Object.create({ a: 'a', b: 'b' }), 'not to have own properties', [
+  'a',
+  'b'
+]);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect({ a: 'a', b: { c: 'c' }, d: 'd' }, 'not to have properties', ['b', 'd']);
 ```
 

--- a/documentation/assertions/object/to-have-property.md
+++ b/documentation/assertions/object/to-have-property.md
@@ -1,6 +1,6 @@
 Asserts presence of a property.
 
-```javascript
+```js
 expect([1, 2], 'to have property', 'length');
 expect({ a: 'b' }, 'to have property', 'a');
 expect({ a: 'b' }, 'to have property', 'toString');
@@ -8,7 +8,7 @@ expect({ a: 'b' }, 'to have property', 'toString');
 
 You can provide a second parameter to assert the value of the property.
 
-```javascript
+```js
 expect([1, 2], 'to have property', 'length', 2);
 expect({ a: 'b' }, 'to have property', 'a', 'b');
 expect({ a: { b: 'c' } }, 'to have property', 'a', { b: 'c' });
@@ -16,14 +16,14 @@ expect({ a: { b: 'c' } }, 'to have property', 'a', { b: 'c' });
 
 Using the `own` flag, you can assert presence of an own property.
 
-```javascript
+```js
 expect({ a: 'b' }, 'to have own property', 'a');
 expect({ a: 'b' }, 'to have own property', 'a', 'b');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect(Object.create({ a: 'b' }), 'to have own property', 'a');
 ```
 
@@ -33,7 +33,7 @@ expected {} to have own property 'a'
 
 You can assert for property descriptors too.
 
-```javascript
+```js
 expect({ a: 'b' }, 'to have enumerable property', 'a');
 expect({ a: 'b' }, 'to have configurable property', 'a');
 expect({ a: 'b' }, 'to have writable property', 'a');
@@ -41,7 +41,7 @@ expect({ a: 'b' }, 'to have writable property', 'a');
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect({ a: 'b' }, 'not to have property', 'b');
 expect(Object.create({ a: 'b' }), 'not to have own property', 'a');
 ```

--- a/documentation/assertions/object/to-have-values-satisfying.md
+++ b/documentation/assertions/object/to-have-values-satisfying.md
@@ -5,24 +5,31 @@ Notice this assertion fails when given an empty object.
 Aliases: `to be a map whose values satisfy`,
 `to be an object whose values satisfy`, `to be a hash whose values satisfy`.
 
-```javascript
-expect({ foo: 0, bar: 1, baz: 2, qux: 3 },
-       'to have values satisfying', function (value, index) {
+```js
+expect(
+  { foo: 0, bar: 1, baz: 2, qux: 3 },
+  'to have values satisfying',
+  function(value, index) {
     expect(value, 'to be a number');
-});
+  }
+);
 
-expect({ foo: 0, bar: 1, baz: 2, qux: 3 },
-       'to have values satisfying',
-       'to be a number');
+expect(
+  { foo: 0, bar: 1, baz: 2, qux: 3 },
+  'to have values satisfying',
+  'to be a number'
+);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
-expect({ foo: [0, 1, 2], bar: [4, 5, 6], baz: [7, 8, 9] },
-       'to have values satisfying',
-       'to have items satisfying',
-       expect.it('to be a number').and('to be below', 8));
+```js
+expect(
+  { foo: [0, 1, 2], bar: [4, 5, 6], baz: [7, 8, 9] },
+  'to have values satisfying',
+  'to have items satisfying',
+  expect.it('to be a number').and('to be below', 8)
+);
 ```
 
 ```output

--- a/documentation/assertions/string/to-be-empty.md
+++ b/documentation/assertions/string/to-be-empty.md
@@ -2,13 +2,13 @@ Asserts that the string is empty.
 
 Aliases: `to be the empty string`, `to be an empty string`
 
-```javascript
+```js
 expect('', 'to be empty');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('Hello world', 'to be empty');
 ```
 
@@ -18,13 +18,13 @@ expected 'Hello world' to be empty
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect('Hello world', 'not to be empty');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('', 'not to be empty');
 ```
 

--- a/documentation/assertions/string/to-be-greater-than-or-equal-to.md
+++ b/documentation/assertions/string/to-be-greater-than-or-equal-to.md
@@ -1,14 +1,13 @@
 Asserts that a string is greater than or equal to another string using
 the `>=` operator.
 
-
-```javascript
+```js
 expect('b', 'to be greater than or equal to', 'b');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('a', 'to be greater than or equal to', 'b');
 ```
 
@@ -18,13 +17,13 @@ expected 'a' to be greater than or equal to 'b'
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect('a', 'not to be greater than or equal to', 'b');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('a', 'not to be greater than or equal to', 'a');
 ```
 

--- a/documentation/assertions/string/to-be-greater-than.md
+++ b/documentation/assertions/string/to-be-greater-than.md
@@ -1,14 +1,14 @@
 Asserts that a string is greater than another string using the `>`
 operator.
 
-```javascript
+```js
 expect('b', 'to be greater than', 'a');
 expect('b', 'to be above', 'a');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('a', 'to be greater than', 'a');
 ```
 
@@ -18,14 +18,14 @@ expected 'a' to be greater than 'a'
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect('a', 'not to be greater than', 'a');
 expect('a', 'not to be above', 'a');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('b', 'not to be above', 'a');
 ```
 

--- a/documentation/assertions/string/to-be-less-than-or-equal-to.md
+++ b/documentation/assertions/string/to-be-less-than-or-equal-to.md
@@ -1,14 +1,13 @@
 Asserts that a string is less than or equal to another string using
 the `<=` operator.
 
-
-```javascript
+```js
 expect('b', 'to be less than or equal to', 'b');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('b', 'to be less than or equal to', 'a');
 ```
 
@@ -18,13 +17,13 @@ expected 'b' to be less than or equal to 'a'
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect('b', 'not to be less than or equal to', 'a');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('a', 'not to be less than or equal to', 'a');
 ```
 

--- a/documentation/assertions/string/to-be-less-than.md
+++ b/documentation/assertions/string/to-be-less-than.md
@@ -1,14 +1,14 @@
 Asserts that a string is less than another string using the `<`
 operator.
 
-```javascript
+```js
 expect('a', 'to be less than', 'b');
 expect('a', 'to be below', 'b');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('a', 'to be less than', 'a');
 ```
 
@@ -18,14 +18,14 @@ expected 'a' to be less than 'a'
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect('a', 'not to be less than', 'a');
 expect('a', 'not to be below', 'a');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('a', 'not to be below', 'b');
 ```
 

--- a/documentation/assertions/string/to-be-non-empty.md
+++ b/documentation/assertions/string/to-be-non-empty.md
@@ -1,17 +1,18 @@
 ---
 title: to be non-empty
 ---
+
 Asserts that the string is non-empty.
 
 Aliases: `not to be empty`.
 
-```javascript
+```js
 expect('Hello', 'to be non-empty');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('', 'to be non-empty');
 ```
 

--- a/documentation/assertions/string/to-be-within.md
+++ b/documentation/assertions/string/to-be-within.md
@@ -1,6 +1,6 @@
 Asserts that a string is within a range of strings.
 
-```javascript
+```js
 expect('a', 'to be within', 'a', 'd');
 expect('b', 'to be within', 'a', 'd');
 expect('aabbcc', 'to be within', 'aaa', 'aaz');
@@ -8,7 +8,7 @@ expect('aabbcc', 'to be within', 'aaa', 'aaz');
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('abbbcc', 'to be within', 'aaa', 'aaz');
 ```
 
@@ -18,7 +18,7 @@ expected 'abbbcc' to be within 'aaa'..'aaz'
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect('bar', 'not to be within', 'foo', 'baz');
 expect('e', 'not to be within', 'a', 'd');
 expect('abbbcc', 'not to be within', 'aaa', 'aaz');
@@ -26,7 +26,7 @@ expect('abbbcc', 'not to be within', 'aaa', 'aaz');
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('c', 'not to be within', 'a', 'd');
 ```
 

--- a/documentation/assertions/string/to-be.md
+++ b/documentation/assertions/string/to-be.md
@@ -1,12 +1,12 @@
 Asserts `===` equality.
 
-```javascript
+```js
 expect('Hello', 'to be', 'Hello');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('Hello beautiful!', 'to be', 'Hello world!');
 ```
 
@@ -19,14 +19,14 @@ expected 'Hello beautiful!' to be 'Hello world!'
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect('Hello', 'not to be', 'Hello world!');
 expect('1', 'not to be', 1);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('Hello world!', 'not to be', 'Hello world!');
 ```
 

--- a/documentation/assertions/string/to-begin-with.md
+++ b/documentation/assertions/string/to-begin-with.md
@@ -1,12 +1,12 @@
 Asserts that a string begins with a given string.
 
-```javascript
+```js
 expect('Hello beautiful world!', 'to begin with', 'Hello');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('Hello world!', 'to begin with', 'foo');
 ```
 
@@ -17,7 +17,7 @@ expected 'Hello world!' to begin with 'foo'
 If there is a partially matching prefix you'll get a diff with the common
 part highlighted:
 
-```javascript
+```js
 expect('Hello world!', 'to begin with', 'Hell yeah');
 ```
 
@@ -30,13 +30,13 @@ Hello world!
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect('Hello world!', 'not to begin with', 'Heaven');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('Hello beautiful world!', 'not to begin with', 'Hello');
 ```
 

--- a/documentation/assertions/string/to-contain.md
+++ b/documentation/assertions/string/to-contain.md
@@ -1,13 +1,13 @@
 Asserts a string contains one or more substrings.
 
-```javascript
+```js
 expect('Hello beautiful world!', 'to contain', 'beautiful');
 expect('Hello beautiful world!', 'to contain', 'Hello', 'world');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('Hello world!', 'to contain', 'beautiful');
 ```
 
@@ -19,18 +19,20 @@ Hello world!
 
 The longest matched prefix(es) will be highlighted:
 
-```javascript
-expect('BEGIN:VEVENT\n' +
-       'UID:B4D3A0F8-6E38-5F0E-8CE7-BA0171DEAA8D\n' +
-       'RECURRENCE-ID;TZID=Europe/Copenhagen:20150113T120000\n' +
-       'DTSTART;TZID=Europe/Copenhagen:20150203T110000\n' +
-       'DTEND;TZID=Europe/Copenhagen:20150203T120000\n' +
-       'DTSTAMP:20150114T121235Z\n' +
-       'SUMMARY:Lunch\n' +
-       'LOCATION:Kalvebod Brygge 24, Copenhagen\n' +
-       'END:VEVENT',
-       'to contain',
-       'UID:6FA459EA-EE8A-3CA4-894E-DB77E160355E');
+```js
+expect(
+  'BEGIN:VEVENT\n' +
+    'UID:B4D3A0F8-6E38-5F0E-8CE7-BA0171DEAA8D\n' +
+    'RECURRENCE-ID;TZID=Europe/Copenhagen:20150113T120000\n' +
+    'DTSTART;TZID=Europe/Copenhagen:20150203T110000\n' +
+    'DTEND;TZID=Europe/Copenhagen:20150203T120000\n' +
+    'DTSTAMP:20150114T121235Z\n' +
+    'SUMMARY:Lunch\n' +
+    'LOCATION:Kalvebod Brygge 24, Copenhagen\n' +
+    'END:VEVENT',
+  'to contain',
+  'UID:6FA459EA-EE8A-3CA4-894E-DB77E160355E'
+);
 ```
 
 ```output
@@ -51,13 +53,13 @@ END:VEVENT
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect('Hello world!', 'not to contain', 'beautiful', 'ugly');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('Hello beautiful world!', 'not to contain', 'beautiful', 'ugly');
 ```
 

--- a/documentation/assertions/string/to-end-with.md
+++ b/documentation/assertions/string/to-end-with.md
@@ -1,12 +1,12 @@
 Asserts that a string ends with a given string.
 
-```javascript
+```js
 expect('Hello beautiful world!', 'to end with', 'world!');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('Hello world!', 'to end with', 'foo');
 ```
 
@@ -17,7 +17,7 @@ expected 'Hello world!' to end with 'foo'
 If there is a partially matching suffix you'll get a diff with the common
 part highlighted:
 
-```javascript
+```js
 expect('Hello world!', 'to end with', 'Hola, world!');
 ```
 
@@ -30,13 +30,13 @@ Hello world!
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect('Hello world!', 'not to end with', 'earth!');
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('Hello beautiful world!', 'not to end with', 'world!');
 ```
 

--- a/documentation/assertions/string/to-have-length.md
+++ b/documentation/assertions/string/to-have-length.md
@@ -1,12 +1,12 @@
 Asserts that the string has the specified length.
 
-```javascript
+```js
 expect('Hello world', 'to have length', 11);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('Hello world', 'to have length', 12);
 ```
 
@@ -17,13 +17,13 @@ expected 'Hello world' to have length 12
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect('Hello world', 'not to have length', 12);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('Hello world', 'not to have length', 11);
 ```
 

--- a/documentation/assertions/string/to-match.md
+++ b/documentation/assertions/string/to-match.md
@@ -1,12 +1,12 @@
 Asserts a string matches a regular expression.
 
-```javascript
+```js
 expect('Hello beautiful world!', 'to match', /bea.t.*/);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('Hello world!', 'to match', /beautiful/);
 ```
 
@@ -16,13 +16,13 @@ expected 'Hello world!' to match /beautiful/
 
 This assertion can be negated using the `not` flag:
 
-```javascript
+```js
 expect('Hello world!', 'not to match', /beautiful/);
 ```
 
 In case of a failing expectation you get the following output:
 
-```javascript
+```js
 expect('Hello beautiful world!', 'not to match', /beautiful/);
 ```
 
@@ -37,19 +37,19 @@ The return value of `String.prototype.match` will be provided as the fulfillment
 value of the returned promise, so the values captured by the regular expression
 are available to the `then` function:
 
-```javascript#async:true
-return expect('Hello world!', 'to match', /(\w+)!/).then(function (captures) {
-    expect(captures[0], 'to equal', 'world!');
-    expect(captures[1], 'to equal', 'world');
-    expect(captures.index, 'to equal', 6);
+```js#async:true
+return expect('Hello world!', 'to match', /(\w+)!/).then(function(captures) {
+  expect(captures[0], 'to equal', 'world!');
+  expect(captures[1], 'to equal', 'world');
+  expect(captures.index, 'to equal', 6);
 });
 ```
 
 Or using the Bluebird-specific `.spread` extension:
 
-```javascript#async:true
-return expect('Hello world!', 'to match', /(\w+)!/).spread(function ($0, $1) {
-    expect($0, 'to equal', 'world!');
-    expect($1, 'to equal', 'world');
+```js#async:true
+return expect('Hello world!', 'to match', /(\w+)!/).spread(function($0, $1) {
+  expect($0, 'to equal', 'world!');
+  expect($1, 'to equal', 'world');
 });
 ```

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -8,7 +8,7 @@ repository: https://github.com/unexpectedjs/unexpected
 # Welcome to Unexpected
 # The extensible BDD assertion toolkit
 
-```javascript
+```js
 const library = {
   name: 'un3xp3c73d',
   created: 2013,


### PR DESCRIPTION
Format the code snippets with prettier and switch to 2 space indentation.

Prerequisite: https://github.com/unexpectedjs/unexpected/pull/478