### PR TITLE
Fix/hack inspection of arrow functions with leading newline (prettier-ism)

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -971,6 +971,7 @@ module.exports = function(expect) {
         let openingBrace;
         let isWrappedInBraces = true;
         let closingBrace = '}';
+        let reindentBodyLevel = 0;
         if (matchBodyAndIndent) {
           openingBrace = matchBodyAndIndent[1];
           body = matchBodyAndIndent[2];
@@ -986,7 +987,7 @@ module.exports = function(expect) {
             openingBrace = matchBodyAndIndent[1];
             isWrappedInBraces = false;
             body = matchBodyAndIndent[2];
-            const matchInitialNewline = openingBrace.match(/^(\n)( +)(  )/);
+            const matchInitialNewline = openingBrace.match(/^\n( +)/);
             if (matchInitialNewline) {
               // An arrow function whose body starts with a newline, as prettier likes to output, eg.:
               //        () =>
@@ -994,9 +995,9 @@ module.exports = function(expect) {
               //            1
               //          );
               // Shuffle/hack things around so it will be formatted correctly:
-              openingBrace = matchInitialNewline[1];
-              bodyIndent = matchInitialNewline[2];
-              body = matchInitialNewline[3] + body;
+              openingBrace = '\n';
+              bodyIndent = matchInitialNewline[1];
+              reindentBodyLevel = 1;
             } else {
               bodyIndent = matchBodyAndIndent[3] || '';
             }
@@ -1009,11 +1010,12 @@ module.exports = function(expect) {
           body = body.replace(new RegExp(`^ {${bodyIndent.length}}`, 'mg'), '');
           const indent = detectIndent(body);
           body = body.replace(
-            new RegExp(`^(?:${indent.indent})+`, 'mg'),
+            new RegExp(`^(?:${indent.indent})*`, 'mg'),
             ({ length }) =>
               utils.leftPad(
                 '',
-                (length / indent.amount) * output.indentationWidth,
+                (length / indent.amount + reindentBodyLevel) *
+                  output.indentationWidth,
                 ' '
               )
           );

--- a/lib/types.js
+++ b/lib/types.js
@@ -986,7 +986,20 @@ module.exports = function(expect) {
             openingBrace = matchBodyAndIndent[1];
             isWrappedInBraces = false;
             body = matchBodyAndIndent[2];
-            bodyIndent = matchBodyAndIndent[3] || '';
+            const matchInitialNewline = openingBrace.match(/^(\n)( +)(  )/);
+            if (matchInitialNewline) {
+              // An arrow function whose body starts with a newline, as prettier likes to output, eg.:
+              //        () =>
+              //          foo(
+              //            1
+              //          );
+              // Shuffle/hack things around so it will be formatted correctly:
+              openingBrace = matchInitialNewline[1];
+              bodyIndent = matchInitialNewline[2];
+              body = matchInitialNewline[3] + body;
+            } else {
+              bodyIndent = matchBodyAndIndent[3] || '';
+            }
             closingBrace = '';
           }
         }

--- a/test/types/function-type.spec.js
+++ b/test/types/function-type.spec.js
@@ -219,18 +219,56 @@ describe('function type', function() {
   }
 
   // We can't complete this test if the runtime doesn't support arrow functions:
-  var arrowFunctionWithLeadingNewline;
+  var arrowFunctionWith1SpaceIndentAndLeadingNewline;
   try {
     // eslint-disable-next-line no-new-func
-    arrowFunctionWithLeadingNewline = new Function(
+    arrowFunctionWith1SpaceIndentAndLeadingNewline = new Function(
+      'return () =>\n foo(\n  1\n )'
+    )();
+  } catch (e) {}
+
+  if (arrowFunctionWith1SpaceIndentAndLeadingNewline) {
+    it('should reindent an implicit return multiline arrow function', function() {
+      expect(
+        arrowFunctionWith1SpaceIndentAndLeadingNewline,
+        'to inspect as',
+        '() =>\n  foo(\n    1\n  )'
+      );
+    });
+  }
+
+  // We can't complete this test if the runtime doesn't support arrow functions:
+  var arrowFunctionWith2SpaceIndentAndLeadingNewline;
+  try {
+    // eslint-disable-next-line no-new-func
+    arrowFunctionWith2SpaceIndentAndLeadingNewline = new Function(
       'return () =>\n        foo(\n          1\n        )'
     )();
   } catch (e) {}
 
-  if (arrowFunctionWithLeadingNewline) {
+  if (arrowFunctionWith2SpaceIndentAndLeadingNewline) {
     it('should reindent an implicit return multiline arrow function', function() {
       expect(
-        arrowFunctionWithLeadingNewline,
+        arrowFunctionWith2SpaceIndentAndLeadingNewline,
+        'to inspect as',
+        '() =>\n  foo(\n    1\n  )'
+      );
+    });
+  }
+
+  // We can't complete this test if the runtime doesn't support arrow functions:
+  var arrowFunctionWith3SpaceIndentAndLeadingNewline;
+  try {
+    // eslint-disable-next-line no-new-func
+    arrowFunctionWith3SpaceIndentAndLeadingNewline = new Function(
+      'return () =>\n      foo(\n         1\n      )'
+    )();
+  } catch (e) {}
+
+  if (arrowFunctionWith3SpaceIndentAndLeadingNewline) {
+    it('should reindent an implicit return multiline arrow function with 4 space indent', function() {
+      expect(
+        arrowFunctionWith3SpaceIndentAndLeadingNewline,
         'to inspect as',
         '() =>\n  foo(\n    1\n  )'
       );

--- a/test/types/function-type.spec.js
+++ b/test/types/function-type.spec.js
@@ -238,6 +238,25 @@ describe('function type', function() {
   }
 
   // We can't complete this test if the runtime doesn't support arrow functions:
+  var arrowFunctionWith4SpaceIndentAndLeadingNewline;
+  try {
+    // eslint-disable-next-line no-new-func
+    arrowFunctionWith4SpaceIndentAndLeadingNewline = new Function(
+      'return () =>\n        foo(\n            1\n        )'
+    )();
+  } catch (e) {}
+
+  if (arrowFunctionWith4SpaceIndentAndLeadingNewline) {
+    it('should reindent an implicit return multiline arrow function with 4 space indent', function() {
+      expect(
+        arrowFunctionWith4SpaceIndentAndLeadingNewline,
+        'to inspect as',
+        '() =>\n  foo(\n    1\n  )'
+      );
+    });
+  }
+
+  // We can't complete this test if the runtime doesn't support arrow functions:
   var multiParamArrowFunction;
   try {
     // eslint-disable-next-line no-new-func

--- a/test/types/function-type.spec.js
+++ b/test/types/function-type.spec.js
@@ -219,6 +219,25 @@ describe('function type', function() {
   }
 
   // We can't complete this test if the runtime doesn't support arrow functions:
+  var arrowFunctionWithLeadingNewline;
+  try {
+    // eslint-disable-next-line no-new-func
+    arrowFunctionWithLeadingNewline = new Function(
+      'return () =>\n        foo(\n          1\n        )'
+    )();
+  } catch (e) {}
+
+  if (arrowFunctionWithLeadingNewline) {
+    it('should reindent an implicit return multiline arrow function', function() {
+      expect(
+        arrowFunctionWithLeadingNewline,
+        'to inspect as',
+        '() =>\n  foo(\n    1\n  )'
+      );
+    });
+  }
+
+  // We can't complete this test if the runtime doesn't support arrow functions:
   var multiParamArrowFunction;
   try {
     // eslint-disable-next-line no-new-func


### PR DESCRIPTION
After adopting prettier in unexpected-mitm, we've run into some functions in the test suite where the indentation isn't properly normalized when inspected by the `function` type.

This fix/hack allows us to fix these cases: https://github.com/unexpectedjs/unexpected-mitm/pull/66/files