### PR TITLE
to throw an: fulfill the promise with the error

### DIFF
--- a/documentation/assertions/function/to-throw-a.md
+++ b/documentation/assertions/function/to-throw-a.md
@@ -36,6 +36,17 @@ expected function willNotThrow() {} to throw a RangeError
     did not throw
 ```
 
+The thrown error is provided as the fulfillment value of
+the returned promise, so you can do further assertions like this:
+
+<!-- unexpected-markdown async:true -->
+
+```js
+return expect(willThrow, 'to throw a', SyntaxError).then(function(err) {
+  expect(err, 'to have message', /\bmessage/);
+});
+```
+
 To test functions that require input wrap the function invocation in an anonymous function:
 
 ```js

--- a/documentation/assertions/function/to-throw.md
+++ b/documentation/assertions/function/to-throw.md
@@ -166,6 +166,17 @@ not to throw
   threw: Error('threw anyway')
 ```
 
+The thrown error is provided as the fulfillment value of
+the returned promise, so you can do further assertions like this:
+
+<!-- unexpected-markdown async:true -->
+
+```js
+return expect(somethingThatThrows, 'to throw').then(function(err) {
+  expect(err, 'to have message', /\bmessage/);
+});
+```
+
 To test functions that require input wrap the function invocation in an anonymous function:
 
 ```js

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1037,7 +1037,7 @@ module.exports = expect => {
         };
       }
       expect.errorMode = 'nested';
-      return expect(subject, 'to throw').then(error => {
+      return expect(subject, 'to throw').tap(error => {
         expect(error, 'to be a', value);
       });
     }

--- a/test/assertions/to-throw-a.spec.js
+++ b/test/assertions/to-throw-a.spec.js
@@ -40,6 +40,17 @@ describe('to throw a/an assertion', () => {
     );
   });
 
+  it('fulfills its promise with the error that was thrown', () => {
+    const err = new SyntaxError('foo');
+    expect(
+      function() {
+        throw err;
+      },
+      'to throw a',
+      SyntaxError
+    ).then(fulfilmentValue => expect(fulfilmentValue, 'to be', err));
+  });
+
   it('fails if the function throws an instance of a different constructor', () => {
     expect(
       function() {


### PR DESCRIPTION
See #594