### PR TITLE
Check documentation link integrity when building docs

### DIFF
--- a/documentation/releases.md
+++ b/documentation/releases.md
@@ -42,7 +42,7 @@ guide](../migration/) to help you upgrade.
   the arguments as part of the pattern. This is a breaking change
   that removes support for the old `addAssertion` syntax where the
   subject type(s) were passed as the first argument.
-  See [addAssertion](./api/addAssertion/) for more
+  See [addAssertion](../api/addAssertion/) for more
   information.
 - The `to be >`, `to be >=`, `to be <`, and `to be <=` assertions
   have been removed as they clashed with the new type syntax.
@@ -72,7 +72,7 @@ guide](../migration/) to help you upgrade.
   plugins accordingly, so please upgrade those to the latest version
   when you upgrade to Unexpected 9.
 - Made it possible to tweak the default error message when creating
-  assertions. See [addAssertion](./api/addAssertion/) for more
+  assertions. See [addAssertion](../api/addAssertion/) for more
   information.
 - Expanded the `to have message` assertion defined for `Error`
   instances to allow matching a serialization other than plain text:
@@ -83,7 +83,7 @@ guide](../migration/) to help you upgrade.
 ### v8.0.0 (2015-06-10)
 
 - All errors originating from assertions are now instances of
-  [`UnexpectedError`](./api/UnexpectedError/), which can be manipulated before being
+  [`UnexpectedError`](../api/UnexpectedError/), which can be manipulated before being
   serialized.
 - Error messages and diffs are now built lazily, improving
   performance.
@@ -102,13 +102,13 @@ guide](../migration/) to help you upgrade.
   multiple lines and is identical to the parent subject.
 - Added a new `bubbleThrough` error mode that will make the error
   bubble all the way to the top, mainly useful internally.
-- Added [`to error`](./assertions/function/to-error/) assertion.
+- Added [`to error`](../assertions/function/to-error/) assertion.
 - Minor bugfixes and output tweaks.
 
 ### v7.0.0 (2015-04-17)
 
 - Support for
-  [asynchronous assertions using promises](./api/addAssertion/#asynchronous-assertions).
+  [asynchronous assertions using promises](../api/addAssertion/#asynchronous-assertions).
   All built-in assertions that delegate to other assertions (such as `to satisfy`)
   have been rewritten to support this. The change is fully backwards compatible.
 - Removed support for the `to be an array of` and

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "test": "make test && make test-chrome-headless",
     "lint": "eslint . && eslint --ext md documentation && prettier --check '**/*.{js,md}'",
     "generate-site": "generate-site --require ./bootstrap-unexpected-markdown.js",
+    "postgenerate-site": "hyperlink -ri --skip content-type-mismatch site-build/index.html | tap-spot",
     "update-examples": "generate-site --require ./bootstrap-unexpected-markdown.js --update-examples",
+    "postupdate-examples": "npm run postgenerate-site",
     "version": "(test -n \"${IS_MAKE_RELEASE}\" || (echo Please run make release instead && exit 1)) && offline-github-changelog --next=${npm_package_version} > CHANGELOG.md && git add CHANGELOG.md"
   },
   "main": "./build/lib/index.js",
@@ -46,6 +48,7 @@
     "find-node-modules": "^2.0.0",
     "fugl": "^1.0.0",
     "gh-pages": "^2.0.0",
+    "hyperlink": "^4.3.1",
     "istanbul": "^0.4.5",
     "jasmine": "~3.4.0",
     "jasmine-core": "^3.1.0",
@@ -69,6 +72,7 @@
     "rollup-plugin-terser": "^5.0.0",
     "rsvp": "^4.7.0",
     "serve": "*",
+    "tap-spot": "^1.1.1",
     "unexpected-documentation-site-generator": "^6.0.0",
     "unexpected-magicpen": "^2.1.0",
     "unexpected-markdown": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "make test && make test-chrome-headless",
     "lint": "eslint . && eslint --ext md documentation && prettier --check '**/*.{js,md}'",
     "generate-site": "generate-site --require ./bootstrap-unexpected-markdown.js",
-    "postgenerate-site": "hyperlink -ri --skip content-type-mismatch site-build/index.html | tap-spot",
+    "postgenerate-site": "hyperlink -ri --canonicalroot https://unexpected.js.org --skip content-type-mismatch --skip unexpected.js.org/unexpected- site-build/index.html | tap-spot",
     "update-examples": "generate-site --require ./bootstrap-unexpected-markdown.js --update-examples",
     "postupdate-examples": "npm run postgenerate-site",
     "version": "(test -n \"${IS_MAKE_RELEASE}\" || (echo Please run make release instead && exit 1)) && offline-github-changelog --next=${npm_package_version} > CHANGELOG.md && git add CHANGELOG.md"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "find-node-modules": "^2.0.0",
     "fugl": "^1.0.0",
     "gh-pages": "^2.0.0",
-    "hyperlink": "^4.3.1",
+    "hyperlink": "^4.3.2",
     "istanbul": "^0.4.5",
     "jasmine": "~3.4.0",
     "jasmine-core": "^3.1.0",


### PR DESCRIPTION
This adds hyperlink to check that the built output doesn't contain broken links to other internal pages.

There are indeed a few broken links, which I assume the first CI build result will show