### PR TITLE
Bring in unexpected-markdown 5 and reconfigure test setup to match.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ endif
 
 .PHONY: coverage
 coverage: nyc-includes test-sources
-	@./node_modules/.bin/nyc --include $(NYC_INCLUDES) --reporter=lcov --reporter=text --all -- mocha --opts $(MOCHA_OPTS) $(TEST_SOURCES) $(TEST_SOURCES_MARKDOWN)
+	@./node_modules/.bin/nyc --include $(NYC_INCLUDES) --reporter=lcov --reporter=text --all -- mocha --opts $(MOCHA_OPTS) --require unexpected-markdown $(TEST_SOURCES) $(TEST_SOURCES_MARKDOWN)
 	@echo google-chrome coverage/lcov-report/index.html
 
  .PHONY: test-browser

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,11 @@ endif
 
 .PHONY: test
 test: test-sources
-	@./node_modules/.bin/mocha --opts $(MOCHA_OPTS) $(TEST_SOURCES) $(TEST_SOURCES_MARKDOWN)
+ifeq ($(MODERN_NODE), true)
+	@./node_modules/.bin/mocha --opts $(MOCHA_OPTS) --require unexpected-markdown $(TEST_SOURCES) $(TEST_SOURCES_MARKDOWN)
+else
+	@./node_modules/.bin/mocha --opts $(MOCHA_OPTS) $(TEST_SOURCES)
+endif
 
 nyc-includes:
 ifeq ($(MODERN_NODE), true)

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "tap-spot": "^1.1.1",
     "unexpected-documentation-site-generator": "^6.0.0",
     "unexpected-magicpen": "^2.1.0",
-    "unexpected-markdown": "^4.0.0"
+    "unexpected-markdown": "^5.0.0"
   },
   "files": [
     "unexpected.js",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -4,4 +4,3 @@
 --timeout 20000
 --require ./test/common
 --require ./test/promisePolyfill
---require unexpected-markdown


### PR DESCRIPTION
The new version of unexpected-markdown uses async/await syntax
which will not work on node 6. Since Unexpected still supports
this currently, we need a few special affordances:
- do not unconditionally include unexpected-markdown in mocha.opts
- use the "MODERN_NODE" trick to execute doc test on node 8+ only
- require unexpected-markdown only when executing doc tests