### PR TITLE
Fix compatibility with the esm module loader

### DIFF
--- a/lib/createTopLevelExpect.js
+++ b/lib/createTopLevelExpect.js
@@ -1286,13 +1286,14 @@ expectPrototype.lookupAssertionRule = function(
 };
 
 expectPrototype._assertTopLevelExpect = function() {
-  if (this !== this._topLevelExpect) {
+  // https://github.com/unexpectedjs/unexpected/issues/631
+  if (this.flags) {
     throw new Error('This method only works on the top level expect function');
   }
 };
 
 expectPrototype._assertWrappedExpect = function() {
-  if (this === this._topLevelExpect) {
+  if (!this.flags) {
     throw new Error(
       'This method only works on the expect function handed to an assertion'
     );
@@ -1429,7 +1430,7 @@ expectPrototype._executeExpect = function(
     }
   }
 
-  if (assertionRule.expect && assertionRule.expect !== this) {
+  if (assertionRule.expect && assertionRule.expect !== this._topLevelExpect) {
     return assertionRule.expect(subject, testDescriptionString, ...args);
   }
 
@@ -1644,7 +1645,11 @@ expectPrototype.hook = function(fn) {
 
 // This is not super elegant, but wrappedExpect.fail was different:
 expectPrototype.fail = function(...args) {
-  if (this === this._topLevelExpect) {
+  if (this.flags) {
+    this._callInNestedContext(() => {
+      this.context.expect.fail(...args);
+    });
+  } else {
     try {
       this._fail(...args);
     } catch (e) {
@@ -1653,10 +1658,6 @@ expectPrototype.fail = function(...args) {
       }
       throw e;
     }
-  } else {
-    this._callInNestedContext(() => {
-      this.context.expect.fail(...args);
-    });
   }
 };
 

--- a/lib/createTopLevelExpect.js
+++ b/lib/createTopLevelExpect.js
@@ -1286,13 +1286,14 @@ expectPrototype.lookupAssertionRule = function(
 };
 
 expectPrototype._assertTopLevelExpect = function() {
-  // https://github.com/unexpectedjs/unexpected/issues/631
+  // Cannot use this !== this._topLevelExpect due to https://github.com/unexpectedjs/unexpected/issues/631
   if (this.flags) {
     throw new Error('This method only works on the top level expect function');
   }
 };
 
 expectPrototype._assertWrappedExpect = function() {
+  // Cannot use this === this._topLevelExpect due to https://github.com/unexpectedjs/unexpected/issues/631
   if (!this.flags) {
     throw new Error(
       'This method only works on the expect function handed to an assertion'
@@ -1645,6 +1646,7 @@ expectPrototype.hook = function(fn) {
 
 // This is not super elegant, but wrappedExpect.fail was different:
 expectPrototype.fail = function(...args) {
+  // Cannot use this !== this._topLevelExpect due to https://github.com/unexpectedjs/unexpected/issues/631
   if (this.flags) {
     this._callInNestedContext(() => {
       this.context.expect.fail(...args);


### PR DESCRIPTION
Avoid !== and === comparisons against this so we don't get fooled by the `Proxy` handed out by esm.

Fixes #631

This is not really ideal, we should be able to rely on basic stuff like this working :worried: