### PR TITLE
Fix highlighting of diffing trailing whitespace in the last line

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -459,7 +459,7 @@ module.exports = expect => {
             value,
             'diffAddedLine',
             options.markUpSpecialCharacters,
-            endsWithNewline
+            endsWithNewline || index === diffLines.length - 1
           );
         } else if (part.removed) {
           this.stringDiffFragment(
@@ -467,7 +467,7 @@ module.exports = expect => {
             value,
             'diffRemovedLine',
             options.markUpSpecialCharacters,
-            endsWithNewline
+            endsWithNewline || index === diffLines.length - 1
           );
         } else {
           const horizon = 3;

--- a/test/styles/stringDiff.spec.js
+++ b/test/styles/stringDiff.spec.js
@@ -142,6 +142,22 @@ describe('stringDiff', () => {
       );
     });
 
+    it('highlights missing trailing whitespace in the last line without newline after', () => {
+      expect(
+        expect.createOutput('ansi').stringDiff('', ' '),
+        'to equal',
+        expect.createOutput('ansi').diffAddedHighlight(' ')
+      );
+    });
+
+    it('highlights extraneous trailing whitespace in the last line without newline after', () => {
+      expect(
+        expect.createOutput('ansi').stringDiff(' ', ''),
+        'to equal',
+        expect.createOutput('ansi').diffRemovedHighlight(' ')
+      );
+    });
+
     it('does not highlight "trailing" whitespace in removed and added chunks within a line', () => {
       expect(
         expect


### PR DESCRIPTION
Fixes bug introduced in #625

Before:
![before](https://user-images.githubusercontent.com/373545/57044029-87f72e00-6c69-11e9-9ee5-f29be8b21cc4.png)

After:
![after](https://user-images.githubusercontent.com/373545/57044031-87f72e00-6c69-11e9-94ea-e4de45084553.png)
