### PR TITLE
Switch the front-page to the light theme temporarily

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -1,6 +1,5 @@
 ---
 template: default.ejs
-theme: dark
 title: Unexpected
 repository: https://github.com/unexpectedjs/unexpected
 ---


### PR DESCRIPTION
or maybe not so temporarily.

<img width="831" alt="Screenshot 2019-12-26 at 18 10 54" src="https://user-images.githubusercontent.com/90802/71484176-4aa06b80-280b-11ea-94b4-0465a055cb08.png">

Instead of:

<img width="832" alt="Screenshot 2019-12-26 at 18 11 03" src="https://user-images.githubusercontent.com/90802/71484179-52601000-280b-11ea-8eb9-88bb97e0337c.png">
