### PR TITLE
Add launch configuration for running the mocha tests in the vscode debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "protocol": "inspector",
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha Tests",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "internalConsoleOptions": "openOnSessionStart",
+      "skipFiles": [
+        "<node_internals>/**" // Prevent stepping through async_hooks.js et al.
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Allows debugging a test by changing `it` to `it.only` and hitting the play button.

Just FYI/checking that it's OK with everyone to add an innocent little config file :)