### PR TITLE
function type: Support inspection of classes and generators

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -935,7 +935,7 @@ module.exports = function(expect) {
       let body;
       let bodyIndent;
       const matchSource = source.match(
-        /^\s*((?:async )?\s*(?:\S+\s*=>|\([^)]*\)\s*=>|function\s?\w*\s*\([^)]*\)))([\s\S]*)$/
+        /^\s*((?:async )?\s*(?:\S+\s*=>|\([^)]*\)\s*=>|class|function\s?\w*\s*\([^)]*\)))([\s\S]*)$/
       );
       if (matchSource) {
         // Normalize so there's always space after "function":

--- a/lib/types.js
+++ b/lib/types.js
@@ -935,7 +935,7 @@ module.exports = function(expect) {
       let body;
       let bodyIndent;
       const matchSource = source.match(
-        /^\s*((?:async )?\s*(?:\S+\s*=>|\([^)]*\)\s*=>|class|function\s?\w*\s*\([^)]*\)))([\s\S]*)$/
+        /^\s*((?:async )?\s*(?:\S+\s*=>|\([^)]*\)\s*=>|class|function\s?(?:\*\s*)?\w*\s*\([^)]*\)))([\s\S]*)$/
       );
       if (matchSource) {
         // Normalize so there's always space after "function":

--- a/lib/types.js
+++ b/lib/types.js
@@ -938,8 +938,10 @@ module.exports = function(expect) {
         /^\s*((?:async )?\s*(?:\S+\s*=>|\([^)]*\)\s*=>|class|function\s?(?:\*\s*)?\w*\s*\([^)]*\)))([\s\S]*)$/
       );
       if (matchSource) {
-        // Normalize so there's always space after "function":
-        preamble = matchSource[1].replace(/function(\S)/, 'function $1');
+        // Normalize so there's always space after "function" and never after "*" for generator functions:
+        preamble = matchSource[1]
+          .replace(/function(\S)/, 'function $1')
+          .replace(/\* /, '*');
         if (preamble === 'function ()' && name) {
           // fn.bind() doesn't seem to include the name in the .toString() output:
           preamble = `function ${name}()`;

--- a/test/types/function-type.spec.js
+++ b/test/types/function-type.spec.js
@@ -348,6 +348,42 @@ describe('function type', () => {
     });
   }
 
+  // We can't complete this test if the runtime doesn't support the class syntax:
+  var emptyClass;
+  try {
+    // eslint-disable-next-line no-new-func
+    emptyClass = new Function('return class Foo {}')();
+  } catch (e) {}
+
+  if (emptyClass) {
+    it('should inspect a class', () => {
+      expect(emptyClass, 'to inspect as', 'class Foo {}');
+    });
+  }
+
+  // We can't complete this test if the runtime doesn't support the class syntax:
+  var classWithOneSpaceIndent;
+  try {
+    // eslint-disable-next-line no-new-func
+    classWithOneSpaceIndent = new Function(
+      'return class Foo {\n constructor(bar) {\n  this.bar = bar;\n }\n}'
+    )();
+  } catch (e) {}
+
+  if (classWithOneSpaceIndent) {
+    it('should inspect and reindent a non-empty class', () => {
+      expect(
+        classWithOneSpaceIndent,
+        'to inspect as',
+        'class Foo {\n' +
+          '  constructor(bar) {\n' +
+          '    this.bar = bar;\n' +
+          '  }\n' +
+          '}'
+      );
+    });
+  }
+
   describe('diff()', function() {
     function foo() {}
     function bar() {}

--- a/test/types/function-type.spec.js
+++ b/test/types/function-type.spec.js
@@ -348,6 +348,62 @@ describe('function type', () => {
     });
   }
 
+  // We can't complete this test if the runtime doesn't support generators:
+  var anonymousGenerator;
+  try {
+    // eslint-disable-next-line no-new-func
+    anonymousGenerator = new Function('return function*(){}')();
+  } catch (e) {}
+
+  if (anonymousGenerator) {
+    it('should inspect an anonymous generator', () => {
+      expect(anonymousGenerator, 'to inspect as', 'function *(){}');
+    });
+  }
+
+  // We can't complete this test if the runtime doesn't support generators:
+  var anonymousGeneratorWithSpaces;
+  try {
+    // eslint-disable-next-line no-new-func
+    anonymousGeneratorWithSpaces = new Function('return function * (){}')();
+  } catch (e) {}
+
+  if (anonymousGeneratorWithSpaces) {
+    it('should inspect an anonymous generator with spaces around the *', () => {
+      expect(anonymousGeneratorWithSpaces, 'to inspect as', 'function * (){}');
+    });
+  }
+
+  // We can't complete this test if the runtime doesn't support generators:
+  var namedGenerator;
+  try {
+    // eslint-disable-next-line no-new-func
+    namedGenerator = new Function('return function*foo(){}')();
+  } catch (e) {}
+
+  if (namedGenerator) {
+    it('should inspect a named generator', () => {
+      expect(namedGenerator, 'to inspect as', 'function *foo(){}');
+    });
+  }
+
+  // We can't complete this test if the runtime doesn't support generators:
+  var namedGeneratorWithSpaces;
+  try {
+    // eslint-disable-next-line no-new-func
+    namedGeneratorWithSpaces = new Function('function * foo(){}')();
+  } catch (e) {}
+
+  if (namedGeneratorWithSpaces) {
+    it('should inspect a named generator with spaces around the *', () => {
+      expect(
+        namedGeneratorWithSpaces,
+        'to inspect as',
+        'return function * foo(){}'
+      );
+    });
+  }
+
   // We can't complete this test if the runtime doesn't support the class syntax:
   var anonymousClass;
   try {

--- a/test/types/function-type.spec.js
+++ b/test/types/function-type.spec.js
@@ -274,7 +274,7 @@ describe('function type', () => {
     expect(
       'function * (){}',
       'if supported by the runtime to inspect as',
-      'function * (){}'
+      'function *(){}'
     );
   });
 
@@ -290,7 +290,7 @@ describe('function type', () => {
     expect(
       'function * foo(){}',
       'if supported by the runtime to inspect as',
-      'function * foo(){}'
+      'function *foo(){}'
     );
   });
 

--- a/test/types/function-type.spec.js
+++ b/test/types/function-type.spec.js
@@ -349,6 +349,19 @@ describe('function type', () => {
   }
 
   // We can't complete this test if the runtime doesn't support the class syntax:
+  var anonymousClass;
+  try {
+    // eslint-disable-next-line no-new-func
+    anonymousClass = new Function('return class {}')();
+  } catch (e) {}
+
+  if (anonymousClass) {
+    it('should inspect an anonymous class', () => {
+      expect(anonymousClass, 'to inspect as', 'class {}');
+    });
+  }
+
+  // We can't complete this test if the runtime doesn't support the class syntax:
   var emptyClass;
   try {
     // eslint-disable-next-line no-new-func

--- a/test/types/function-type.spec.js
+++ b/test/types/function-type.spec.js
@@ -159,299 +159,168 @@ describe('function type', () => {
     // jscs:enable
   });
 
-  // We can't complete this test if the runtime doesn't support arrow functions:
-  var singleParamArrowFunction;
-  try {
-    // eslint-disable-next-line no-new-func
-    singleParamArrowFunction = new Function('return a => a + 1;')();
-  } catch (e) {}
+  expect.addAssertion(
+    '<string> if supported by the runtime <assertion>',
+    (expect, subject) => {
+      let value;
+      try {
+        // eslint-disable-next-line no-new-func
+        value = new Function(`return ${subject};`)();
+      } catch (err) {
+        // Not supported, don't do anything
+        return;
+      }
+      return expect.shift(value);
+    }
+  );
 
-  if (singleParamArrowFunction) {
-    it('should render a single param arrow function', () => {
-      expect(singleParamArrowFunction, 'to inspect as', 'a => a + 1');
-    });
-  }
+  it('should render a single param arrow function', () => {
+    expect(
+      'a => a + 1',
+      'if supported by the runtime to inspect as',
+      'a => a + 1'
+    );
+  });
 
-  // We can't complete this test if the runtime doesn't support arrow functions:
-  var implicitReturnMultilineArrowFunction;
-  try {
-    // eslint-disable-next-line no-new-func
-    implicitReturnMultilineArrowFunction = new Function(
-      'return a => \n    a + 1;'
-    )();
-  } catch (e) {}
+  it('should render an implicit return multiline arrow function', () => {
+    expect(
+      'a => \n    a + 1',
+      'if supported by the runtime to inspect as',
+      'a => \n    a + 1'
+    );
+  });
 
-  if (implicitReturnMultilineArrowFunction) {
-    it('should render an implicit return multiline arrow function', () => {
-      expect(
-        implicitReturnMultilineArrowFunction,
-        'to inspect as',
-        'a => \n    a + 1'
-      );
-    });
-  }
+  it('should render an implicit return arrow function a single line break after the arrow', () => {
+    expect(
+      'a =>\n  a',
+      'if supported by the runtime to inspect as',
+      `a =>\n  a`
+    );
+  });
 
-  var implicitReturnArrowFunction;
-  try {
-    // eslint-disable-next-line no-new-func
-    implicitReturnArrowFunction = new Function('return a =>\n  a')();
-  } catch (e) {}
+  it('should reindent an implicit return arrow function with a single line break after the arrow', () => {
+    expect(
+      'a =>\n    a',
+      'if supported by the runtime to inspect as',
+      `a =>\n  a`
+    );
+  });
 
-  if (implicitReturnArrowFunction) {
-    it('should render an implicit return arrow function a single line break after the arrow', () => {
-      expect(implicitReturnArrowFunction, 'to inspect as', `a =>\n  a`);
-    });
-  }
+  it('should render an implicit return multiline arrow function with an evil alternation', () => {
+    expect(
+      'a => \n    a || {}',
+      'if supported by the runtime to inspect as',
+      'a => \n    a || {}'
+    );
+  });
 
-  var implicitReturnArrowFunctionWith4SpaceIndent;
-  try {
-    // eslint-disable-next-line no-new-func
-    implicitReturnArrowFunctionWith4SpaceIndent = new Function(
-      'return a =>\n    a'
-    )();
-  } catch (e) {}
+  it('should reindent an implicit return multiline arrow function with 1 space indent', () => {
+    expect(
+      '() =>\n foo(\n  1\n )',
+      'if supported by the runtime to inspect as',
+      '() =>\n  foo(\n    1\n  )'
+    );
+  });
 
-  if (implicitReturnArrowFunctionWith4SpaceIndent) {
-    it('should reindent an implicit return arrow function with a single line break after the arrow', () => {
-      expect(
-        implicitReturnArrowFunctionWith4SpaceIndent,
-        'to inspect as',
-        `a =>\n  a`
-      );
-    });
-  }
+  it('should reindent an implicit return multiline arrow function with 2 space indent', () => {
+    expect(
+      '() =>\n        foo(\n          1\n        )',
+      'if supported by the runtime to inspect as',
+      '() =>\n  foo(\n    1\n  )'
+    );
+  });
 
-  // We can't complete this test if the runtime doesn't support arrow functions:
-  var evilImplicitReturnMultilineArrowFunction;
-  try {
-    // eslint-disable-next-line no-new-func
-    evilImplicitReturnMultilineArrowFunction = new Function(
-      'return a => \n    a || {};'
-    )();
-  } catch (e) {}
+  it('should reindent an implicit return multiline arrow function with 4 space indent', () => {
+    expect(
+      '() =>\n      foo(\n         1\n      )',
+      'if supported by the runtime to inspect as',
+      '() =>\n  foo(\n    1\n  )'
+    );
+  });
 
-  if (evilImplicitReturnMultilineArrowFunction) {
-    it('should render an implicit return multiline arrow function with an evil alternation', () => {
-      expect(
-        evilImplicitReturnMultilineArrowFunction,
-        'to inspect as',
-        'a => \n    a || {}'
-      );
-    });
-  }
+  it('should reindent an implicit return multiline arrow function with long leading indent', () => {
+    expect(
+      '() =>\n        foo(\n            1\n        )',
+      'if supported by the runtime to inspect as',
+      '() =>\n  foo(\n    1\n  )'
+    );
+  });
 
-  // We can't complete this test if the runtime doesn't support arrow functions:
-  var arrowFunctionWith1SpaceIndentAndLeadingNewline;
-  try {
-    // eslint-disable-next-line no-new-func
-    arrowFunctionWith1SpaceIndentAndLeadingNewline = new Function(
-      'return () =>\n foo(\n  1\n )'
-    )();
-  } catch (e) {}
+  it('should render a multi param arrow function', () => {
+    expect(
+      '(a, b) => a + b;',
+      'if supported by the runtime to inspect as',
+      '(a, b) => a + b'
+    );
+  });
 
-  if (arrowFunctionWith1SpaceIndentAndLeadingNewline) {
-    it('should reindent an implicit return multiline arrow function with 1 space indent', () => {
-      expect(
-        arrowFunctionWith1SpaceIndentAndLeadingNewline,
-        'to inspect as',
-        '() =>\n  foo(\n    1\n  )'
-      );
-    });
-  }
+  it('should render "async" before an AsyncFunction instance', () => {
+    expect(
+      'async function foo(a) { return a + 1; }',
+      'if supported by the runtime to inspect as',
+      'async function foo(a) { return a + 1; }'
+    );
+  });
 
-  // We can't complete this test if the runtime doesn't support arrow functions:
-  var arrowFunctionWith2SpaceIndentAndLeadingNewline;
-  try {
-    // eslint-disable-next-line no-new-func
-    arrowFunctionWith2SpaceIndentAndLeadingNewline = new Function(
-      'return () =>\n        foo(\n          1\n        )'
-    )();
-  } catch (e) {}
+  it('should inspect an anonymous generator', () => {
+    expect(
+      'function*(){}',
+      'if supported by the runtime to inspect as',
+      'function *(){}'
+    );
+  });
 
-  if (arrowFunctionWith2SpaceIndentAndLeadingNewline) {
-    it('should reindent an implicit return multiline arrow function with 2 space indent', () => {
-      expect(
-        arrowFunctionWith2SpaceIndentAndLeadingNewline,
-        'to inspect as',
-        '() =>\n  foo(\n    1\n  )'
-      );
-    });
-  }
+  it('should inspect an anonymous generator with spaces around the *', () => {
+    expect(
+      'function * (){}',
+      'if supported by the runtime to inspect as',
+      'function * (){}'
+    );
+  });
 
-  // We can't complete this test if the runtime doesn't support arrow functions:
-  var arrowFunctionWith3SpaceIndentAndLeadingNewline;
-  try {
-    // eslint-disable-next-line no-new-func
-    arrowFunctionWith3SpaceIndentAndLeadingNewline = new Function(
-      'return () =>\n      foo(\n         1\n      )'
-    )();
-  } catch (e) {}
+  it('should inspect a named generator', () => {
+    expect(
+      'function*foo(){}',
+      'if supported by the runtime to inspect as',
+      'function *foo(){}'
+    );
+  });
 
-  if (arrowFunctionWith3SpaceIndentAndLeadingNewline) {
-    it('should reindent an implicit return multiline arrow function with 4 space indent', () => {
-      expect(
-        arrowFunctionWith3SpaceIndentAndLeadingNewline,
-        'to inspect as',
-        '() =>\n  foo(\n    1\n  )'
-      );
-    });
-  }
+  it('should inspect a named generator with spaces around the *', () => {
+    expect(
+      'function * foo(){}',
+      'if supported by the runtime to inspect as',
+      'function * foo(){}'
+    );
+  });
 
-  // We can't complete this test if the runtime doesn't support arrow functions:
-  var arrowFunctionWith4SpaceIndentAndLeadingNewline;
-  try {
-    // eslint-disable-next-line no-new-func
-    arrowFunctionWith4SpaceIndentAndLeadingNewline = new Function(
-      'return () =>\n        foo(\n            1\n        )'
-    )();
-  } catch (e) {}
+  it('should inspect an anonymous class', () => {
+    expect('class {}', 'if supported by the runtime to inspect as', 'class {}');
+  });
 
-  if (arrowFunctionWith4SpaceIndentAndLeadingNewline) {
-    it('should reindent an implicit return multiline arrow function with long leading indent', () => {
-      expect(
-        arrowFunctionWith4SpaceIndentAndLeadingNewline,
-        'to inspect as',
-        '() =>\n  foo(\n    1\n  )'
-      );
-    });
-  }
+  it('should inspect a class', () => {
+    expect(
+      'class Foo {}',
+      'if supported by the runtime to inspect as',
+      'class Foo {}'
+    );
+  });
 
-  // We can't complete this test if the runtime doesn't support arrow functions:
-  var multiParamArrowFunction;
-  try {
-    // eslint-disable-next-line no-new-func
-    multiParamArrowFunction = new Function('return (a, b) => a + b;')();
-  } catch (e) {}
-
-  if (multiParamArrowFunction) {
-    it('should render a multi param arrow function', () => {
-      expect(multiParamArrowFunction, 'to inspect as', '(a, b) => a + b');
-    });
-  }
-
-  // We can't complete this test if the runtime doesn't support the async keyword:
-  var asyncFunction;
-  try {
-    // eslint-disable-next-line no-new-func
-    asyncFunction = new Function(
-      'return async function foo(a) {return a + 1;}'
-    )();
-  } catch (e) {}
-
-  if (asyncFunction) {
-    it('should render "async" before an AsyncFunction instance', () => {
-      expect(
-        asyncFunction,
-        'to inspect as',
-        'async function foo(a) { return a + 1; }'
-      );
-    });
-  }
-
-  // We can't complete this test if the runtime doesn't support generators:
-  var anonymousGenerator;
-  try {
-    // eslint-disable-next-line no-new-func
-    anonymousGenerator = new Function('return function*(){}')();
-  } catch (e) {}
-
-  if (anonymousGenerator) {
-    it('should inspect an anonymous generator', () => {
-      expect(anonymousGenerator, 'to inspect as', 'function *(){}');
-    });
-  }
-
-  // We can't complete this test if the runtime doesn't support generators:
-  var anonymousGeneratorWithSpaces;
-  try {
-    // eslint-disable-next-line no-new-func
-    anonymousGeneratorWithSpaces = new Function('return function * (){}')();
-  } catch (e) {}
-
-  if (anonymousGeneratorWithSpaces) {
-    it('should inspect an anonymous generator with spaces around the *', () => {
-      expect(anonymousGeneratorWithSpaces, 'to inspect as', 'function * (){}');
-    });
-  }
-
-  // We can't complete this test if the runtime doesn't support generators:
-  var namedGenerator;
-  try {
-    // eslint-disable-next-line no-new-func
-    namedGenerator = new Function('return function*foo(){}')();
-  } catch (e) {}
-
-  if (namedGenerator) {
-    it('should inspect a named generator', () => {
-      expect(namedGenerator, 'to inspect as', 'function *foo(){}');
-    });
-  }
-
-  // We can't complete this test if the runtime doesn't support generators:
-  var namedGeneratorWithSpaces;
-  try {
-    // eslint-disable-next-line no-new-func
-    namedGeneratorWithSpaces = new Function('function * foo(){}')();
-  } catch (e) {}
-
-  if (namedGeneratorWithSpaces) {
-    it('should inspect a named generator with spaces around the *', () => {
-      expect(
-        namedGeneratorWithSpaces,
-        'to inspect as',
-        'return function * foo(){}'
-      );
-    });
-  }
-
-  // We can't complete this test if the runtime doesn't support the class syntax:
-  var anonymousClass;
-  try {
-    // eslint-disable-next-line no-new-func
-    anonymousClass = new Function('return class {}')();
-  } catch (e) {}
-
-  if (anonymousClass) {
-    it('should inspect an anonymous class', () => {
-      expect(anonymousClass, 'to inspect as', 'class {}');
-    });
-  }
-
-  // We can't complete this test if the runtime doesn't support the class syntax:
-  var emptyClass;
-  try {
-    // eslint-disable-next-line no-new-func
-    emptyClass = new Function('return class Foo {}')();
-  } catch (e) {}
-
-  if (emptyClass) {
-    it('should inspect a class', () => {
-      expect(emptyClass, 'to inspect as', 'class Foo {}');
-    });
-  }
-
-  // We can't complete this test if the runtime doesn't support the class syntax:
-  var classWithOneSpaceIndent;
-  try {
-    // eslint-disable-next-line no-new-func
-    classWithOneSpaceIndent = new Function(
-      'return class Foo {\n constructor(bar) {\n  this.bar = bar;\n }\n}'
-    )();
-  } catch (e) {}
-
-  if (classWithOneSpaceIndent) {
-    it('should inspect and reindent a non-empty class', () => {
-      expect(
-        classWithOneSpaceIndent,
-        'to inspect as',
-        'class Foo {\n' +
-          '  constructor(bar) {\n' +
-          '    this.bar = bar;\n' +
-          '  }\n' +
-          '}'
-      );
-    });
-  }
+  it('should inspect and reindent a non-empty class', () => {
+    expect(
+      'class Foo {\n' +
+        ' constructor(bar) {\n' +
+        '  this.bar = bar;\n' +
+        ' }\n' +
+        '}',
+      'if supported by the runtime to inspect as',
+      'class Foo {\n' +
+        '  constructor(bar) {\n' +
+        '    this.bar = bar;\n' +
+        '  }\n' +
+        '}'
+    );
+  });
 
   describe('diff()', function() {
     function foo() {}


### PR DESCRIPTION
I wasn't aware that functions created using the `class` syntax would reflect that in the output of the `toString` method:

```
console.log((class Foo {}).toString()); // 'class Foo {}'
```

Let's inspect them like that instead of `function Foo( /*...*/ ) { /*...*/ }` as we do now :sweat_smile: