### PR TITLE
Make a separate BrowserStack project for separate branches

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -29,7 +29,8 @@ module.exports = function(config) {
 
     browserStack: {
       video: false,
-      project: 'unexpected'
+      project:
+        process.env.TRAVIS_BRANCH === 'master' ? 'unexpected' : 'unexpected-dev'
     },
 
     customLaunchers: {


### PR DESCRIPTION
Right now we have a red BrowserStack badge when a branch fails, that makes it
look like there is something wrong with master.