### PR TITLE
Avoid double rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPORTER = dot
 
-TARGETS ?= unexpected.js unexpected.js.map
+TARGETS ?= unexpected.js
 
 CHEWBACCA_THRESHOLD ?= 25
 


### PR DESCRIPTION
The sourcemap is automatically output by the build/lib target.
This meant listing the source map then triggers rebuilding the
library a second time. Fix that.