### PR TITLE
Remove long-deprecated support for this.subject etc. in assertion handlers

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -1467,9 +1467,7 @@ Unexpected.prototype._expect = function expect(context, args) {
       wrappedExpect.argTypes = wrappedExpect._getArgTypes();
     }
 
-    return oathbreaker(
-      assertionRule.handler.call(wrappedExpect, wrappedExpect, subject, ...args)
-    );
+    return oathbreaker(assertionRule.handler(wrappedExpect, subject, ...args));
   }
 
   try {

--- a/test/api/shift.spec.js
+++ b/test/api/shift.spec.js
@@ -133,7 +133,7 @@ describe('expect.shift', () => {
         expect,
         subject
       ) {
-        return this.shift(expect, `foo${subject}`, 0);
+        return expect.shift(expect, `foo${subject}`, 0);
       });
     clonedExpect(
       'foo',

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -175,19 +175,6 @@ describe('unexpected', () => {
         new Error('foo')
       );
     });
-
-    it('should make the wrapped expect available as the context (legacy)', () => {
-      var clonedExpect = expect
-        .clone()
-        .addAssertion('to foo', function(expect, subject) {
-          this.errorMode = 'nested';
-          expect(this, 'to be', expect);
-        });
-
-      return expect(function() {
-        return clonedExpect(undefined, 'to foo');
-      }, 'not to error');
-    });
   });
 
   describe('when given an expect.it as the 2nd argument', () => {


### PR DESCRIPTION
As [discussed on gitter](https://gitter.im/unexpectedjs/unexpected?at=5c30a3b682a6c30b908afa07).

Has been deprecated and undocumented since around Unexpected 3, so it's very unlikely to be in use :)