### PR TITLE
Link to the documentation site using https

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Extensible BDD assertion toolkit
 [![Dependency Status](https://david-dm.org/unexpectedjs/unexpected.svg)](https://david-dm.org/unexpectedjs/unexpected)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/unexpectedjs/unexpected?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-Read [the documentation](http://unexpected.js.org/).
+Read [the documentation](https://unexpected.js.org/).

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -13,7 +13,7 @@ repository: https://github.com/unexpectedjs/unexpected
 const library = {
   name: 'un3xp3c73d',
   created: 2013,
-  site: 'http://unexpected.js.org'
+  site: 'https://unexpected.js.org'
 };
 
 expect(library, 'to satisfy', {
@@ -23,7 +23,7 @@ expect(library, 'to satisfy', {
 ```
 
 ```output
-expected { name: 'un3xp3c73d', created: 2013, site: 'http://unexpected.js.org' }
+expected { name: 'un3xp3c73d', created: 2013, site: 'https://unexpected.js.org' }
 to satisfy { name: 'Unexpected', created: 2013 }
 
 {
@@ -32,7 +32,7 @@ to satisfy { name: 'Unexpected', created: 2013 }
                       // -un3xp3c73d
                       // +Unexpected
   created: 2013,
-  site: 'http://unexpected.js.org'
+  site: 'https://unexpected.js.org'
 }
 ```
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -233,7 +233,7 @@ See [changelog](https://github.com/unexpectedjs/unexpected/blob/master/CHANGELOG
 
 ### 6.0.0
 
-* New documentation and [corresponding site](https://unexpectedjs.github.io/).
+* New documentation and [corresponding site](https://unexpected.js.org/).
 * Use `Object.is`/the [SameValue algorithm](http://ecma-international.org/ecma-262/5.1/#sec-9.12) when checking equality of primitive values (the `to be` and `to equal` assertions).
 * Tweaked the output of numerous assertions.
 * Constrained `to be empty` and `to have length` to only work with strings and array-like objects.


### PR DESCRIPTION
I'm not sure exactly when .js.org started working with https, but apparently there's a Let's Encrypt certificate for it now :hugs: