### PR TITLE
Always define Symbol and Buffer, even if the runtime doesn't support them

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -55,21 +55,19 @@ module.exports = function(expect) {
     }
   });
 
-  if (typeof Symbol === 'function') {
-    expect.addType({
-      name: 'Symbol',
-      identify(obj) {
-        return typeof obj === 'symbol';
-      },
-      inspect(obj, depth, output, inspect) {
-        return output
-          .jsKeyword('Symbol')
-          .text('(')
-          .singleQuotedString(obj.toString().replace(/^Symbol\(|\)$/g, ''))
-          .text(')');
-      }
-    });
-  }
+  expect.addType({
+    name: 'Symbol',
+    identify(obj) {
+      return typeof obj === 'symbol';
+    },
+    inspect(obj, depth, output, inspect) {
+      return output
+        .jsKeyword('Symbol')
+        .text('(')
+        .singleQuotedString(obj.toString().replace(/^Symbol\(|\)$/g, ''))
+        .text(')');
+    }
+  });
 
   expect.addType({
     name: 'object',

--- a/lib/types.js
+++ b/lib/types.js
@@ -1266,16 +1266,16 @@ module.exports = function(expect) {
     }, this);
   }, this);
 
-  if (typeof Buffer !== 'undefined') {
-    expect.addType({
-      name: 'Buffer',
-      base: 'binaryArray',
-      identify: Buffer.isBuffer,
-      prefix(output) {
-        return output.code(`Buffer.from([`, 'javascript');
-      }
-    });
-  }
+  expect.addType({
+    name: 'Buffer',
+    base: 'binaryArray',
+    identify(value) {
+      return typeof Buffer === 'function' && Buffer.isBuffer(value);
+    },
+    prefix(output) {
+      return output.code(`Buffer.from([`, 'javascript');
+    }
+  });
 
   expect.addType({
     name: 'string',

--- a/lib/types.js
+++ b/lib/types.js
@@ -1252,17 +1252,17 @@ module.exports = function(expect) {
     ['Int', 'Uint'].forEach(intOrUint => {
       const constructorName = `${intOrUint + numBits}Array`;
       const Constructor = global[constructorName];
-      if (typeof Constructor !== 'undefined') {
-        expect.addType({
-          name: constructorName,
-          base: 'binaryArray',
-          hexDumpWidth: 128 / numBits,
-          digitWidth: numBits / 4,
-          identify(obj) {
+      expect.addType({
+        name: constructorName,
+        base: 'binaryArray',
+        hexDumpWidth: 128 / numBits,
+        digitWidth: numBits / 4,
+        identify:
+          Constructor !== 'undefined' &&
+          function(obj) {
             return obj instanceof Constructor;
           }
-        });
-      }
+      });
     }, this);
   }, this);
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -1269,9 +1269,7 @@ module.exports = function(expect) {
   expect.addType({
     name: 'Buffer',
     base: 'binaryArray',
-    identify(value) {
-      return typeof Buffer === 'function' && Buffer.isBuffer(value);
-    },
+    identify: typeof Buffer === 'function' && Buffer.isBuffer,
     prefix(output) {
       return output.code(`Buffer.from([`, 'javascript');
     }


### PR DESCRIPTION
Context: https://github.com/unexpectedjs/unexpected/pull/674#issuecomment-566797167