### PR TITLE
Link to 'to satisfy' from the 'to have property' docs

### DIFF
--- a/documentation/assertions/object/to-have-property.md
+++ b/documentation/assertions/object/to-have-property.md
@@ -45,3 +45,19 @@ This assertion can be negated using the `not` flag:
 expect({ a: 'b' }, 'not to have property', 'b');
 expect(Object.create({ a: 'b' }), 'not to have own property', 'a');
 ```
+
+### Nested properties
+
+This assertion does *not* support checking for nested properties using `a.b.c`
+or similar syntax, as [you might expect from other assertion
+libraries](https://github.com/unexpectedjs/unexpected/issues/405). Since `.` is
+a valid character in a property name, that syntax would be ambiguous.
+
+Instead we recommend using [to satisfy](../../any/to-satisfy/) for this use
+case:
+
+```js
+const myObj = {foo: 'bar', a: { b: { c: 123, d: true } } };
+
+expect(myObj, 'to satisfy', { a: { b: { c: 123 } } });
+```


### PR DESCRIPTION
To help users expecting `a.b.c` syntax for deep properties.

Fixes #405