### PR TITLE
Any "to satisfy" Any comes out as "to equal" rather than "to satisfy"

### DIFF
--- a/test/assertions/to-satisfy.spec.js
+++ b/test/assertions/to-satisfy.spec.js
@@ -2763,4 +2763,36 @@ describe('to satisfy assertion', () => {
       { foo: 123 }
     );
   });
+
+  describe('when comparing two any types', () => {
+    const clonedExpect = expect.clone();
+    clonedExpect.addType({
+      name: 'anyOne',
+      identify(obj) {
+        return obj && obj.anyOne;
+      },
+      inspect() {
+        return 'anyOne';
+      }
+    });
+    clonedExpect.addType({
+      name: 'anyPerson',
+      identify(obj) {
+        return obj && obj.anyPerson;
+      },
+      inspect() {
+        return 'anyPerson';
+      }
+    });
+
+    it('should output the assertion as "satisfy"', () => {
+      expect(
+        () => {
+          clonedExpect({ anyOne: true }, 'to satisfy', { anyPerson: true });
+        },
+        'to throw',
+        'expected anyOne to satisfy anyPerson'
+      );
+    });
+  });
 });


### PR DESCRIPTION
I believe the output we'd want in this case is the top level assertion to say "satisfy" even if internally its using "to equal" as an implementation detail - adding the test because I'm not sure what the best way to address this is.