### PR TITLE
mocha: Use --require unexpected-markdown instead of --compilers ...

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -4,4 +4,4 @@
 --timeout 20000
 --require ./test/common
 --require ./test/promisePolyfill
---compilers md:unexpected-markdown
+--require unexpected-markdown


### PR DESCRIPTION
Silences an annoying warning when running the documentation tests.

Background: https://github.com/mochajs/mocha/wiki/compilers-deprecation