### PR TITLE
Truncate subject in begin and end with assertions

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -756,6 +756,19 @@ module.exports = expect => {
           }' assertion does not support a suffix of the empty string`
         );
       }
+      var isTruncated = false;
+      var outputSubject = utils.truncateSubjectStringForEnd(subject, value);
+      if (outputSubject === null) {
+        outputSubject = subject;
+      } else {
+        isTruncated = true;
+      }
+      expect.subjectOutput = output => {
+        if (isTruncated) {
+          output = output.jsComment('...');
+        }
+        output.jsString("'" + outputSubject.replace(/\n/g, '\\n') + "'");
+      };
       expect.withError(
         () => {
           expect(subject.substr(-value.length), '[not] to equal', value);
@@ -771,7 +784,7 @@ module.exports = expect => {
               } else {
                 let i = 0;
                 while (
-                  subject[subject.length - 1 - i] ===
+                  outputSubject[outputSubject.length - 1 - i] ===
                   value[value.length - 1 - i]
                 ) {
                   i += 1;
@@ -781,9 +794,13 @@ module.exports = expect => {
                   return null;
                 }
                 output
-                  .text(subject.substr(0, subject.length - i))
+                  .jsComment(isTruncated ? '...' : '')
+                  .text(outputSubject.substr(0, outputSubject.length - i))
                   .partialMatch(
-                    subject.substr(subject.length - i, subject.length)
+                    outputSubject.substr(
+                      outputSubject.length - i,
+                      outputSubject.length
+                    )
                   );
               }
               return output;

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -696,6 +696,21 @@ module.exports = expect => {
           }' assertion does not support a prefix of the empty string`
         );
       }
+      var isTruncated = false;
+      var outputSubject = utils.truncateSubjectStringForBegin(subject, value);
+      if (outputSubject === null) {
+        outputSubject = subject;
+      } else {
+        isTruncated = true;
+      }
+      expect.subjectOutput = output => {
+        output = output.jsString(
+          "'" + outputSubject.replace(/\n/g, '\\n') + "'"
+        );
+        if (isTruncated) {
+          output.jsComment('...');
+        }
+      };
       expect.withError(
         () => {
           expect(subject.substr(0, value.length), '[not] to equal', value);
@@ -719,7 +734,8 @@ module.exports = expect => {
                 } else {
                   output
                     .partialMatch(subject.substr(0, i))
-                    .text(subject.substr(i));
+                    .text(outputSubject.substr(i))
+                    .jsComment(isTruncated ? '...' : '');
                 }
               }
               return output;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -334,5 +334,18 @@ const utils = (module.exports = {
       }
       return packing;
     }
+  },
+
+  truncateSubjectStringForBegin(subject, value) {
+    var contextLength = value.length + 25;
+    if (subject.length <= contextLength) {
+      return null;
+    }
+    var truncationIndex = subject.indexOf(' ', value.length + 1);
+    if (truncationIndex > -1 && truncationIndex < contextLength) {
+      return subject.substring(0, truncationIndex);
+    } else {
+      return subject.substring(0, contextLength);
+    }
   }
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -347,5 +347,18 @@ const utils = (module.exports = {
     } else {
       return subject.substring(0, contextLength);
     }
+  },
+
+  truncateSubjectStringForEnd(subject, value) {
+    var contextLength = subject.length - value.length - 25;
+    if (contextLength <= 0) {
+      return null;
+    }
+    var truncationIndex = subject.lastIndexOf(' ', value.length + 1);
+    if (truncationIndex > -1 && truncationIndex >= contextLength) {
+      return subject.substring(truncationIndex + 1, subject.length);
+    } else {
+      return subject.substring(contextLength, subject.length);
+    }
   }
 });

--- a/test/assertions/to-begin-with.spec.js
+++ b/test/assertions/to-begin-with.spec.js
@@ -76,6 +76,51 @@ describe('to begin with assertion', function() {
         );
       });
     });
+
+    it('builds the diff correctly when the string is truncated with no common prefix', function() {
+      expect(
+        function() {
+          expect(
+            'foobarbaz-AtSomePointThisStringWillBeTruncated',
+            'to begin with',
+            'barbazquux'
+          );
+        },
+        'to throw exception',
+        "expected 'foobarbaz-AtSomePointThisStringWill'... to begin with 'barbazquux'"
+      );
+    });
+
+    it('builds the diff correctly when the string contains a space and is truncated', function() {
+      expect(
+        function() {
+          expect(
+            'foobarbaz-StringTruncates AtTheSpace',
+            'to begin with',
+            'barbazquux'
+          );
+        },
+        'to throw exception',
+        "expected 'foobarbaz-StringTruncates'... to begin with 'barbazquux'"
+      );
+    });
+
+    it('builds the diff correctly when the string is truncated after a partial match', function() {
+      expect(
+        function() {
+          expect(
+            'foobarbaz-ButAtSomePointThisStringWillBeTruncated',
+            'to begin with',
+            'foobarquux'
+          );
+        },
+        'to throw exception',
+        "expected 'foobarbaz-ButAtSomePointThisStringW'... to begin with 'foobarquux'\n" +
+          '\n' +
+          'foobarbaz-ButAtSomePointThisStringW...\n' +
+          '^^^^^^'
+      );
+    });
   });
 
   describe('with the "not" flag', function() {

--- a/test/assertions/to-end-with.spec.js
+++ b/test/assertions/to-end-with.spec.js
@@ -76,6 +76,51 @@ describe('to end with assertion', function() {
         );
       });
     });
+
+    it('builds the diff correctly when the string is truncated with no common prefix', function() {
+      expect(
+        function() {
+          expect(
+            'AtSomePointThisStringWillBeTruncated-foobarbaz',
+            'to end with',
+            'barbazquux'
+          );
+        },
+        'to throw exception',
+        "expected ...'ThisStringWillBeTruncated-foobarbaz' to end with 'barbazquux'"
+      );
+    });
+
+    it('builds the diff correctly when the string contains a space and is truncated', function() {
+      expect(
+        function() {
+          expect(
+            'a ThenPleaseTruncateString-foobarbaz',
+            'to end with',
+            'barbazquux'
+          );
+        },
+        'to throw exception',
+        "expected ...'ThenPleaseTruncateString-foobarbaz' to end with 'barbazquux'"
+      );
+    });
+
+    it('builds the diff correctly when the string is truncated after a partial match', function() {
+      expect(
+        function() {
+          expect(
+            'ButAtSomePointThisStringWillBeTruncated-bazbarfoo',
+            'to end with',
+            'quuxbarfoo'
+          );
+        },
+        'to throw exception',
+        "expected ...'ThisStringWillBeTruncated-bazbarfoo' to end with 'quuxbarfoo'\n" +
+          '\n' +
+          '...ThisStringWillBeTruncated-bazbarfoo\n' +
+          '                                ^^^^^^'
+      );
+    });
   });
 
   describe('with the "not" flag', function() {


### PR DESCRIPTION
This is a post-prettier replacement PR for the earlier work done in https://github.com/unexpectedjs/unexpected/pull/320 based on an output improvement suggestion by @Munter.