### PR TITLE
<object> to satisfy <object>: Do not dereference properties that aren't needed for the assertion

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1827,26 +1827,23 @@ module.exports = expect => {
       const promiseByKey = {};
       let forceExhaustivelyComparison = false;
       uniqueKeys.forEach((key, index) => {
-        const subjectKey = subjectType.hasKey(subject, key)
-          ? subjectType.valueForKey(subject, key)
-          : undefined;
+        const subjectHasKey = subjectType.hasKey(subject, key);
         const valueKey = valueType.hasKey(value, key, true)
           ? valueType.valueForKey(value, key)
           : undefined;
         const valueKeyType = expect.findTypeOf(valueKey);
-        const isDefinedSubjectKey = typeof subjectKey !== 'undefined';
-        const isDefinedValueKey = typeof valueKey !== 'undefined';
         if (expect.flags.exhaustively) {
-          if (valueKeyType.is('expect.it') && !isDefinedSubjectKey) {
+          if (valueKeyType.is('expect.it') && !subjectHasKey) {
             // ensure value only expect.it key is marked missing
             forceExhaustivelyComparison = true;
           }
-        } else {
-          if (isDefinedSubjectKey && !isDefinedValueKey) {
-            // ignore subject only keys unless we are being exhaustive
-            return;
-          }
+        } else if (subjectHasKey && typeof valueKey === 'undefined') {
+          // ignore subject only keys unless we are being exhaustive
+          return;
         }
+        const subjectKey = subjectHasKey
+          ? subjectType.valueForKey(subject, key)
+          : undefined;
 
         promiseByKey[key] = expect.promise(() => {
           if (valueKeyType.is('expect.it')) {

--- a/test/assertions/to-satisfy.spec.js
+++ b/test/assertions/to-satisfy.spec.js
@@ -2564,4 +2564,17 @@ describe('to satisfy assertion', () => {
       });
     });
   });
+
+  it('should not dereference properties that are not being asserted on', function() {
+    expect(
+      {
+        get ohNo() {
+          throw new Error('argh');
+        },
+        foo: 123
+      },
+      'to satisfy',
+      { foo: 123 }
+    );
+  });
 });


### PR DESCRIPTION
Fixes regression from #482