### PR TITLE
exportTheme

### DIFF
--- a/lib/createTopLevelExpect.js
+++ b/lib/createTopLevelExpect.js
@@ -1604,6 +1604,10 @@ expectPrototype.child = function() {
     parent.addAssertion(testDescription, handler, childExpect);
     return this;
   };
+  childExpect.exportTheme = function(...args) {
+    parent.installTheme(...args);
+    return this;
+  };
   childExpect.exportType = function(type) {
     if (childExpect.getType(type.name) !== type) {
       childExpect.addType(type);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/unexpectedjs/unexpected"
   },
   "scripts": {
+    "prepare": "make build/lib",
     "test": "make test && make test-chrome-headless",
     "lint": "eslint . && eslint --ext md documentation && prettier --check '**/*.{js,md}'",
     "generate-site": "generate-site --require ./bootstrap-unexpected-markdown.js",

--- a/test/api/exportTheme.spec.js
+++ b/test/api/exportTheme.spec.js
@@ -1,0 +1,58 @@
+/* global expect */
+describe('exportTheme', () => {
+  let parentExpect;
+  let childExpect;
+
+  beforeEach(() => {
+    parentExpect = expect.clone();
+    childExpect = parentExpect.child();
+  });
+
+  it('is chainable', () => {
+    childExpect
+      .exportTheme('html', {
+        styles: {
+          firstStyle: '#E3E3E3'
+        }
+      })
+      .exportTheme('html', {
+        styles: {
+          secondStyle: '#3E3E3E'
+        }
+      });
+
+    expect(parentExpect.output.theme('html'), 'to satisfy', {
+      styles: {
+        firstStyle: '#E3E3E3',
+        secondStyle: '#3E3E3E'
+      }
+    });
+  });
+
+  it('makes the style available to the parent expect', () => {
+    childExpect.exportTheme('html', {
+      styles: {
+        error: ['#000000', 'italic']
+      }
+    });
+
+    expect(
+      parentExpect
+        .createOutput('html')
+        .error('yadda')
+        .toString(),
+      'to contain',
+      '<span style="color: #000000; font-style: italic">yadda</span>'
+    );
+  });
+
+  it('does not make the style available to a parent parent expect', () => {
+    childExpect
+      .child()
+      .exportTheme('html', { styles: { fancyQuotes: '#333333' } });
+
+    expect(expect.output.theme('html'), 'to satisfy', {
+      styles: expect.it('not to have property', 'fancyQuotes')
+    });
+  });
+});


### PR DESCRIPTION
Note the second commit is required in order to link the library using a git reference (otherwise the build library is not exported). IBrowser tests are failing because the "prepare" script does not rebuild the bundles so Unexpected cannot be loaded in the browser.