### PR TITLE
Simplify the "to be rejected with" and "to call the callback with error" assertions

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -4,7 +4,6 @@ const arrayChanges = require('array-changes');
 const arrayChangesAsync = require('array-changes-async');
 const throwIfNonUnexpectedError = require('./throwIfNonUnexpectedError');
 const objectIs = utils.objectIs;
-const isRegExp = utils.isRegExp;
 const extend = utils.extend;
 
 module.exports = expect => {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -2515,15 +2515,7 @@ module.exports = expect => {
     (expect, subject, value) =>
       expect(subject, 'to call the callback with error').tap(err => {
         expect.errorMode = 'nested';
-        if (
-          err &&
-          err._isUnexpected &&
-          (typeof value === 'string' || isRegExp(value))
-        ) {
-          return expect(err, 'to have message', value);
-        } else {
-          return expect(err, 'to satisfy', value);
-        }
+        expect(err, 'to satisfy', value);
       })
   );
 };

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -2265,17 +2265,7 @@ module.exports = expect => {
       expect.errorMode = 'nested';
       return expect(subject, 'to be rejected').tap(err =>
         expect.withError(
-          () => {
-            if (
-              err &&
-              err._isUnexpected &&
-              (typeof value === 'string' || isRegExp(value))
-            ) {
-              return expect(err, 'to have message', value);
-            } else {
-              return expect(err, 'to [exhaustively] satisfy', value);
-            }
-          },
+          () => expect(err, 'to [exhaustively] satisfy', value),
           e => {
             e.originalError = err;
             throw e;


### PR DESCRIPTION
Along the same lines as #538.