### PR TITLE
WIP: unified diff

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -310,26 +310,29 @@ module.exports = expect => {
     ch,
     line,
     baseStyle,
-    markUpSpecialCharacters
+    markUpSpecialCharacters,
+    outputOpts = {}
   ) {
+    const { forceHighlight } = outputOpts;
+    const isChangedNewline = line === '' && ch !== ' ';
+
     this.alt({
-      text: ch,
+      text() {
+        if (forceHighlight) {
+          this[ch === '+' ? 'diffAddedLine' : 'diffRemovedLine']('\\n');
+        }
+        if (!forceHighlight) {
+          this.raw(ch);
+        }
+      },
       fallback() {
-        if (line === '' && ch !== ' ') {
+        if (isChangedNewline) {
           this[ch === '+' ? 'diffAddedSpecialChar' : 'diffRemovedSpecialChar'](
             '\\n'
           );
         }
       }
     });
-
-    let matchTrailingSpace = null;
-    if (ch === '+' || ch === '-') {
-      matchTrailingSpace = line.match(/^(.*[^ ])?( +)$/);
-      if (matchTrailingSpace) {
-        line = matchTrailingSpace[1] || '';
-      }
-    }
 
     let outputStyle = this[baseStyle]
       ? baseStyle
@@ -352,31 +355,40 @@ module.exports = expect => {
         this[outputStyle](line);
       }
     }
-
-    if (matchTrailingSpace) {
-      outputStyle = ch === '+' ? 'diffAddedHighlight' : 'diffRemovedHighlight';
-      outputStyle = this[outputStyle]
-        ? outputStyle
-        : stringDiffFallbacks[outputStyle];
-
-      this[outputStyle](matchTrailingSpace[2]);
-    }
-
-    if (line.length === 0) {
-      this.nl();
-    }
   });
 
   expect.addStyle('stringDiff', function(actual, expected, options = {}) {
     const changes = stringDiff.diffLines(actual, expected);
 
     let sawFirst = false;
+    let sawNewline = false;
 
-    unifiedDiff(changes, (ch, value) => {
-      if (sawFirst) {
-        this.nl();
-      } else {
+    const drawNewline = () => {
+      sawNewline = true;
+      this.nl();
+    };
+
+    unifiedDiff(changes, (ch, value, outputOpts = {}) => {
+      const { leadingNewline = true, trailingNewline = true } = outputOpts;
+
+      if (!sawFirst) {
         sawFirst = true;
+      } else if (leadingNewline) {
+        drawNewline();
+      }
+
+      let matchTrailingSpace = null;
+      if (ch === '+' || ch === '-') {
+        matchTrailingSpace = value.match(/^(.*[^ ])?( +)$/);
+        if (matchTrailingSpace) {
+          this.stringDiffFragment(
+            ch,
+            matchTrailingSpace[2],
+            ch === '+' ? 'diffAddedHighlight' : 'diffRemovedHighlight',
+            options.markUpSpecialCharacters
+          );
+          return;
+        }
       }
 
       if (ch === '+') {
@@ -384,35 +396,47 @@ module.exports = expect => {
           '+',
           value,
           'diffAddedLine',
-          options.markUpSpecialCharacters
+          options.markUpSpecialCharacters,
+          outputOpts
         );
       } else if (ch === '>') {
         this.stringDiffFragment(
           '+',
           value,
           'diffAddedHighlight',
-          options.markUpSpecialCharacters
+          options.markUpSpecialCharacters,
+          outputOpts
         );
       } else if (ch === '-') {
         this.stringDiffFragment(
           '-',
           value,
           'diffRemovedLine',
-          options.markUpSpecialCharacters
+          options.markUpSpecialCharacters,
+          outputOpts
         );
       } else if (ch === '<') {
         this.stringDiffFragment(
           '-',
           value,
           'diffRemovedHighlight',
-          options.markUpSpecialCharacters
+          options.markUpSpecialCharacters,
+          outputOpts
         );
       } else if (ch === '~') {
         this.jsComment('...');
       } else {
         this.stringDiffFragment(' ', value, 'text');
       }
+
+      if (ch !== '~' && value.length === 0 && trailingNewline) {
+        drawNewline();
+      }
     });
+
+    if (!sawNewline) {
+      this.nl();
+    }
   });
 
   expect.addStyle('arrow', function(options = {}) {

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -1,4 +1,5 @@
 const utils = require('./utils');
+const unifiedDiff = require('./unifiedDiff');
 const stringDiff = require('diff');
 const specialCharRegExp = require('./specialCharRegExp');
 
@@ -300,153 +301,118 @@ module.exports = expect => {
     });
   });
 
+  const stringDiffFallbacks = {
+    diffAddedHighlight: 'diffAddedLine',
+    diffRemovedHighlight: 'diffRemovedLine'
+  };
+
   expect.addStyle('stringDiffFragment', function(
     ch,
-    text,
+    line,
     baseStyle,
     markUpSpecialCharacters
   ) {
-    text.split(/\n/).forEach(function(line, i, { length }) {
-      if (this.isAtStartOfLine()) {
-        this.alt({
-          text: ch,
-          fallback() {
-            if (line === '' && ch !== ' ' && (i === 0 || i !== length - 1)) {
-              this[
-                ch === '+' ? 'diffAddedSpecialChar' : 'diffRemovedSpecialChar'
-              ]('\\n');
-            }
-          }
-        });
+    this.alt({
+      text: ch,
+      fallback() {
+        if (line === '' && ch !== ' ') {
+          this[ch === '+' ? 'diffAddedSpecialChar' : 'diffRemovedSpecialChar'](
+            '\\n'
+          );
+        }
       }
-      const matchTrailingSpace = line.match(/^(.*[^ ])?( +)$/);
+    });
+
+    let matchTrailingSpace = null;
+    if (ch === '+' || ch === '-') {
+      matchTrailingSpace = line.match(/^(.*[^ ])?( +)$/);
       if (matchTrailingSpace) {
         line = matchTrailingSpace[1] || '';
       }
+    }
 
+    let outputStyle = this[baseStyle]
+      ? baseStyle
+      : stringDiffFallbacks[baseStyle];
+
+    if (line.length > 0) {
       if (markUpSpecialCharacters) {
-        line.split(specialCharRegExp).forEach(function(part) {
+        line.split(specialCharRegExp).forEach(part => {
           if (specialCharRegExp.test(part)) {
             this[
               { '+': 'diffAddedSpecialChar', '-': 'diffRemovedSpecialChar' }[
                 ch
-              ] || baseStyle
+              ] || outputStyle
             ](utils.escapeChar(part));
           } else {
-            this[baseStyle](part);
+            this[outputStyle](part);
           }
-        }, this);
+        });
       } else {
-        this[baseStyle](line);
+        this[outputStyle](line);
       }
-      if (matchTrailingSpace) {
-        this[
-          { '+': 'diffAddedHighlight', '-': 'diffRemovedHighlight' }[ch] ||
-            baseStyle
-        ](matchTrailingSpace[2]);
-      }
-      if (i !== length - 1) {
-        this.nl();
-      }
-    }, this);
+    }
+
+    if (matchTrailingSpace) {
+      outputStyle = ch === '+' ? 'diffAddedHighlight' : 'diffRemovedHighlight';
+      outputStyle = this[outputStyle]
+        ? outputStyle
+        : stringDiffFallbacks[outputStyle];
+
+      this[outputStyle](matchTrailingSpace[2]);
+    }
+
+    if (line.length === 0) {
+      this.nl();
+    }
   });
 
   expect.addStyle('stringDiff', function(actual, expected, options = {}) {
-    const type = options.type || 'WordsWithSpace';
-    const diffLines = [];
-    let lastPart;
-    stringDiff.diffLines(actual, expected).forEach(part => {
-      if (lastPart && lastPart.removed && part.added) {
-        diffLines.push({
-          oldValue: lastPart.value,
-          newValue: part.value,
-          replaced: true
-        });
-        lastPart = null;
+    const changes = stringDiff.diffLines(actual, expected);
+
+    let sawFirst = false;
+
+    unifiedDiff(changes, (ch, value) => {
+      if (sawFirst) {
+        this.nl();
       } else {
-        if (lastPart) {
-          diffLines.push(lastPart);
-        }
-        lastPart = part;
+        sawFirst = true;
+      }
+
+      if (ch === '+') {
+        this.stringDiffFragment(
+          '+',
+          value,
+          'diffAddedLine',
+          options.markUpSpecialCharacters
+        );
+      } else if (ch === '>') {
+        this.stringDiffFragment(
+          '+',
+          value,
+          'diffAddedHighlight',
+          options.markUpSpecialCharacters
+        );
+      } else if (ch === '-') {
+        this.stringDiffFragment(
+          '-',
+          value,
+          'diffRemovedLine',
+          options.markUpSpecialCharacters
+        );
+      } else if (ch === '<') {
+        this.stringDiffFragment(
+          '-',
+          value,
+          'diffRemovedHighlight',
+          options.markUpSpecialCharacters
+        );
+      } else if (ch === '~') {
+        this.jsComment('...');
+      } else {
+        this.stringDiffFragment(' ', value, 'text');
       }
     });
-    if (lastPart) {
-      diffLines.push(lastPart);
-    }
-
-    diffLines.forEach(function(part, index) {
-      if (part.replaced) {
-        let oldValue = part.oldValue;
-        let newValue = part.newValue;
-        const newLine = this.clone();
-        const oldEndsWithNewline = oldValue.slice(-1) === '\n';
-        const newEndsWithNewline = newValue.slice(-1) === '\n';
-        if (oldEndsWithNewline) {
-          oldValue = oldValue.slice(0, -1);
-        }
-        if (newEndsWithNewline) {
-          newValue = newValue.slice(0, -1);
-        }
-        stringDiff[`diff${type}`](oldValue, newValue).forEach(function({
-          added,
-          value,
-          removed
-        }) {
-          if (added) {
-            newLine.stringDiffFragment(
-              '+',
-              value,
-              'diffAddedHighlight',
-              options.markUpSpecialCharacters
-            );
-          } else if (removed) {
-            this.stringDiffFragment(
-              '-',
-              value,
-              'diffRemovedHighlight',
-              options.markUpSpecialCharacters
-            );
-          } else {
-            newLine.stringDiffFragment('+', value, 'diffAddedLine');
-            this.stringDiffFragment('-', value, 'diffRemovedLine');
-          }
-        },
-        this);
-        if (newEndsWithNewline && !oldEndsWithNewline) {
-          newLine.diffAddedSpecialChar('\\n');
-        }
-
-        if (oldEndsWithNewline && !newEndsWithNewline) {
-          this.diffRemovedSpecialChar('\\n');
-        }
-        this.nl()
-          .append(newLine)
-          .nl(oldEndsWithNewline && index < diffLines.length - 1 ? 1 : 0);
-      } else {
-        const endsWithNewline = /\n$/.test(part.value);
-        const value = endsWithNewline ? part.value.slice(0, -1) : part.value;
-        if (part.added) {
-          this.stringDiffFragment(
-            '+',
-            value,
-            'diffAddedLine',
-            options.markUpSpecialCharacters
-          );
-        } else if (part.removed) {
-          this.stringDiffFragment(
-            '-',
-            value,
-            'diffRemovedLine',
-            options.markUpSpecialCharacters
-          );
-        } else {
-          this.stringDiffFragment(' ', value, 'text');
-        }
-        if (endsWithNewline) {
-          this.nl();
-        }
-      }
-    }, this);
   });
 
   expect.addStyle('arrow', function(options = {}) {

--- a/lib/styles.js
+++ b/lib/styles.js
@@ -357,8 +357,23 @@ module.exports = expect => {
     }
   });
 
+  expect.addStyle('regexDiff', function(actual, expected) {
+    const changes = stringDiff.diffChars(actual, expected);
+
+    this.unifiedDiff(changes, {
+      disableLeadingNewlines: true,
+      markUpSpecialCharacters: true
+    });
+  });
+
   expect.addStyle('stringDiff', function(actual, expected, options = {}) {
     const changes = stringDiff.diffLines(actual, expected);
+
+    this.unifiedDiff(changes, options);
+  });
+
+  expect.addStyle('unifiedDiff', function(changes, options = {}) {
+    const { disableLeadingNewlines = false } = options;
 
     let sawFirst = false;
     let sawNewline = false;
@@ -373,7 +388,7 @@ module.exports = expect => {
 
       if (!sawFirst) {
         sawFirst = true;
-      } else if (leadingNewline) {
+      } else if (leadingNewline && !disableLeadingNewlines) {
         drawNewline();
       }
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -1137,10 +1137,7 @@ module.exports = function(expect) {
     },
     diff(actual, expected, output, diff, inspect) {
       output.inline = false;
-      return output.stringDiff(String(actual), String(expected), {
-        type: 'Chars',
-        markUpSpecialCharacters: true
-      });
+      return output.regexDiff(String(actual), String(expected));
     }
   });
 

--- a/lib/unifiedDiff.js
+++ b/lib/unifiedDiff.js
@@ -24,7 +24,8 @@ function allChangeLines(change) {
   return lastChangeLines(change, change.count);
 }
 
-function firstChangeLines(change, includeCount) {
+function firstChangeLines(change, maxLines) {
+  let includeCount = Math.min(maxLines, change.count);
   let value = change.value;
 
   if (value[value.length - 1] !== '\n') {
@@ -52,7 +53,8 @@ function firstChangeLines(change, includeCount) {
   return lines;
 }
 
-function lastChangeLines(change, includeCount) {
+function lastChangeLines(change, maxLines) {
+  let includeCount = Math.min(maxLines, change.count);
   let value = change.value;
 
   if (value[value.length - 1] !== '\n') {
@@ -110,9 +112,7 @@ module.exports = function(changes, outputter) {
 
     if (changeType === CHANGE_NONE && !hunkOpen) {
       // HUNK START
-      const includeCount = Math.min(contextLines, change.count);
-
-      lastChangeLines(change, includeCount).forEach(line => {
+      lastChangeLines(change, contextLines).forEach(line => {
         // place the relevant lines into the ring buffer
         contextualRingIndex = (contextualRingIndex + 1) % contextLines;
         contextualRingBuffer[contextualRingIndex] = [CHANGE_NONE, line];
@@ -129,9 +129,7 @@ module.exports = function(changes, outputter) {
 
     if (changeType === CHANGE_NONE && hunkOpen) {
       // HUNK END
-      const includeCount = Math.min(contextLines, change.count);
-
-      firstChangeLines(change, includeCount).forEach(line => {
+      firstChangeLines(change, contextLines).forEach(line => {
         outputter([CHANGE_NONE, line]);
       });
 

--- a/lib/unifiedDiff.js
+++ b/lib/unifiedDiff.js
@@ -21,7 +21,7 @@ function changeToType(change) {
 }
 
 function allChangeLines(change) {
-  return lastChangeLines(change, change.count);
+  return lastChangeLines(change, Infinity);
 }
 
 function firstChangeLines(change, maxLines) {
@@ -82,15 +82,28 @@ function lastChangeLines(change, maxLines) {
   return lines.reverse();
 }
 
+function lastChar(str) {
+  return str ? str[str.length - 1] : '';
+}
+
 function markupReplacementsInDiff(changes) {
-  let lastPart;
+  let lastPart = {};
+
   changes.forEach((part, partIndex) => {
-    if (lastPart && lastPart.removed && part.added) {
-      lastPart.replaced = true;
-      part.replaced = true;
+    if (!(lastPart.removed && part.added)) {
+      lastPart = part;
+      return;
     }
 
-    lastPart = changes[partIndex];
+    lastPart.replaced = true;
+    part.replaced = true;
+
+    if (lastChar(lastPart.value) === '\n' && lastChar(part.value) === '\n') {
+      lastPart.value = lastPart.value.slice(0, -1);
+      part.value = part.value.slice(0, -1);
+    }
+
+    lastPart = part;
   });
 
   return changes;
@@ -193,12 +206,24 @@ module.exports = function(changes, outputter) {
         }
       }
 
-      allChangeLines(change).forEach((line, index) => {
+      const hasTrailingNewline = lastChar(change.value) === '\n';
+      const lines = allChangeLines(change);
+      lines.forEach((line, lineIndex) => {
         const outputChangeType = change.replaced
           ? changeTypeToHighlight[changeType]
           : changeType;
 
         outputter(outputChangeType, line);
+
+        if (
+          changeType !== '=' &&
+          line !== '' &&
+          hasTrailingNewline &&
+          (changeIndex === changes.length - 1 || change.replaced) &&
+          lineIndex === lines.length - 1
+        ) {
+          outputter(outputChangeType, '');
+        }
       });
     }
   });

--- a/lib/unifiedDiff.js
+++ b/lib/unifiedDiff.js
@@ -173,7 +173,18 @@ module.exports = function(changes, outputter) {
         }
       }
 
-      const hasTrailingNewline = lastChar(change.value) === '\n';
+      const matchTrailingNewlines = change.value.match(/[\n]+$/);
+      const countTrailingNewlines = matchTrailingNewlines
+        ? matchTrailingNewlines[0].length
+        : 0;
+      if (countTrailingNewlines > 0) {
+        change.value = change.value.slice(0, -countTrailingNewlines);
+      }
+      if (change.value === '') {
+        outputter(changeType, '', { trailingNewline: false });
+        return;
+      }
+
       const lines = allChangeLines(change);
       lines.forEach((line, lineIndex) => {
         const outputChangeType = change.replaced
@@ -185,11 +196,15 @@ module.exports = function(changes, outputter) {
         if (
           changeType !== '=' &&
           line !== '' &&
-          hasTrailingNewline &&
+          countTrailingNewlines > 0 &&
           (changeIndex === changes.length - 1 || change.replaced) &&
           lineIndex === lines.length - 1
         ) {
-          outputter(outputChangeType, '');
+          outputter(outputChangeType, '', {
+            forceHighlight: true,
+            leadingNewline: false,
+            trailingNewline: false
+          });
         }
       });
     }

--- a/lib/unifiedDiff.js
+++ b/lib/unifiedDiff.js
@@ -102,6 +102,11 @@ module.exports = function(changes, outputter) {
   const contextualRingBuffer = new Array(contextLines);
   let contextualRingIndex = -1;
   let contextualRingInserted = 0;
+  function contextualRingInsert(line) {
+    contextualRingIndex = (contextualRingIndex + 1) % contextLines;
+    contextualRingBuffer[contextualRingIndex] = line;
+    contextualRingInserted += 1;
+  }
 
   changes = markupReplacementsInDiff(changes);
 
@@ -113,10 +118,7 @@ module.exports = function(changes, outputter) {
     if (changeType === CHANGE_NONE && !hunkOpen) {
       // HUNK START
       lastChangeLines(change, contextLines).forEach(line => {
-        // place the relevant lines into the ring buffer
-        contextualRingIndex = (contextualRingIndex + 1) % contextLines;
-        contextualRingBuffer[contextualRingIndex] = [CHANGE_NONE, line];
-        contextualRingInserted += 1;
+        contextualRingInsert([CHANGE_NONE, line]);
       });
 
       // If this is the first change the diff starts with leading unchanged
@@ -134,6 +136,17 @@ module.exports = function(changes, outputter) {
       });
 
       hunkOpen = false;
+
+      if (change.count > contextLines) {
+        // make the unique bit of the change count towards context
+        lastChangeLines(change, contextLines).forEach(line => {
+          contextualRingInsert([CHANGE_NONE, line]);
+        });
+      } else {
+        // empty the ring buffer to avoid duplicated context
+        contextualRingIndex = -1;
+        contextualRingInserted = 0;
+      }
 
       // If this is the last change the diff ends with trailing unchanged
       // lines - if those exceed the context length, ensure the output will

--- a/lib/unifiedDiff.js
+++ b/lib/unifiedDiff.js
@@ -105,7 +105,7 @@ module.exports = function(changes, outputter) {
 
   let hunkCount = 0;
   let hunkOpen = false;
-  changes.forEach(change => {
+  changes.forEach((change, changeIndex) => {
     const changeType = changeToType(change);
 
     if (changeType === CHANGE_NONE && !hunkOpen) {
@@ -129,6 +129,13 @@ module.exports = function(changes, outputter) {
       });
 
       hunkOpen = false;
+
+      // If this is the last change the diff ends with trailing unchanged
+      // lines - if those exceed the context length, ensure the output will
+      // relfect that more lines will be skipped.
+      if (changeIndex === changes.length - 1 && change.count > contextLines) {
+        outputter([CHANGE_MARKER]);
+      }
     }
 
     if (changeType === CHANGE_ADDED || changeType === CHANGE_REMOVED) {

--- a/lib/unifiedDiff.js
+++ b/lib/unifiedDiff.js
@@ -25,61 +25,28 @@ function allChangeLines(change) {
 }
 
 function firstChangeLines(change, maxLines) {
-  let includeCount = Math.min(maxLines, change.count);
-  let value = change.value;
+  const includeCount = Math.min(maxLines, change.count);
+  const lines = change.value.split('\n');
 
-  if (value[value.length - 1] !== '\n') {
-    value += '\n';
-  }
-
-  const lines = [];
-
-  let index = 0;
-  while (includeCount > 0) {
-    let chars = [];
-
-    let char;
-    while ((char = value[index]) !== '\n') {
-      chars.push(char);
-      index += 1;
-    }
-
-    lines.push(chars.join(''));
-
-    index += 1;
-    includeCount -= 1;
-  }
-
-  return lines;
+  return lines.slice(0, includeCount);
 }
 
 function lastChangeLines(change, maxLines) {
-  let includeCount = Math.min(maxLines, change.count);
   let value = change.value;
 
-  if (value[value.length - 1] !== '\n') {
-    value += '\n';
+  // discard a trailing newline
+  if (lastChar(value) === '\n') {
+    value = value.slice(0, -1);
   }
 
-  const lines = [];
+  const lines = value.split('\n');
 
-  let index = value.length - 2;
-  while (includeCount > 0) {
-    let chars = [];
-
-    let char;
-    while (index > -1 && (char = value[index]) !== '\n') {
-      chars.push(char);
-      index -= 1;
-    }
-
-    lines.push(chars.reverse().join(''));
-
-    index -= 1;
-    includeCount -= 1;
+  if (maxLines === Infinity) {
+    return lines;
   }
 
-  return lines.reverse();
+  const includeCount = Math.min(maxLines, change.count);
+  return lines.slice(lines.length - includeCount, lines.length);
 }
 
 function lastChar(str) {

--- a/lib/unifiedDiff.js
+++ b/lib/unifiedDiff.js
@@ -1,0 +1,136 @@
+const CHANGE_ADDED = '+';
+const CHANGE_REMOVED = '-';
+const CHANGE_MARKER = '~';
+const CHANGE_NONE = '=';
+
+function changeToType(change) {
+  if (change.added) {
+    return CHANGE_ADDED;
+  } else if (change.removed) {
+    return CHANGE_REMOVED;
+  } else {
+    return CHANGE_NONE;
+  }
+}
+
+function allChangeLines(change) {
+  return lastChangeLines(change, change.count);
+}
+
+function firstChangeLines(change, includeCount) {
+  let value = change.value;
+
+  if (value[value.length - 1] !== '\n') {
+    value += '\n';
+  }
+
+  const lines = [];
+
+  let index = 0;
+  while (includeCount > 0) {
+    let chars = [];
+
+    let char;
+    while ((char = value[index]) !== '\n') {
+      chars.push(char);
+      index += 1;
+    }
+
+    lines.push(chars.join(''));
+
+    index += 1;
+    includeCount -= 1;
+  }
+
+  return lines;
+}
+
+function lastChangeLines(change, includeCount) {
+  let value = change.value;
+
+  if (value[value.length - 1] !== '\n') {
+    value += '\n';
+  }
+
+  const lines = [];
+
+  let index = value.length - 2;
+  while (includeCount > 0) {
+    let chars = [];
+
+    let char;
+    while (index > -1 && (char = value[index]) !== '\n') {
+      chars.push(char);
+      index -= 1;
+    }
+
+    lines.push(chars.reverse().join(''));
+
+    index -= 1;
+    includeCount -= 1;
+  }
+
+  return lines.reverse();
+}
+
+module.exports = function(changes, outputter) {
+  const contextLines = 3;
+
+  const contextualRingBuffer = new Array(contextLines);
+  let contextualRingIndex = -1;
+
+  let hunkCount = 0;
+  let hunkOpen = false;
+  changes.forEach(change => {
+    const changeType = changeToType(change);
+
+    if (changeType === CHANGE_NONE && !hunkOpen) {
+      // HUNK START
+      const includeCount = Math.min(contextLines, change.count);
+
+      lastChangeLines(change, includeCount).forEach(line => {
+        // place the relevant lines into the ring buffer
+        contextualRingIndex = (contextualRingIndex + 1) % contextLines;
+        contextualRingBuffer[contextualRingIndex] = [CHANGE_NONE, line];
+      });
+    }
+
+    if (changeType === CHANGE_NONE && hunkOpen) {
+      // HUNK END
+      const includeCount = Math.min(contextLines, change.count);
+
+      firstChangeLines(change, includeCount).forEach(line => {
+        outputter([CHANGE_NONE, line]);
+      });
+
+      hunkOpen = false;
+    }
+
+    if (changeType === CHANGE_ADDED || changeType === CHANGE_REMOVED) {
+      if (!hunkOpen) {
+        if (hunkCount > 0) {
+          outputter([CHANGE_MARKER]);
+        }
+
+        hunkCount += 1;
+        hunkOpen = true;
+
+        // empty ring buffer from the oldest entry
+        let lastFromIndex = (contextualRingIndex + 1) % contextLines;
+        let emptyFromIndex = (lastFromIndex + 1) % contextLines;
+
+        outputter(contextualRingBuffer[lastFromIndex]);
+
+        while (emptyFromIndex !== lastFromIndex) {
+          outputter(contextualRingBuffer[emptyFromIndex]);
+
+          emptyFromIndex = (emptyFromIndex + 1) % contextLines;
+        }
+      }
+
+      allChangeLines(change).forEach(line => {
+        outputter([changeType, line]);
+      });
+    }
+  });
+};

--- a/lib/unifiedDiff.js
+++ b/lib/unifiedDiff.js
@@ -1,7 +1,14 @@
 const CHANGE_ADDED = '+';
+const CHANGE_ADDED_HIGHLIGHT = '>';
 const CHANGE_REMOVED = '-';
+const CHANGE_REMOVED_HIGHLIGHT = '<';
 const CHANGE_MARKER = '~';
 const CHANGE_NONE = '=';
+
+const changeTypeToHighlight = {
+  [CHANGE_ADDED]: CHANGE_ADDED_HIGHLIGHT,
+  [CHANGE_REMOVED]: CHANGE_REMOVED_HIGHLIGHT
+};
 
 function changeToType(change) {
   if (change.added) {
@@ -163,8 +170,12 @@ module.exports = function(changes, outputter) {
         }
       }
 
-      allChangeLines(change).forEach(line => {
-        outputter([changeType, line]);
+      allChangeLines(change).forEach((line, index) => {
+        const outputChangeType = change.replaced
+          ? changeTypeToHighlight[changeType]
+          : changeType;
+
+        outputter([outputChangeType, line]);
       });
     }
   });

--- a/lib/unifiedDiff.js
+++ b/lib/unifiedDiff.js
@@ -115,16 +115,19 @@ module.exports = function(changes, outputter) {
         hunkCount += 1;
         hunkOpen = true;
 
-        // empty ring buffer from the oldest entry
-        let lastFromIndex = (contextualRingIndex + 1) % contextLines;
-        let emptyFromIndex = (lastFromIndex + 1) % contextLines;
+        // if the ring buffer was ever filled
+        if (contextualRingIndex > -1) {
+          // empty ring buffer from the oldest entry
+          let lastFromIndex = (contextualRingIndex + 1) % contextLines;
+          let emptyFromIndex = (lastFromIndex + 1) % contextLines;
 
-        outputter(contextualRingBuffer[lastFromIndex]);
+          outputter(contextualRingBuffer[lastFromIndex]);
 
-        while (emptyFromIndex !== lastFromIndex) {
-          outputter(contextualRingBuffer[emptyFromIndex]);
+          while (emptyFromIndex !== lastFromIndex) {
+            outputter(contextualRingBuffer[emptyFromIndex]);
 
-          emptyFromIndex = (emptyFromIndex + 1) % contextLines;
+            emptyFromIndex = (emptyFromIndex + 1) % contextLines;
+          }
         }
       }
 

--- a/lib/unifiedDiff.js
+++ b/lib/unifiedDiff.js
@@ -125,14 +125,14 @@ module.exports = function(changes, outputter) {
       // lines - if those exceed the context length, ensure the output will
       // relfect that lines were skipped.
       if (changeIndex === 0 && change.count > contextLines) {
-        outputter([CHANGE_MARKER]);
+        outputter(CHANGE_MARKER);
       }
     }
 
     if (changeType === CHANGE_NONE && hunkOpen) {
       // HUNK END
       firstChangeLines(change, contextLines).forEach(line => {
-        outputter([CHANGE_NONE, line]);
+        outputter(CHANGE_NONE, line);
       });
 
       hunkOpen = false;
@@ -152,14 +152,14 @@ module.exports = function(changes, outputter) {
       // lines - if those exceed the context length, ensure the output will
       // relfect that more lines will be skipped.
       if (changeIndex === changes.length - 1 && change.count > contextLines) {
-        outputter([CHANGE_MARKER]);
+        outputter(CHANGE_MARKER);
       }
     }
 
     if (changeType === CHANGE_ADDED || changeType === CHANGE_REMOVED) {
       if (!hunkOpen) {
         if (hunkCount > 0) {
-          outputter([CHANGE_MARKER]);
+          outputter(CHANGE_MARKER);
         }
 
         hunkCount += 1;
@@ -175,7 +175,7 @@ module.exports = function(changes, outputter) {
           emptyFromIndex = (lastFromIndex + 1) % contextLines;
 
           // output the first entry
-          outputter(contextualRingBuffer[lastFromIndex]);
+          outputter(...contextualRingBuffer[lastFromIndex]);
         } else if (contextualRingIndex > -1) {
           // The ring buffer was only partially filled.
           emptyFromIndex = 0;
@@ -187,7 +187,7 @@ module.exports = function(changes, outputter) {
         }
 
         while (emptyFromIndex !== lastFromIndex) {
-          outputter(contextualRingBuffer[emptyFromIndex]);
+          outputter(...contextualRingBuffer[emptyFromIndex]);
 
           emptyFromIndex = (emptyFromIndex + 1) % contextLines;
         }
@@ -198,7 +198,7 @@ module.exports = function(changes, outputter) {
           ? changeTypeToHighlight[changeType]
           : changeType;
 
-        outputter([outputChangeType, line]);
+        outputter(outputChangeType, line);
       });
     }
   });

--- a/lib/unifiedDiff.js
+++ b/lib/unifiedDiff.js
@@ -156,10 +156,8 @@ module.exports = function(changes, outputter) {
 
         let lastFromIndex;
         let emptyFromIndex;
-        // if the ring buffer was ever filled
         if (contextualRingInserted >= contextLines) {
-          // The contextual ring has been completely
-          // filled at least once.
+          // The ring buffer was completely filled.
 
           // empty ring buffer from the oldest entry
           lastFromIndex = (contextualRingIndex + 1) % contextLines;
@@ -168,11 +166,11 @@ module.exports = function(changes, outputter) {
           // output the first entry
           outputter(contextualRingBuffer[lastFromIndex]);
         } else if (contextualRingIndex > -1) {
-          // The contextual ring was only partially filled.
+          // The ring buffer was only partially filled.
           emptyFromIndex = 0;
           lastFromIndex = contextualRingIndex + 1;
         } else {
-          // Cause it to be a noop.
+          // The ring buffer was empty so force a noop.
           lastFromIndex = 0;
           emptyFromIndex = 0;
         }

--- a/lib/unifiedDiff.js
+++ b/lib/unifiedDiff.js
@@ -118,6 +118,13 @@ module.exports = function(changes, outputter) {
         contextualRingBuffer[contextualRingIndex] = [CHANGE_NONE, line];
         contextualRingInserted += 1;
       });
+
+      // If this is the first change the diff starts with leading unchanged
+      // lines - if those exceed the context length, ensure the output will
+      // relfect that lines were skipped.
+      if (changeIndex === 0 && change.count > contextLines) {
+        outputter([CHANGE_MARKER]);
+      }
     }
 
     if (changeType === CHANGE_NONE && hunkOpen) {

--- a/lib/unifiedDiff.js
+++ b/lib/unifiedDiff.js
@@ -73,12 +73,28 @@ function lastChangeLines(change, includeCount) {
   return lines.reverse();
 }
 
+function markupReplacementsInDiff(changes) {
+  let lastPart;
+  changes.forEach((part, partIndex) => {
+    if (lastPart && lastPart.removed && part.added) {
+      lastPart.replaced = true;
+      part.replaced = true;
+    }
+
+    lastPart = changes[partIndex];
+  });
+
+  return changes;
+}
+
 module.exports = function(changes, outputter) {
   const contextLines = 3;
 
   const contextualRingBuffer = new Array(contextLines);
   let contextualRingIndex = -1;
   let contextualRingInserted = 0;
+
+  changes = markupReplacementsInDiff(changes);
 
   let hunkCount = 0;
   let hunkOpen = false;

--- a/lib/unifiedDiff.js
+++ b/lib/unifiedDiff.js
@@ -78,6 +78,7 @@ module.exports = function(changes, outputter) {
 
   const contextualRingBuffer = new Array(contextLines);
   let contextualRingIndex = -1;
+  let contextualRingInserted = 0;
 
   let hunkCount = 0;
   let hunkOpen = false;
@@ -92,6 +93,7 @@ module.exports = function(changes, outputter) {
         // place the relevant lines into the ring buffer
         contextualRingIndex = (contextualRingIndex + 1) % contextLines;
         contextualRingBuffer[contextualRingIndex] = [CHANGE_NONE, line];
+        contextualRingInserted += 1;
       });
     }
 
@@ -115,19 +117,33 @@ module.exports = function(changes, outputter) {
         hunkCount += 1;
         hunkOpen = true;
 
+        let lastFromIndex;
+        let emptyFromIndex;
         // if the ring buffer was ever filled
-        if (contextualRingIndex > -1) {
+        if (contextualRingInserted >= contextLines) {
+          // The contextual ring has been completely
+          // filled at least once.
+
           // empty ring buffer from the oldest entry
-          let lastFromIndex = (contextualRingIndex + 1) % contextLines;
-          let emptyFromIndex = (lastFromIndex + 1) % contextLines;
+          lastFromIndex = (contextualRingIndex + 1) % contextLines;
+          emptyFromIndex = (lastFromIndex + 1) % contextLines;
 
+          // output the first entry
           outputter(contextualRingBuffer[lastFromIndex]);
+        } else if (contextualRingIndex > -1) {
+          // The contextual ring was only partially filled.
+          emptyFromIndex = 0;
+          lastFromIndex = contextualRingIndex + 1;
+        } else {
+          // Cause it to be a noop.
+          lastFromIndex = 0;
+          emptyFromIndex = 0;
+        }
 
-          while (emptyFromIndex !== lastFromIndex) {
-            outputter(contextualRingBuffer[emptyFromIndex]);
+        while (emptyFromIndex !== lastFromIndex) {
+          outputter(contextualRingBuffer[emptyFromIndex]);
 
-            emptyFromIndex = (emptyFromIndex + 1) % contextLines;
-          }
+          emptyFromIndex = (emptyFromIndex + 1) % contextLines;
         }
       }
 

--- a/test/api/exportAssertion.spec.js
+++ b/test/api/exportAssertion.spec.js
@@ -173,6 +173,7 @@ describe('exportAssertion', () => {
         "    -expected 'bar' to foo\n" +
         "    +expected 'barf' to foo\n" +
         '     \n' +
+        '\n' +
         '     got >>bar<< but expected >>foo<<'
     );
   });

--- a/test/assertions/to-equal.spec.js
+++ b/test/assertions/to-equal.spec.js
@@ -323,17 +323,11 @@ describe('to equal assertion', () => {
       },
       'to throw',
       expect.it('to have ansi diff', function() {
-        this.block(function() {
-          this.diffRemovedLine('/fo')
-            .diffRemovedHighlight('q')
-            .diffRemovedLine('/i');
-        })
-          .nl()
-          .block(function() {
-            this.diffAddedLine('/fo')
-              .diffAddedHighlight('b')
-              .diffAddedLine('/i');
-          });
+        this.text('/fo')
+          .diffRemovedHighlight('q')
+          .diffAddedHighlight('b')
+          .text('/i')
+          .nl();
       })
     );
   });

--- a/test/styles/stringDiff.spec.js
+++ b/test/styles/stringDiff.spec.js
@@ -15,6 +15,7 @@ describe('stringDiff', () => {
           '-def\n' +
           ' ghi\n' +
           ' jkl\n' +
+          '...\n' +
           '-mno\n' +
           '+mno\n' +
           '+pqr\n' +
@@ -27,46 +28,34 @@ describe('stringDiff', () => {
         'to equal',
         expect
           .createOutput('text')
-          .block(function() {
-            this.diffRemovedLine('-')
-              .nl()
-              .diffRemovedLine('-');
-          })
-          .block(function() {
-            this.diffRemovedLine('abc')
-              .nl()
-              .diffRemovedLine('def');
-          })
+          .raw('-')
+          .diffRemovedLine('abc')
           .nl()
-          .text(' ghi')
+          .raw('-')
+          .diffRemovedLine('def')
           .nl()
-          .text(' jkl')
+          .raw(' ')
+          .text('ghi')
           .nl()
-          .block(function() {
-            this.diffRemovedLine('-');
-          })
-          .block(function() {
-            this.diffRemovedLine('mno');
-          })
+          .raw(' ')
+          .text('jkl')
           .nl()
-          .block(function() {
-            this.diffAddedLine('+')
-              .nl()
-              .diffAddedLine('+')
-              .nl()
-              .diffAddedLine('+')
-              .nl()
-              .diffAddedLine('+');
-          })
-          .block(function() {
-            this.diffAddedLine('mno')
-              .nl()
-              .diffAddedHighlight('pqr')
-              .nl()
-              .diffAddedHighlight('stu')
-              .nl()
-              .diffAddedHighlight('vwx');
-          })
+          .jsComment('...')
+          .nl()
+          .raw('-')
+          .diffRemovedLine('mno')
+          .nl()
+          .raw('+')
+          .diffAddedLine('mno')
+          .nl()
+          .raw('+')
+          .diffAddedHighlight('pqr')
+          .nl()
+          .raw('+')
+          .diffAddedHighlight('stu')
+          .nl()
+          .raw('+')
+          .diffAddedHighlight('vwx')
       );
     });
   });
@@ -86,9 +75,11 @@ describe('stringDiff', () => {
           .nl()
           .text('jkl')
           .nl()
-          .diffRemovedLine('mno')
+          .jsComment('...')
           .nl()
-          .diffAddedLine('mno')
+          .diffRemovedHighlight('mno')
+          .nl()
+          .diffAddedHighlight('mno')
           .nl()
           .diffAddedHighlight('pqr')
           .nl()

--- a/test/styles/stringDiff.spec.js
+++ b/test/styles/stringDiff.spec.js
@@ -207,6 +207,18 @@ describe('stringDiff', () => {
           .diffAddedHighlight('foo')
       );
     });
+
+    it('should support rendering regular expressions', () => {
+      expect(
+        expect.createOutput('ansi').stringDiff(String(/foq/i), String(/fob/i)),
+        'to equal',
+        expect
+          .createOutput('ansi')
+          .diffRemovedHighlight('/foq/i')
+          .nl()
+          .diffAddedHighlight('/fob/i')
+      );
+    });
   });
 
   describe('stringDiffFragment', () => {

--- a/test/styles/stringDiff.spec.js
+++ b/test/styles/stringDiff.spec.js
@@ -58,6 +58,37 @@ describe('stringDiff', () => {
           .diffAddedHighlight('vwx')
       );
     });
+
+    it('should support a string ending with a newline', () => {
+      expect(
+        expect.createOutput('text').stringDiff('foo\n', 'foo'),
+        'to equal',
+        expect
+          .createOutput('text')
+          .raw('-')
+          .diffRemovedHighlight('foo')
+          .diffRemovedLine('\\n')
+          .nl()
+          .raw('+')
+          .diffAddedHighlight('foo')
+      );
+    });
+
+    it('should show an empty removed line', () => {
+      expect(
+        expect.createOutput('text').stringDiff('foo\n\nbar', 'foo\nbar'),
+        'to equal',
+        expect
+          .createOutput('text')
+          .raw(' ')
+          .text('foo')
+          .nl()
+          .raw('-')
+          .nl()
+          .raw(' ')
+          .text('bar')
+      );
+    });
   });
 
   describe('in ansi mode', () => {
@@ -118,6 +149,7 @@ describe('stringDiff', () => {
         expect
           .createOutput('ansi')
           .diffRemovedHighlight('  ')
+          .diffRemovedSpecialChar('\\n')
           .nl()
       );
     });
@@ -129,6 +161,7 @@ describe('stringDiff', () => {
         expect
           .createOutput('ansi')
           .diffAddedHighlight('  ')
+          .diffAddedSpecialChar('\\n')
           .nl()
       );
     });
@@ -153,12 +186,25 @@ describe('stringDiff', () => {
         'to equal',
         expect
           .createOutput('ansi')
-          .diffRemovedHighlight('aa ')
-          .diffRemovedLine(');')
+          .diffRemovedHighlight('aa );')
           .nl()
           .diffAddedSpecialChar('\\n')
+          .nl() // FIXME: should not be rendered
+          .nl() // FIXME: should not be rendered
+          .diffAddedHighlight(');')
+      );
+    });
+
+    it('should support a string ending with a newline', () => {
+      expect(
+        expect.createOutput('ansi').stringDiff('foo\n', 'foo'),
+        'to equal',
+        expect
+          .createOutput('ansi')
+          .diffRemovedHighlight('foo')
+          .diffRemovedSpecialChar('\\n')
           .nl()
-          .diffAddedLine(');')
+          .diffAddedHighlight('foo')
       );
     });
   });

--- a/test/styles/stringDiff.spec.js
+++ b/test/styles/stringDiff.spec.js
@@ -207,18 +207,6 @@ describe('stringDiff', () => {
           .diffAddedHighlight('foo')
       );
     });
-
-    it('should support rendering regular expressions', () => {
-      expect(
-        expect.createOutput('ansi').stringDiff(String(/foq/i), String(/fob/i)),
-        'to equal',
-        expect
-          .createOutput('ansi')
-          .diffRemovedHighlight('/foq/i')
-          .nl()
-          .diffAddedHighlight('/fob/i')
-      );
-    });
   });
 
   describe('stringDiffFragment', () => {
@@ -234,6 +222,22 @@ describe('stringDiff', () => {
           .createOutput('text')
           .raw(' ')
           .text('\ufffd')
+      );
+    });
+  });
+
+  describe('regexDiff', () => {
+    it('should support rendering regular expressions', () => {
+      expect(
+        expect.createOutput('ansi').regexDiff(String(/foq/i), String(/fob/i)),
+        'to equal',
+        expect
+          .createOutput('ansi')
+          .text('/fo')
+          .diffRemovedHighlight('q')
+          .diffAddedHighlight('b')
+          .text('/i')
+          .nl()
       );
     });
   });

--- a/test/unifiedDiff.spec.js
+++ b/test/unifiedDiff.spec.js
@@ -93,4 +93,26 @@ describe('unifiedDiff', () => {
       ['=', 'qxqx']
     ]);
   });
+
+  it('should support input that immediately begins with a change', () => {
+    var actual = 'abc\ndef\nghi\njkl\nmno';
+    var expected = 'ghi\njkl\nmno\npqr\nstu\nvwx';
+
+    const changes = diff.diffLines(actual, expected);
+    const output = [];
+    unifiedDiff(changes, out => output.push(out));
+
+    expect(output, 'to equal', [
+      ['-', 'abc'],
+      ['-', 'def'],
+      ['=', 'ghi'],
+      ['=', 'jkl'],
+      ['~'],
+      ['-', 'mno'],
+      ['+', 'mno'],
+      ['+', 'pqr'],
+      ['+', 'stu'],
+      ['+', 'vwx']
+    ]);
+  });
 });

--- a/test/unifiedDiff.spec.js
+++ b/test/unifiedDiff.spec.js
@@ -137,4 +137,39 @@ describe('unifiedDiff', () => {
 
     expect(output, 'to equal', [['=', 'foo  '], ['<', 'bar'], ['>', 'quux']]);
   });
+
+  describe('when the diff ends with unchanged lines', () => {
+    it('should include a marker when there are more than context lines', () => {
+      const actual = 'bbbbb\n' + 'aaaaaaa\n'.repeat(10);
+      const expected = 'aaaaaaa\n'.repeat(10);
+
+      const changes = diff.diffLines(actual, expected);
+      const output = [];
+      unifiedDiff(changes, out => output.push(out));
+
+      expect(output, 'to equal', [
+        ['-', 'bbbbb'],
+        ['=', 'aaaaaaa'],
+        ['=', 'aaaaaaa'],
+        ['=', 'aaaaaaa'],
+        ['~']
+      ]);
+    });
+
+    it('should not include a marker when there are more than context lines', () => {
+      const actual = 'bbbbb\n' + 'aaaaaaa\n'.repeat(3);
+      const expected = 'aaaaaaa\n'.repeat(3);
+
+      const changes = diff.diffLines(actual, expected);
+      const output = [];
+      unifiedDiff(changes, out => output.push(out));
+
+      expect(output, 'to equal', [
+        ['-', 'bbbbb'],
+        ['=', 'aaaaaaa'],
+        ['=', 'aaaaaaa'],
+        ['=', 'aaaaaaa']
+      ]);
+    });
+  });
 });

--- a/test/unifiedDiff.spec.js
+++ b/test/unifiedDiff.spec.js
@@ -10,7 +10,7 @@ describe('unifiedDiff', () => {
 
     const changes = diff.diffLines(lhsString, rhsString);
     const output = [];
-    unifiedDiff(changes, out => output.push(out));
+    unifiedDiff(changes, (...args) => output.push(args));
 
     expect(output, 'to equal', [
       ['=', 'foo'],
@@ -29,7 +29,7 @@ describe('unifiedDiff', () => {
 
     const changes = diff.diffLines(lhsString, rhsString);
     const output = [];
-    unifiedDiff(changes, out => output.push(out));
+    unifiedDiff(changes, (...args) => output.push(args));
 
     expect(output, 'to equal', [
       ['=', 'foo'],
@@ -72,7 +72,7 @@ describe('unifiedDiff', () => {
 
     const changes = diff.diffLines(lhsString, rhsString);
     const output = [];
-    unifiedDiff(changes, out => output.push(out));
+    unifiedDiff(changes, (...args) => output.push(args));
 
     expect(output, 'to equal', [
       ['=', 'foo'],
@@ -100,7 +100,7 @@ describe('unifiedDiff', () => {
 
     const changes = diff.diffLines(actual, expected);
     const output = [];
-    unifiedDiff(changes, out => output.push(out));
+    unifiedDiff(changes, (...args) => output.push(args));
 
     expect(output, 'to equal', [
       ['-', 'abc'],
@@ -122,7 +122,7 @@ describe('unifiedDiff', () => {
 
     const changes = diff.diffLines(actual, expected);
     const output = [];
-    unifiedDiff(changes, out => output.push(out));
+    unifiedDiff(changes, (...args) => output.push(args));
 
     expect(output, 'to equal', [['-', '']]);
   });
@@ -135,7 +135,7 @@ describe('unifiedDiff', () => {
 
     const changes = diff.diffLines(actual, expected);
     const output = [];
-    unifiedDiff(changes, out => output.push(out));
+    unifiedDiff(changes, (...args) => output.push(args));
 
     expect(output, 'to equal', [
       ['<', 'foo1'],
@@ -158,7 +158,7 @@ describe('unifiedDiff', () => {
 
     const changes = diff.diffLines(actual, expected);
     const output = [];
-    unifiedDiff(changes, out => output.push(out));
+    unifiedDiff(changes, (...args) => output.push(args));
 
     expect(output, 'to equal', [['=', 'foo  '], ['<', 'bar'], ['>', 'quux']]);
   });
@@ -170,7 +170,7 @@ describe('unifiedDiff', () => {
 
       const changes = diff.diffLines(actual, expected);
       const output = [];
-      unifiedDiff(changes, out => output.push(out));
+      unifiedDiff(changes, (...args) => output.push(args));
 
       expect(output, 'to equal', [
         ['~'],
@@ -187,7 +187,7 @@ describe('unifiedDiff', () => {
 
       const changes = diff.diffLines(actual, expected);
       const output = [];
-      unifiedDiff(changes, out => output.push(out));
+      unifiedDiff(changes, (...args) => output.push(args));
 
       expect(output, 'to equal', [
         ['=', 'aaaaaaa'],
@@ -205,7 +205,7 @@ describe('unifiedDiff', () => {
 
       const changes = diff.diffLines(actual, expected);
       const output = [];
-      unifiedDiff(changes, out => output.push(out));
+      unifiedDiff(changes, (...args) => output.push(args));
 
       expect(output, 'to equal', [
         ['-', 'bbbbb'],
@@ -222,7 +222,7 @@ describe('unifiedDiff', () => {
 
       const changes = diff.diffLines(actual, expected);
       const output = [];
-      unifiedDiff(changes, out => output.push(out));
+      unifiedDiff(changes, (...args) => output.push(args));
 
       expect(output, 'to equal', [
         ['-', 'bbbbb'],

--- a/test/unifiedDiff.spec.js
+++ b/test/unifiedDiff.spec.js
@@ -138,6 +138,17 @@ describe('unifiedDiff', () => {
     expect(output, 'to equal', [['<', 'foo'], ['<', ''], ['>', 'foo']]);
   });
 
+  it('should support an empty removed line', () => {
+    const actual = 'foo\n\nbar';
+    const expected = 'foo\nbar';
+
+    const changes = diff.diffLines(actual, expected);
+    const output = [];
+    unifiedDiff(changes, (...args) => output.push(args));
+
+    expect(output, 'to equal', [['=', 'foo'], ['-', ''], ['=', 'bar']]);
+  });
+
   it('should always output context after a marker', () => {
     const actual =
       'foo1\nfoo2\nfoo3\nfoo4\nfoo5\nfoo6\nfoo7\nfoo8\nfoo9\nfoo10';

--- a/test/unifiedDiff.spec.js
+++ b/test/unifiedDiff.spec.js
@@ -138,6 +138,41 @@ describe('unifiedDiff', () => {
     expect(output, 'to equal', [['=', 'foo  '], ['<', 'bar'], ['>', 'quux']]);
   });
 
+  describe('when the diff starts with unchanged lines', () => {
+    it('should include a marker when there are more than context lines', () => {
+      const actual = 'aaaaaaa\n'.repeat(10) + 'bbbbb';
+      const expected = 'aaaaaaa\n'.repeat(10);
+
+      const changes = diff.diffLines(actual, expected);
+      const output = [];
+      unifiedDiff(changes, out => output.push(out));
+
+      expect(output, 'to equal', [
+        ['~'],
+        ['=', 'aaaaaaa'],
+        ['=', 'aaaaaaa'],
+        ['=', 'aaaaaaa'],
+        ['-', 'bbbbb']
+      ]);
+    });
+
+    it('should not include a marker when there are more than context lines', () => {
+      const actual = 'aaaaaaa\n'.repeat(3) + 'bbbbb';
+      const expected = 'aaaaaaa\n'.repeat(3);
+
+      const changes = diff.diffLines(actual, expected);
+      const output = [];
+      unifiedDiff(changes, out => output.push(out));
+
+      expect(output, 'to equal', [
+        ['=', 'aaaaaaa'],
+        ['=', 'aaaaaaa'],
+        ['=', 'aaaaaaa'],
+        ['-', 'bbbbb']
+      ]);
+    });
+  });
+
   describe('when the diff ends with unchanged lines', () => {
     it('should include a marker when there are more than context lines', () => {
       const actual = 'bbbbb\n' + 'aaaaaaa\n'.repeat(10);

--- a/test/unifiedDiff.spec.js
+++ b/test/unifiedDiff.spec.js
@@ -127,6 +127,17 @@ describe('unifiedDiff', () => {
     expect(output, 'to equal', [['-', '']]);
   });
 
+  it('should support a string ending with a newline', () => {
+    const actual = 'foo\n';
+    const expected = 'foo';
+
+    const changes = diff.diffLines(actual, expected);
+    const output = [];
+    unifiedDiff(changes, (...args) => output.push(args));
+
+    expect(output, 'to equal', [['<', 'foo'], ['<', ''], ['>', 'foo']]);
+  });
+
   it('should always output context after a marker', () => {
     const actual =
       'foo1\nfoo2\nfoo3\nfoo4\nfoo5\nfoo6\nfoo7\nfoo8\nfoo9\nfoo10';

--- a/test/unifiedDiff.spec.js
+++ b/test/unifiedDiff.spec.js
@@ -127,6 +127,31 @@ describe('unifiedDiff', () => {
     expect(output, 'to equal', [['-', '']]);
   });
 
+  it('should always output context after a marker', () => {
+    const actual =
+      'foo1\nfoo2\nfoo3\nfoo4\nfoo5\nfoo6\nfoo7\nfoo8\nfoo9\nfoo10';
+    const expected =
+      'bar1\nfoo2\nfoo3\nfoo4\nfoo5\nfoo6\nfoo7\nfoo8\nfoo9\nbar10';
+
+    const changes = diff.diffLines(actual, expected);
+    const output = [];
+    unifiedDiff(changes, out => output.push(out));
+
+    expect(output, 'to equal', [
+      ['<', 'foo1'],
+      ['>', 'bar1'],
+      ['=', 'foo2'],
+      ['=', 'foo3'],
+      ['=', 'foo4'],
+      ['~'],
+      ['=', 'foo7'],
+      ['=', 'foo8'],
+      ['=', 'foo9'],
+      ['<', 'foo10'],
+      ['>', 'bar10']
+    ]);
+  });
+
   it('should not break when the ring buffer is partially filled', () => {
     const actual = 'foo  \nbar';
     const expected = 'foo  \nquux';

--- a/test/unifiedDiff.spec.js
+++ b/test/unifiedDiff.spec.js
@@ -1,0 +1,96 @@
+/* global expect */
+const diff = require('diff');
+
+const unifiedDiff = require('../lib/unifiedDiff');
+
+describe('unifiedDiff', () => {
+  it('should produce output with context', () => {
+    const lhsString = ['foo', 'bar', 'baz', 'quux', 'xuuq', 'qxqx'].join('\n');
+    const rhsString = ['foo', 'bar', 'baz', 'quuq', 'xuuq', 'qxqx'].join('\n');
+
+    const changes = diff.diffLines(lhsString, rhsString);
+    const output = [];
+    unifiedDiff(changes, out => output.push(out));
+
+    expect(output, 'to equal', [
+      ['=', 'foo'],
+      ['=', 'bar'],
+      ['=', 'baz'],
+      ['-', 'quux'],
+      ['+', 'quuq'],
+      ['=', 'xuuq'],
+      ['=', 'qxqx']
+    ]);
+  });
+
+  it('should allow ending on a change', () => {
+    const lhsString = ['foo', 'bar', 'baz', 'quux'].join('\n');
+    const rhsString = ['foo', 'bar', 'baz', 'quuq'].join('\n');
+
+    const changes = diff.diffLines(lhsString, rhsString);
+    const output = [];
+    unifiedDiff(changes, out => output.push(out));
+
+    expect(output, 'to equal', [
+      ['=', 'foo'],
+      ['=', 'bar'],
+      ['=', 'baz'],
+      ['-', 'quux'],
+      ['+', 'quuq']
+    ]);
+  });
+
+  it('should support multiple chunks', () => {
+    const lhsString = [
+      'foo',
+      'bar',
+      'baz',
+      'quux',
+      'xuuq',
+      'qxqx',
+      'foo',
+      'bar',
+      'baz',
+      'quux',
+      'xuuq',
+      'qxqx'
+    ].join('\n');
+    const rhsString = [
+      'foo',
+      'bar',
+      'baz',
+      'quuq',
+      'xuuq',
+      'qxqx',
+      'foo',
+      'bar',
+      'baz',
+      'quuq',
+      'xuuq',
+      'qxqx'
+    ].join('\n');
+
+    const changes = diff.diffLines(lhsString, rhsString);
+    const output = [];
+    unifiedDiff(changes, out => output.push(out));
+
+    expect(output, 'to equal', [
+      ['=', 'foo'],
+      ['=', 'bar'],
+      ['=', 'baz'],
+      ['-', 'quux'],
+      ['+', 'quuq'],
+      ['=', 'xuuq'],
+      ['=', 'qxqx'],
+      ['=', 'foo'],
+      ['~'],
+      ['=', 'foo'],
+      ['=', 'bar'],
+      ['=', 'baz'],
+      ['-', 'quux'],
+      ['+', 'quuq'],
+      ['=', 'xuuq'],
+      ['=', 'qxqx']
+    ]);
+  });
+});

--- a/test/unifiedDiff.spec.js
+++ b/test/unifiedDiff.spec.js
@@ -126,4 +126,15 @@ describe('unifiedDiff', () => {
 
     expect(output, 'to equal', [['-', '']]);
   });
+
+  it('should not break when the ring buffer is partially filled', () => {
+    const actual = 'foo  \nbar';
+    const expected = 'foo  \nquux';
+
+    const changes = diff.diffLines(actual, expected);
+    const output = [];
+    unifiedDiff(changes, out => output.push(out));
+
+    expect(output, 'to equal', [['=', 'foo  '], ['-', 'bar'], ['+', 'quux']]);
+  });
 });

--- a/test/unifiedDiff.spec.js
+++ b/test/unifiedDiff.spec.js
@@ -115,4 +115,15 @@ describe('unifiedDiff', () => {
       ['+', 'vwx']
     ]);
   });
+
+  it('should support a newline being removed', () => {
+    const actual = '\n';
+    const expected = '';
+
+    const changes = diff.diffLines(actual, expected);
+    const output = [];
+    unifiedDiff(changes, out => output.push(out));
+
+    expect(output, 'to equal', [['-', '']]);
+  });
 });

--- a/test/unifiedDiff.spec.js
+++ b/test/unifiedDiff.spec.js
@@ -124,7 +124,7 @@ describe('unifiedDiff', () => {
     const output = [];
     unifiedDiff(changes, (...args) => output.push(args));
 
-    expect(output, 'to equal', [['-', '']]);
+    expect(output, 'to equal', [['-', '', { trailingNewline: false }]]);
   });
 
   it('should support a string ending with a newline', () => {
@@ -135,7 +135,15 @@ describe('unifiedDiff', () => {
     const output = [];
     unifiedDiff(changes, (...args) => output.push(args));
 
-    expect(output, 'to equal', [['<', 'foo'], ['<', ''], ['>', 'foo']]);
+    expect(output, 'to equal', [
+      ['<', 'foo'],
+      [
+        '<',
+        '',
+        { forceHighlight: true, leadingNewline: false, trailingNewline: false }
+      ],
+      ['>', 'foo']
+    ]);
   });
 
   it('should support an empty removed line', () => {
@@ -146,7 +154,11 @@ describe('unifiedDiff', () => {
     const output = [];
     unifiedDiff(changes, (...args) => output.push(args));
 
-    expect(output, 'to equal', [['=', 'foo'], ['-', ''], ['=', 'bar']]);
+    expect(output, 'to equal', [
+      ['=', 'foo'],
+      ['-', '', { trailingNewline: false }],
+      ['=', 'bar']
+    ]);
   });
 
   it('should always output context after a marker', () => {

--- a/test/unifiedDiff.spec.js
+++ b/test/unifiedDiff.spec.js
@@ -16,8 +16,8 @@ describe('unifiedDiff', () => {
       ['=', 'foo'],
       ['=', 'bar'],
       ['=', 'baz'],
-      ['-', 'quux'],
-      ['+', 'quuq'],
+      ['<', 'quux'],
+      ['>', 'quuq'],
       ['=', 'xuuq'],
       ['=', 'qxqx']
     ]);
@@ -35,8 +35,8 @@ describe('unifiedDiff', () => {
       ['=', 'foo'],
       ['=', 'bar'],
       ['=', 'baz'],
-      ['-', 'quux'],
-      ['+', 'quuq']
+      ['<', 'quux'],
+      ['>', 'quuq']
     ]);
   });
 
@@ -78,8 +78,8 @@ describe('unifiedDiff', () => {
       ['=', 'foo'],
       ['=', 'bar'],
       ['=', 'baz'],
-      ['-', 'quux'],
-      ['+', 'quuq'],
+      ['<', 'quux'],
+      ['>', 'quuq'],
       ['=', 'xuuq'],
       ['=', 'qxqx'],
       ['=', 'foo'],
@@ -87,8 +87,8 @@ describe('unifiedDiff', () => {
       ['=', 'foo'],
       ['=', 'bar'],
       ['=', 'baz'],
-      ['-', 'quux'],
-      ['+', 'quuq'],
+      ['<', 'quux'],
+      ['>', 'quuq'],
       ['=', 'xuuq'],
       ['=', 'qxqx']
     ]);
@@ -108,11 +108,11 @@ describe('unifiedDiff', () => {
       ['=', 'ghi'],
       ['=', 'jkl'],
       ['~'],
-      ['-', 'mno'],
-      ['+', 'mno'],
-      ['+', 'pqr'],
-      ['+', 'stu'],
-      ['+', 'vwx']
+      ['<', 'mno'],
+      ['>', 'mno'],
+      ['>', 'pqr'],
+      ['>', 'stu'],
+      ['>', 'vwx']
     ]);
   });
 
@@ -135,6 +135,6 @@ describe('unifiedDiff', () => {
     const output = [];
     unifiedDiff(changes, out => output.push(out));
 
-    expect(output, 'to equal', [['=', 'foo  '], ['-', 'bar'], ['+', 'quux']]);
+    expect(output, 'to equal', [['=', 'foo  '], ['<', 'bar'], ['>', 'quux']]);
   });
 });


### PR DESCRIPTION
This PR contains the work done so far on a unified diff implementation for Unexpected.

While it is not yet perfect, it should be enough to prove that the implementation largely works and I think it will now massively benefit from extra eyeballs - reviews suggestions or both. I have concentrated purely on the unified diff chunk itself. In the spirit of keeping high quality output, a majority of the effort was around outputting context in a somewhat memory efficient way while still keeping the thorough work that was done around carefully colouring output.

The context is generated by writing lines as they are seen into a ring buffer - this should make the memory overhead for this very low as they buffer is the size of the number of context lines. When changes are encountered, the ring buffer is emptied into the output and the the changes written. An attempt have been made to keep the rendering somewhat separate from the diff output, and as such a unifiedDiff file is added which takes care of the majority of heavy lifting marking lines to be output a particular way. The stringDiff style is then responsible for rendering the line output by unifiedDiff.