### PR TITLE
Update the changelog in the preversion hook, avoiding an extra commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,18 +103,9 @@ endif
 deploy-site: site-build
 	./node_modules/.bin/gh-pages -d site-build -r git@github.com:unexpectedjs/unexpectedjs.github.io.git -b master
 
-.PHONY: changelog
-changelog: git-dirty-check
-	@./node_modules/.bin/offline-github-changelog > CHANGELOG.md
-	@git add CHANGELOG.md
-	@if [ "`git status --porcelain`" != "" ]; then \
-		git commit -m "Updated the changelog" ; \
-	fi
-
 .PHONY: release-%
 release-%: git-dirty-check lint ${TARGETS} test-chrome-headless test-jasmine test-jest deploy-site
 	IS_MAKE_RELEASE=yes npm version $*
-	make changelog
 	@echo $* release ready to be publised to NPM
 	@echo Remember to push master and tags
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint . && eslint --ext md documentation && prettier --check '**/*.{js,md}'",
     "generate-site": "generate-site --require ./bootstrap-unexpected-markdown.js",
     "update-examples": "generate-site --require ./bootstrap-unexpected-markdown.js --update-examples",
-    "preversion": "test -n \"${IS_MAKE_RELEASE}\" || (echo Please run make release instead && exit 1)"
+    "preversion": "(test -n \"${IS_MAKE_RELEASE}\" || (echo Please run make release instead && exit 1)) && offline-github-changelog --next=${npm_package_version} > CHANGELOG.md && git add CHANGELOG.md"
   },
   "main": "./build/lib/index.js",
   "dependencies": {
@@ -58,7 +58,7 @@
     "mocha-slow-reporter": "^*",
     "node-version-check": "^2.2.0",
     "nyc": "^13.0.1",
-    "offline-github-changelog": "^1.2.0",
+    "offline-github-changelog": "^1.6.0",
     "prettier": "~1.16.0",
     "rollup": "^1.0.1",
     "rollup-plugin-commonjs": "^9.1.0",


### PR DESCRIPTION
Uses [`offline-github-changelog`'s new `--next` feature](https://github.com/sunesimonsen/offline-github-changelog/pull/7) and @gustavnikolaj's `${npm_package_version}` trick :sunglasses: