### PR TITLE
Fix unexpected messy missing diff

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1357,7 +1357,7 @@ module.exports = expect => {
   );
 
   expect.addAssertion(
-    '<any|Error|object> to [exhaustively] satisfy <expect.it>',
+    '<any|Error> to [exhaustively] satisfy <expect.it>',
     (expect, subject, value) => expect.promise(() => value(subject))
   );
 
@@ -1410,7 +1410,7 @@ module.exports = expect => {
   );
 
   expect.addAssertion(
-    '<any> to [exhaustively] satisfy [assertion] <expect.it>',
+    '<any|object> to [exhaustively] satisfy [assertion] <expect.it>',
     (expect, subject, value) =>
       expect.withError(
         () => value(subject, expect.context),


### PR DESCRIPTION
When running unexpected-messy against v11 we get a missing diff. This PR should fix the problem.