### PR TITLE
Deprecate value argument in "to have property"

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -300,10 +300,20 @@ module.exports = expect => {
     }
   );
 
+  const toHavePropertyValueDeprecation = utils.createDeprecationWarning(
+    "unexpected: The value argument of 'to have property' assertion is deprecated.\n" +
+      "Please use 'to have properties' with object argument instead:\n" +
+      'http://unexpected.js.org/assertions/object/to-have-properties/'
+  );
+
   expect.addAssertion(
     '<object> to have [own] property <string> <any>',
-    (expect, subject, key, expectedPropertyValue) =>
-      expect(subject, 'to have [own] property', key).then(
+    (expect, subject, key, expectedPropertyValue) => {
+      if (expectedPropertyValue) {
+        toHavePropertyValueDeprecation();
+      }
+
+      return expect(subject, 'to have [own] property', key).then(
         actualPropertyValue => {
           expect.argsOutput = function() {
             this.appendInspected(key)
@@ -315,7 +325,8 @@ module.exports = expect => {
           expect(actualPropertyValue, 'to equal', expectedPropertyValue);
           return actualPropertyValue;
         }
-      )
+      );
+    }
   );
 
   expect.addAssertion(

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@
 const canSetPrototype =
   Object.setPrototypeOf || { __proto__: [] } instanceof Array;
 const greedyIntervalPacker = require('greedy-interval-packer');
+const magicpen = require('magicpen');
 
 const setPrototypeOf =
   Object.setPrototypeOf ||
@@ -375,5 +376,28 @@ const utils = (module.exports = {
     } else if (typeof process === 'object' && process.env) {
       return process.env[varName];
     }
+  },
+
+  createDeprecationWarning(message) {
+    let deprecationWarningDisplayed = false;
+
+    return () => {
+      if (deprecationWarningDisplayed) {
+        return;
+      }
+
+      deprecationWarningDisplayed = true;
+
+      let format = magicpen.defaultFormat;
+      if (format === 'html') {
+        // override given this will be output in the browser console
+        format = 'text';
+      }
+      console.warn(
+        magicpen()
+          .text(message, 'bgYellow', 'black')
+          .toString(format)
+      );
+    };
   }
 });


### PR DESCRIPTION
This commit adds a small utility function that can be used when we add deprecation notices for assertions. I've also added a nice deprecation notice for that value argument in "to have property", outputted once, that informs the user what to do:
![Screenshot 2020-01-05 at 17 09 41](https://user-images.githubusercontent.com/721814/71784951-0aef3600-2ffa-11ea-9441-35d284f9bcee.png)
