### PR TITLE
expect.it: Forward flags to assertions further down the parameter list

### DIFF
--- a/lib/createTopLevelExpect.js
+++ b/lib/createTopLevelExpect.js
@@ -1308,9 +1308,10 @@ expectPrototype._createWrappedExpect = function(
   subject,
   args,
   testDescriptionString,
-  context
+  context,
+  forwardedFlags
 ) {
-  const flags = extend({}, assertionRule.flags);
+  const flags = extend({}, forwardedFlags, assertionRule.flags);
   const parentExpect = this;
 
   function wrappedExpect(subject, testDescriptionString) {
@@ -1342,7 +1343,8 @@ expectPrototype._createWrappedExpect = function(
         context.child(),
         subject,
         testDescriptionString,
-        args
+        args,
+        wrappedExpect.flags
       )
     );
   }
@@ -1383,7 +1385,8 @@ expectPrototype._executeExpect = function(
   context,
   subject,
   testDescriptionString,
-  args
+  args,
+  forwardedFlags
 ) {
   let assertionRule = this.lookupAssertionRule(
     subject,
@@ -1438,7 +1441,8 @@ expectPrototype._executeExpect = function(
     subject,
     args,
     testDescriptionString,
-    context
+    context,
+    forwardedFlags
   );
 
   return oathbreaker(assertionRule.handler(wrappedExpect, subject, ...args));

--- a/lib/createTopLevelExpect.js
+++ b/lib/createTopLevelExpect.js
@@ -84,7 +84,7 @@ function getOrGroups(expectations) {
   return orGroups;
 }
 
-function evaluateGroup(unexpected, context, subject, orGroup) {
+function evaluateGroup(unexpected, context, subject, orGroup, forwardedFlags) {
   return orGroup.map(expectation => {
     const args = Array.prototype.slice.call(expectation);
     args.unshift(subject);
@@ -101,7 +101,7 @@ function evaluateGroup(unexpected, context, subject, orGroup) {
             return args[1](args[0]);
           }
         } else {
-          return unexpected._expect(context.child(), args);
+          return unexpected._expect(context.child(), args, forwardedFlags);
         }
       })
     };
@@ -171,7 +171,7 @@ function writeGroupEvaluationsToOutput(output, groupEvaluations) {
   });
 }
 
-function createExpectIt(expect, expectations) {
+function createExpectIt(expect, expectations, forwardedFlags) {
   const orGroups = getOrGroups(expectations);
 
   function expectIt(subject, context) {
@@ -193,7 +193,13 @@ function createExpectIt(expect, expectations) {
     const groupEvaluations = [];
     const promises = [];
     orGroups.forEach(orGroup => {
-      const evaluations = evaluateGroup(expect, context, subject, orGroup);
+      const evaluations = evaluateGroup(
+        expect,
+        context,
+        subject,
+        orGroup,
+        forwardedFlags
+      );
       evaluations.forEach(({ promise }) => {
         promises.push(promise);
       });
@@ -231,12 +237,12 @@ function createExpectIt(expect, expectations) {
   expectIt.and = function(...args) {
     const copiedExpectations = expectations.slice();
     copiedExpectations.push(args);
-    return createExpectIt(expect, copiedExpectations);
+    return createExpectIt(expect, copiedExpectations, forwardedFlags);
   };
   expectIt.or = function(...args) {
     const copiedExpectations = expectations.slice();
     copiedExpectations.push(OR, args);
-    return createExpectIt(expect, copiedExpectations);
+    return createExpectIt(expect, copiedExpectations, forwardedFlags);
   };
   return expectIt;
 }
@@ -249,10 +255,11 @@ const expectPrototype = {
 utils.setPrototypeOfOrExtend(expectPrototype, Function.prototype);
 
 expectPrototype.it = function(...args) {
+  // FIXME: Make this unnecessary:
   if (this.flags && typeof args[0] === 'string') {
     args[0] = utils.forwardFlags(args[0], this.flags);
   }
-  return createExpectIt(this._topLevelExpect, [args]);
+  return createExpectIt(this._topLevelExpect, [args], this.flags);
 };
 
 expectPrototype.equal = function(actual, expected, depth, seen) {
@@ -1370,7 +1377,7 @@ expectPrototype._createWrappedExpect = function(
       ((argRule && argRule.type.is('assertion')) ||
         wrappedExpect._getAssertionIndices().indexOf(i) >= 0)
     ) {
-      return new AssertionString(arg);
+      return new AssertionString(utils.forwardFlags(arg, flags));
     }
 
     return output => {
@@ -1448,7 +1455,7 @@ expectPrototype._executeExpect = function(
   return oathbreaker(assertionRule.handler(wrappedExpect, subject, ...args));
 };
 
-expectPrototype._expect = function expect(context, args) {
+expectPrototype._expect = function expect(context, args, forwardedFlags) {
   const subject = args[0];
   const testDescriptionString = args[1];
 
@@ -1468,7 +1475,8 @@ expectPrototype._expect = function expect(context, args) {
       context,
       subject,
       testDescriptionString,
-      Array.prototype.slice.call(args, 2)
+      Array.prototype.slice.call(args, 2),
+      forwardedFlags
     );
     if (utils.isPromise(result)) {
       result = wrapPromiseIfNecessary(result);

--- a/lib/createTopLevelExpect.js
+++ b/lib/createTopLevelExpect.js
@@ -255,10 +255,6 @@ const expectPrototype = {
 utils.setPrototypeOfOrExtend(expectPrototype, Function.prototype);
 
 expectPrototype.it = function(...args) {
-  // FIXME: Make this unnecessary:
-  if (this.flags && typeof args[0] === 'string') {
-    args[0] = utils.forwardFlags(args[0], this.flags);
-  }
   return createExpectIt(this._topLevelExpect, [args], this.flags);
 };
 
@@ -1395,6 +1391,12 @@ expectPrototype._executeExpect = function(
   args,
   forwardedFlags
 ) {
+  if (forwardedFlags) {
+    testDescriptionString = utils.forwardFlags(
+      testDescriptionString,
+      forwardedFlags
+    );
+  }
   let assertionRule = this.lookupAssertionRule(
     subject,
     testDescriptionString,

--- a/test/api/expect.spec.js
+++ b/test/api/expect.spec.js
@@ -1,4 +1,4 @@
-/*global expect*/
+/* global expect */
 describe('expect', function() {
   it('should forward flags to assertion strings that are processed by the next assertion', function() {
     var clonedExpect = expect.clone();

--- a/test/api/expect.spec.js
+++ b/test/api/expect.spec.js
@@ -1,0 +1,44 @@
+/*global expect*/
+describe('expect', function() {
+  it('should forward flags to assertion strings that are processed by the next assertion', function() {
+    var clonedExpect = expect.clone();
+
+    clonedExpect.addAssertion(
+      '<number> [not] to have an absolute value of <number>',
+      function(expect, subject, value) {
+        expect.errorMode = 'nested';
+        expect(
+          subject,
+          'when passed as parameter to',
+          Math.abs,
+          '[not] to equal',
+          value
+        );
+      }
+    );
+
+    clonedExpect(-124, 'not to have an absolute value of', 0);
+  });
+
+  it('should forward flags to assertion strings that are processed by the next next assertion', function() {
+    var clonedExpect = expect.clone();
+
+    clonedExpect.addAssertion(
+      '<number> [not] to have a floored absolute value of <number>',
+      function(expect, subject, value) {
+        expect.errorMode = 'nested';
+        expect(
+          subject,
+          'when passed as parameter to',
+          Math.abs,
+          'when passed as parameter to',
+          Math.floor,
+          '[not] to equal',
+          value
+        );
+      }
+    );
+
+    clonedExpect(-124, 'not to have a floored absolute value of', 0);
+  });
+});


### PR DESCRIPTION
https://github.com/unexpectedjs/unexpected-knex/pull/28#discussion_r244633170

Not too sure about the implementation. Maybe this is something that belongs in `expect.context`?