### PR TITLE
Fix inspection of single line arrow functions that have a linebreak right after the arrow

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -989,7 +989,7 @@ module.exports = function(expect) {
             isWrappedInBraces = false;
             body = matchBodyAndIndent[2];
             const matchInitialNewline = openingBrace.match(/^\n( +)/);
-            if (matchInitialNewline) {
+            if (matchInitialNewline && /\n/.test(body)) {
               // An arrow function whose body starts with a newline, as prettier likes to output, eg.:
               //        () =>
               //          foo(

--- a/test/types/function-type.spec.js
+++ b/test/types/function-type.spec.js
@@ -195,6 +195,19 @@ describe('function type', () => {
     });
   }
 
+  var implicitReturnArrowFunction;
+  try {
+    // eslint-disable-next-line no-new-func
+    implicitReturnArrowFunction = new Function('return a =>\n  a')();
+  } catch (e) {}
+
+  if (implicitReturnArrowFunction) {
+    it('should render an implicit return arrow function a single line break after the arrow', () => {
+      // eslint-disable-next-line no-eval
+      expect(eval(`a =>\n  a`), 'to inspect as', `a =>\n  a`);
+    });
+  }
+
   // We can't complete this test if the runtime doesn't support arrow functions:
   var evilImplicitReturnMultilineArrowFunction;
   try {


### PR DESCRIPTION
Fixes #549 (regression introduced in #519).