### PR TITLE
exportStyle: Pass on the allowRedefinition parameter to the parent's addStyle

### DIFF
--- a/lib/createTopLevelExpect.js
+++ b/lib/createTopLevelExpect.js
@@ -1593,11 +1593,15 @@ expectPrototype.child = function() {
     parent.addType(type, childExpect);
     return this;
   };
-  childExpect.exportStyle = function(name, handler) {
-    parent.addStyle(name, function(...args) {
-      const childOutput = childExpect.createOutput(this.format);
-      this.append(handler.call(childOutput, ...args) || childOutput);
-    });
+  childExpect.exportStyle = function(name, handler, allowRedefinition) {
+    parent.addStyle(
+      name,
+      function(...args) {
+        const childOutput = childExpect.createOutput(this.format);
+        this.append(handler.call(childOutput, ...args) || childOutput);
+      },
+      allowRedefinition
+    );
     return this;
   };
   return childExpect;

--- a/test/api/exportStyle.spec.js
+++ b/test/api/exportStyle.spec.js
@@ -64,4 +64,30 @@ describe('styleType', () => {
       '>>yadda<<'
     );
   });
+
+  it('passes on the allowRedefinition parameter', function() {
+    parentExpect.addStyle('fancyQuotes', function(text) {
+      this.text('"')
+        .text(text)
+        .text('"');
+    });
+    childExpect.exportStyle(
+      'fancyQuotes',
+      function(text) {
+        this.text('>>')
+          .text(text)
+          .text('<<');
+      },
+      true
+    );
+
+    expect(
+      parentExpect
+        .createOutput()
+        .fancyQuotes('yadda')
+        .toString(),
+      'to equal',
+      '>>yadda<<'
+    );
+  });
 });


### PR DESCRIPTION
Previously you'd get this error when trying to export a style from a child expect that collides with one that's already defined in the parent:

```
Error: "fancyQuotes" style is already defined, set 3rd arg (allowRedefinition) to true to define it anyway
```

But the advice didn't work because `exportStyle` did not pass it on.