### PR TITLE
Deprecate legacy typeless addAssertion

### DIFF
--- a/lib/Unexpected.js
+++ b/lib/Unexpected.js
@@ -476,6 +476,13 @@ Unexpected.prototype.parseAssertion = function(assertionString) {
 
   let assertion;
   if (tokens.length === 1 && typeof tokens[0] === 'string') {
+    if (!this._legacyTypelessAssertionWarned) {
+      console.warn(
+        'The typeless expect.addAssertion syntax is deprecated and will be removed in a future update\n' +
+          'Please refer to http://unexpected.js.org/api/addAssertion/'
+      );
+      this._legacyTypelessAssertionWarned = true;
+    }
     assertion = {
       subject: parseTypeToken('any'),
       assertion: tokens[0],

--- a/test/api/addAssertion.spec.js
+++ b/test/api/addAssertion.spec.js
@@ -2,8 +2,8 @@
 describe('addAssertion', () => {
   it('is chainable', () => {
     expect
-      .addAssertion('foo', function() {})
-      .addAssertion('bar', function() {});
+      .addAssertion('<any> foo', function() {})
+      .addAssertion('<any> bar', function() {});
 
     expect(expect.assertions, 'to have keys', 'foo', 'bar');
   });
@@ -11,7 +11,7 @@ describe('addAssertion', () => {
   it('supports transfering flags from the custom assertion to nested expect', () => {
     var clonedExpect = expect
       .clone()
-      .addAssertion('[not] to be sorted', function(expect, subject) {
+      .addAssertion('<any> [not] to be sorted', function(expect, subject) {
         expect(subject, 'to be an array');
         expect(subject, '[not] to equal', [].concat(subject).sort());
       });
@@ -80,11 +80,11 @@ describe('addAssertion', () => {
       it('uses the most recently added version', () => {
         var clonedExpect = expect
           .clone()
-          .addAssertion('to foo', function(expect, subject) {
+          .addAssertion('<any> to foo', function(expect, subject) {
             expect.errorMode = 'bubble';
             expect.fail('old');
           })
-          .addAssertion('to foo', function(expect, subject) {
+          .addAssertion('<any> to foo', function(expect, subject) {
             expect.errorMode = 'bubble';
             expect.fail('new');
           });
@@ -102,7 +102,9 @@ describe('addAssertion', () => {
 
   it('allows overlapping patterns within a single addAssertion call', () => {
     expect(function() {
-      expect.clone().addAssertion(['to foo', 'to [really] foo'], function() {});
+      expect
+        .clone()
+        .addAssertion(['<any> to foo', '<any> to [really] foo'], function() {});
     }, 'not to throw');
   });
 
@@ -110,7 +112,10 @@ describe('addAssertion', () => {
     var clonedExpect = expect
       .clone()
       .addAssertion(
-        ['[not] to be foo', 'to be foo aliased without the not flag'],
+        [
+          '<any> [not] to be foo',
+          '<any> to be foo aliased without the not flag'
+        ],
         function(expect, subject) {
           expect(subject, '[not] to equal', 'foo');
         }
@@ -176,7 +181,7 @@ describe('addAssertion', () => {
     it('must not contain unbalanced brackets', () => {
       expect(
         function() {
-          expect.addAssertion('foo [', function() {});
+          expect.addAssertion('<any> foo [', function() {});
         },
         'to throw',
         "Assertion patterns must not contain unbalanced brackets: 'foo ['"
@@ -184,7 +189,7 @@ describe('addAssertion', () => {
 
       expect(
         function() {
-          expect.addAssertion('foo ]', function() {});
+          expect.addAssertion('<any> foo ]', function() {});
         },
         'to throw',
         "Assertion patterns must not contain unbalanced brackets: 'foo ]'"
@@ -194,7 +199,7 @@ describe('addAssertion', () => {
     it('must not contain unbalanced parentheses', () => {
       expect(
         function() {
-          expect.addAssertion('foo (', function() {});
+          expect.addAssertion('<any> foo (', function() {});
         },
         'to throw',
         "Assertion patterns must not contain unbalanced parentheses: 'foo ('"
@@ -202,7 +207,7 @@ describe('addAssertion', () => {
 
       expect(
         function() {
-          expect.addAssertion('foo )', function() {});
+          expect.addAssertion('<any> foo )', function() {});
         },
         'to throw',
         "Assertion patterns must not contain unbalanced parentheses: 'foo )'"
@@ -212,7 +217,7 @@ describe('addAssertion', () => {
     it('must not only contain flags', () => {
       expect(
         function() {
-          expect.addAssertion('[foo] [bar]', function() {});
+          expect.addAssertion('<any> [foo] [bar]', function() {});
         },
         'to throw',
         'Assertion patterns must not only contain flags'
@@ -223,7 +228,7 @@ describe('addAssertion', () => {
       it('must not be empty', () => {
         expect(
           function() {
-            expect.addAssertion('foo []', function() {});
+            expect.addAssertion('<any> foo []', function() {});
           },
           'to throw',
           "Assertion patterns must not contain empty flags: 'foo []'"
@@ -233,7 +238,7 @@ describe('addAssertion', () => {
       it('must not contain brackets', () => {
         expect(
           function() {
-            expect.addAssertion('foo [[bar]', function() {});
+            expect.addAssertion('<any> foo [[bar]', function() {});
           },
           'to throw',
           "Assertion patterns must not contain flags with brackets: 'foo [[bar]'"
@@ -241,7 +246,7 @@ describe('addAssertion', () => {
 
         expect(
           function() {
-            expect.addAssertion('foo [[bar]]', function() {});
+            expect.addAssertion('<any> foo [[bar]]', function() {});
           },
           'to throw',
           "Assertion patterns must not contain flags with brackets: 'foo [[bar]]'"
@@ -251,7 +256,7 @@ describe('addAssertion', () => {
       it('must not contain parentheses', () => {
         expect(
           function() {
-            expect.addAssertion('foo [(bar]', function() {});
+            expect.addAssertion('<any> foo [(bar]', function() {});
           },
           'to throw',
           "Assertion patterns must not contain flags with parentheses: 'foo [(bar]'"
@@ -259,7 +264,7 @@ describe('addAssertion', () => {
 
         expect(
           function() {
-            expect.addAssertion('foo [bar)]', function() {});
+            expect.addAssertion('<any> foo [bar)]', function() {});
           },
           'to throw',
           "Assertion patterns must not contain flags with parentheses: 'foo [bar)]'"
@@ -271,7 +276,7 @@ describe('addAssertion', () => {
       it('can be empty', () => {
         var clonedExpect = expect
           .clone()
-          .addAssertion('to foo (|bar)', function(expect, subject) {
+          .addAssertion('<any> to foo (|bar)', function(expect, subject) {
             expect(subject, 'to equal', 'foo');
           });
         clonedExpect('foo', 'to foo');
@@ -281,7 +286,7 @@ describe('addAssertion', () => {
       it('must not contain brackets', () => {
         expect(
           function() {
-            expect.addAssertion('foo ([bar)', function() {});
+            expect.addAssertion('<any> foo ([bar)', function() {});
           },
           'to throw',
           "Assertion patterns must not contain alternations with brackets: 'foo ([bar)'"
@@ -289,7 +294,7 @@ describe('addAssertion', () => {
 
         expect(
           function() {
-            expect.addAssertion('foo (bar])', function() {});
+            expect.addAssertion('<any> foo (bar])', function() {});
           },
           'to throw',
           "Assertion patterns must not contain alternations with brackets: 'foo (bar])'"
@@ -299,7 +304,7 @@ describe('addAssertion', () => {
       it('must not contain parentheses', () => {
         expect(
           function() {
-            expect.addAssertion('foo ((bar)', function() {});
+            expect.addAssertion('<any> foo ((bar)', function() {});
           },
           'to throw',
           "Assertion patterns must not contain alternations with parentheses: 'foo ((bar)'"
@@ -307,7 +312,7 @@ describe('addAssertion', () => {
 
         expect(
           function() {
-            expect.addAssertion('foo ((bar))', function() {});
+            expect.addAssertion('<any> foo ((bar))', function() {});
           },
           'to throw',
           "Assertion patterns must not contain alternations with parentheses: 'foo ((bar))'"
@@ -399,7 +404,7 @@ describe('addAssertion', () => {
       beforeEach(() => {
         clonedExpect = expect
           .clone()
-          .addAssertion('[not] to be sorted', function(expect, subject) {
+          .addAssertion('<any> [not] to be sorted', function(expect, subject) {
             expect.errorMode = errorMode;
             expect(subject, 'to be an array');
             expect(subject, '[not] to equal', [].concat(subject).sort());
@@ -491,7 +496,7 @@ describe('addAssertion', () => {
       it('avoids repeating large subjects', () => {
         var clonedExpect = expect
           .clone()
-          .addAssertion('to foobarbaz', function(expect, subject) {
+          .addAssertion('<any> to foobarbaz', function(expect, subject) {
             expect.errorMode = 'nested';
             expect(subject, 'to satisfy', { foo: 123 });
           });
@@ -530,24 +535,22 @@ describe('addAssertion', () => {
       beforeEach(() => {
         clonedExpect = expect
           .clone()
-          .addAssertion('to be sorted after delay', function(
-            expect,
-            subject,
-            delay,
-            done
-          ) {
-            expect.errorMode = errorMode;
-            expect.argsOutput.pop(); // Don't let the function be inspected in case of failure
-            setTimeout(function() {
-              try {
-                expect(subject, 'to be an array');
-                expect(subject, 'to equal', [].concat(subject).sort());
-              } catch (e) {
-                done(e);
-              }
-            }, delay);
-          })
-          .addAssertion('to be sorted after a while', function(
+          .addAssertion(
+            '<any> to be sorted after delay <number> <function>',
+            function(expect, subject, delay, done) {
+              expect.errorMode = errorMode;
+              expect.argsOutput.pop(); // Don't let the function be inspected in case of failure
+              setTimeout(function() {
+                try {
+                  expect(subject, 'to be an array');
+                  expect(subject, 'to equal', [].concat(subject).sort());
+                } catch (e) {
+                  done(e);
+                }
+              }, delay);
+            }
+          )
+          .addAssertion('<any> to be sorted after a while <function>', function(
             expect,
             subject,
             done
@@ -645,11 +648,10 @@ describe('addAssertion', () => {
       beforeEach(() => {
         clonedExpect = expect
           .clone()
-          .addAssertion('to be sorted after delay', function(
+          .addAssertion('<any> to be sorted after delay <number>', function(
             expect,
             subject,
-            delay,
-            done
+            delay
           ) {
             expect.errorMode = errorMode;
             return expect.promise(function(run) {
@@ -740,7 +742,7 @@ describe('addAssertion', () => {
       it('serializes the error with the error mode that was in effect at the time of its creation', () => {
         var clonedExpect = expect
           .clone()
-          .addAssertion('to be equal to foo', function(expect, subject) {
+          .addAssertion('<any> to be equal to foo', function(expect, subject) {
             expect.errorMode = 'nested';
             try {
               expect(subject, 'to equal', 'foo');
@@ -768,7 +770,10 @@ describe('addAssertion', () => {
   it('nested expects throws if the assertion does not exists', () => {
     var clonedExpect = expect
       .clone()
-      .addAssertion('to be foo', function theCustomAssertion(expect, subject) {
+      .addAssertion('<any> to be foo', function theCustomAssertion(
+        expect,
+        subject
+      ) {
         expect(subject, 'to bee', 'foo');
       });
     expect(
@@ -832,7 +837,7 @@ describe('addAssertion', () => {
 
   it('makes expect.it available inside a custom assertion', () => {
     var clonedExpect = expect.clone();
-    clonedExpect.addAssertion('to foo', function(expect, subject) {
+    clonedExpect.addAssertion('<any> to foo', function(expect, subject) {
       expect.it('to equal', 'foo')(subject);
     });
     clonedExpect('foo', 'to foo');

--- a/test/api/exportAssertion.spec.js
+++ b/test/api/exportAssertion.spec.js
@@ -9,8 +9,8 @@ describe('exportAssertion', () => {
 
   it('is chainable', () => {
     childExpect
-      .exportAssertion('foo', function() {})
-      .exportAssertion('bar', function() {});
+      .exportAssertion('<any> foo', function() {})
+      .exportAssertion('<any> bar', function() {});
 
     expect(parentExpect.assertions, 'to have keys', 'foo', 'bar');
   });

--- a/test/api/it.spec.js
+++ b/test/api/it.spec.js
@@ -33,7 +33,7 @@ describe('expect.it', () => {
   it('does not catch errors that are not thrown by unexpected', () => {
     var clonedExpect = expect
       .clone()
-      .addAssertion('explode', function(expect, subject) {
+      .addAssertion('<any> explode', function(expect, subject) {
         throw new Error('Explosion');
       });
 
@@ -160,7 +160,7 @@ describe('expect.it', () => {
   describe('with async assertions', () => {
     var clonedExpect = expect
       .clone()
-      .addAssertion('to be a number after a short delay', function(
+      .addAssertion('<any> to be a number after a short delay', function(
         expect,
         subject
       ) {
@@ -175,7 +175,7 @@ describe('expect.it', () => {
           );
         });
       })
-      .addAssertion('to be finite after a short delay', function(
+      .addAssertion('<any> to be finite after a short delay', function(
         expect,
         subject
       ) {
@@ -190,7 +190,7 @@ describe('expect.it', () => {
           );
         });
       })
-      .addAssertion('to be a string after a short delay', function(
+      .addAssertion('<any> to be a string after a short delay', function(
         expect,
         subject
       ) {

--- a/test/api/promise.spec.js
+++ b/test/api/promise.spec.js
@@ -3,7 +3,7 @@ describe('expect.promise', () => {
   it('should forward non-unexpected errors', () => {
     var clonedExpect = expect
       .clone()
-      .addAssertion('to foo', function(expect, subject, value) {
+      .addAssertion('<any> to foo', function(expect, subject) {
         return expect.withError(
           function() {
             return expect.promise(function() {
@@ -34,7 +34,7 @@ describe('expect.promise', () => {
   it('should return the fulfilled promise even if it is oathbreakable', () => {
     var clonedExpect = expect
       .clone()
-      .addAssertion('to foo', function(expect, subject, value) {
+      .addAssertion('<any> to foo', function(expect, subject) {
         return expect.promise(function() {
           expect(subject, 'to equal', 'foo');
           return 'bar';
@@ -46,7 +46,7 @@ describe('expect.promise', () => {
   it('should preserve the resolved value when an assertion contains a non-oathbreakable promise', function(done) {
     var clonedExpect = expect
       .clone()
-      .addAssertion('to foo', function(expect, subject, value) {
+      .addAssertion('<any> to foo', function(expect, subject) {
         return expect.promise(function(resolve, reject) {
           expect(subject, 'to equal', 'foo');
           setTimeout(function() {
@@ -63,7 +63,7 @@ describe('expect.promise', () => {
   it('should return a promise fulfilled with the return value when an assertion returns a non-promise value', () => {
     var clonedExpect = expect
       .clone()
-      .addAssertion('to foo', function(expect, subject, value) {
+      .addAssertion('<any> to foo', function(expect, subject) {
         expect(subject, 'to equal', 'foo');
         return 'bar';
       });
@@ -216,10 +216,10 @@ describe('expect.promise', () => {
       it('should mount the and method on a promise returned from a nested assertion', () => {
         var clonedExpect = expect
           .clone()
-          .addAssertion('to foo', function(expect, subject) {
+          .addAssertion('<any> to foo', function(expect, subject) {
             return expect(subject, 'to bar').and('to equal', 'foo');
           })
-          .addAssertion('to bar', function(expect, subject) {
+          .addAssertion('<any> to bar', function(expect, subject) {
             return expect.promise(function(run) {
               setTimeout(
                 run(function() {

--- a/test/api/shift.spec.js
+++ b/test/api/shift.spec.js
@@ -320,7 +320,7 @@ describe('expect.shift', () => {
     it('should allow a subsequent .and()', () => {
       var clonedExpect = expect
         .clone()
-        .addAssertion('promisified', function(expect, subject) {
+        .addAssertion('<any> promisified', function(expect, subject) {
           return expect.shift(new Promise(subject));
         });
       return clonedExpect(resolve => {
@@ -333,7 +333,7 @@ describe('expect.shift', () => {
     it('should allow a subsequent .and() within a nested context', () => {
       var clonedExpect = expect
         .clone()
-        .addAssertion('promisified', function(expect, subject) {
+        .addAssertion('<any> promisified', function(expect, subject) {
           return expect.shift(new Promise(subject));
         })
         .addAssertion('<function> executed inside an assertion', function(

--- a/test/assertionParser.spec.js
+++ b/test/assertionParser.spec.js
@@ -73,15 +73,40 @@ describe('parseAssertion', () => {
     ]);
   });
 
-  it('accepts legacy assertions', () => {
-    var assertion = expect.parseAssertion('[not] to be');
-    expect(assertion, 'to satisfy', [
-      {
-        subject: { type: { name: 'any' }, minimum: 1, maximum: 1 },
-        assertion: '[not] to be',
-        args: [{ type: { name: 'any' }, minimum: 0, maximum: Infinity }]
-      }
-    ]);
+  describe('when the legacy typeless assertion syntax is used', () => {
+    // Poor man's sinon.stub:
+    const originalConsoleWarn = console.warn;
+    const consoleWarnCalls = [];
+    beforeEach(function() {
+      console.warn = (...args) => consoleWarnCalls.push(args);
+    });
+    afterEach(function() {
+      console.warn = originalConsoleWarn;
+    });
+
+    it('assumes <any> ... <any+>', () => {
+      const assertion = expect.parseAssertion('[not] to be');
+      expect(assertion, 'to satisfy', [
+        {
+          subject: { type: { name: 'any' }, minimum: 1, maximum: 1 },
+          assertion: '[not] to be',
+          args: [{ type: { name: 'any' }, minimum: 0, maximum: Infinity }]
+        }
+      ]);
+    });
+
+    it('outputs a warning the first time', () => {
+      expect.parseAssertion('[not] to be');
+      expect(consoleWarnCalls, 'to satisfy', [
+        [
+          'The typeless expect.addAssertion syntax is deprecated and will be removed in a future update\n' +
+            'Please refer to http://unexpected.js.org/api/addAssertion/'
+        ]
+      ]);
+
+      expect.parseAssertion('[not] to be');
+      expect(consoleWarnCalls, 'to have length', 1);
+    });
   });
 
   it('accepts assertions with no arguments', () => {

--- a/test/assertions/to-have-a-value-satisfying.spec.js
+++ b/test/assertions/to-have-a-value-satisfying.spec.js
@@ -159,10 +159,9 @@ describe('to have a value satisfying assertion', () => {
   describe('delegating to an async assertion', () => {
     var clonedExpect = expect
       .clone()
-      .addAssertion('to be a number after a short delay', function(
+      .addAssertion('<any> to be a number after a short delay', function(
         expect,
-        subject,
-        delay
+        subject
       ) {
         expect.errorMode = 'nested';
 

--- a/test/assertions/to-have-an-item-satisfying.spec.js
+++ b/test/assertions/to-have-an-item-satisfying.spec.js
@@ -171,10 +171,9 @@ describe('to have an item satisfying assertion', () => {
   describe('delegating to an async assertion', () => {
     var clonedExpect = expect
       .clone()
-      .addAssertion('to be a number after a short delay', function(
+      .addAssertion('<any> to be a number after a short delay', function(
         expect,
-        subject,
-        delay
+        subject
       ) {
         expect.errorMode = 'nested';
 

--- a/test/assertions/to-have-items-satisfying.spec.js
+++ b/test/assertions/to-have-items-satisfying.spec.js
@@ -252,10 +252,9 @@ describe('to have items satisfying assertion', () => {
   describe('delegating to an async assertion', () => {
     var clonedExpect = expect
       .clone()
-      .addAssertion('to be a number after a short delay', function(
+      .addAssertion('<any> to be a number after a short delay', function(
         expect,
-        subject,
-        delay
+        subject
       ) {
         expect.errorMode = 'nested';
 

--- a/test/assertions/to-have-keys-satisfying.spec.js
+++ b/test/assertions/to-have-keys-satisfying.spec.js
@@ -196,22 +196,21 @@ describe('to have keys satisfying assertion', () => {
   describe('delegating to an async assertion', () => {
     var clonedExpect = expect
       .clone()
-      .addAssertion('to be a sequence of as after a short delay', function(
-        expect,
-        subject,
-        delay
-      ) {
-        expect.errorMode = 'nested';
+      .addAssertion(
+        '<any> to be a sequence of as after a short delay',
+        function(expect, subject) {
+          expect.errorMode = 'nested';
 
-        return expect.promise(function(run) {
-          setTimeout(
-            run(function() {
-              expect(subject, 'to match', /^a+$/);
-            }),
-            1
-          );
-        });
-      });
+          return expect.promise(function(run) {
+            setTimeout(
+              run(function() {
+                expect(subject, 'to match', /^a+$/);
+              }),
+              1
+            );
+          });
+        }
+      );
 
     it('should succeed', () => {
       return clonedExpect(

--- a/test/assertions/to-have-values-satisfying.spec.js
+++ b/test/assertions/to-have-values-satisfying.spec.js
@@ -228,10 +228,9 @@ describe('to have values satisfying assertion', () => {
   describe('delegating to an async assertion', () => {
     var clonedExpect = expect
       .clone()
-      .addAssertion('to be a number after a short delay', function(
+      .addAssertion('<any> to be a number after a short delay', function(
         expect,
-        subject,
-        delay
+        subject
       ) {
         expect.errorMode = 'nested';
 

--- a/test/assertions/to-satisfy.spec.js
+++ b/test/assertions/to-satisfy.spec.js
@@ -625,7 +625,7 @@ describe('to satisfy assertion', () => {
   it('forwards normal errors found in promise aggregate errors to the top level', () => {
     var clonedExpect = expect
       .clone()
-      .addAssertion('to foo', function(expect, subject) {
+      .addAssertion('<any> to foo', function(expect, subject) {
         var promises = [
           clonedExpect.promise(function() {
             clonedExpect('foo', 'to equal', 'bar');
@@ -2287,7 +2287,7 @@ describe('to satisfy assertion', () => {
   describe('when delegating to async assertions', () => {
     var clonedExpect = expect
       .clone()
-      .addAssertion('to be a number after a short delay', function(
+      .addAssertion('<any> to be a number after a short delay', function(
         expect,
         subject
       ) {

--- a/test/unexpected.spec.js
+++ b/test/unexpected.spec.js
@@ -91,7 +91,7 @@ describe('unexpected', () => {
       it('fails when given no parameters', () => {
         var clonedExpect = expect
           .clone()
-          .addAssertion('to foo', function(expect) {
+          .addAssertion('<any> to foo', function(expect) {
             expect();
           });
         expect(
@@ -106,7 +106,7 @@ describe('unexpected', () => {
       it('fails when the second parameter is not a string', () => {
         var clonedExpect = expect
           .clone()
-          .addAssertion('to foo', function(expect) {
+          .addAssertion('<any> to foo', function(expect) {
             expect({}, {});
           });
         expect(
@@ -153,10 +153,10 @@ describe('unexpected', () => {
     it('should catch non-Unexpected error caught from a nested assertion', () => {
       var clonedExpect = expect
         .clone()
-        .addAssertion('to foo', function(expect, subject) {
+        .addAssertion('<any> to foo', function(expect, subject) {
           return expect(subject, 'to bar');
         })
-        .addAssertion('to bar', function(expect, subject) {
+        .addAssertion('<any> to bar', function(expect, subject) {
           return expect.promise(function(run) {
             setTimeout(
               run(function() {
@@ -951,7 +951,7 @@ describe('unexpected', () => {
     it('should render the error message sanely in an annotation block inside a satisfy diff', () => {
       var clonedExpect = expect
         .clone()
-        .addAssertion('foobar', function(expect, subject) {
+        .addAssertion('<any> foobar', function(expect, subject) {
           expect(subject, 'to equal', 'foobar');
         });
       expect(


### PR DESCRIPTION
Fixes #339

I think we should get this in now, as it will make `addAssertion` less confusing per the linked issue. Then we can remove the support in Unexpected 12 or 13.