### PR TITLE
Remove support for: not to have (configurable|enumerable|writable) property

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -279,11 +279,13 @@ module.exports = expect => {
   expect.addAssertion(
     '<object> [not] to have (enumerable|configurable|writable) property <string>',
     (expect, subject, key) => {
-      const descriptor = expect.alternations[0];
-      expect(
-        Object.getOwnPropertyDescriptor(subject, key)[descriptor],
-        '[not] to be truthy'
-      );
+      const attribute = expect.alternations[0];
+      const descriptor = Object.getOwnPropertyDescriptor(subject, key);
+      if (expect.flags.not && !descriptor) {
+        return;
+      }
+      expect(descriptor, 'to be defined');
+      expect(descriptor[attribute], '[not] to be truthy');
       return subject[key];
     }
   );

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -277,15 +277,12 @@ module.exports = expect => {
   );
 
   expect.addAssertion(
-    '<object> [not] to have (enumerable|configurable|writable) property <string>',
+    '<object> to have (enumerable|configurable|writable) property <string>',
     (expect, subject, key) => {
       const attribute = expect.alternations[0];
       const descriptor = Object.getOwnPropertyDescriptor(subject, key);
-      if (expect.flags.not && !descriptor) {
-        return;
-      }
       expect(descriptor, 'to be defined');
-      expect(descriptor[attribute], '[not] to be truthy');
+      expect(descriptor[attribute], 'to be truthy');
       return subject[key];
     }
   );

--- a/test/assertions/to-have-property.spec.js
+++ b/test/assertions/to-have-property.spec.js
@@ -62,6 +62,38 @@ describe('to have property assertion', () => {
           "to have writable property 'writableFalse'"
       );
     });
+
+    // Regression test
+    it('does not break when the object does not have the given property', function() {
+      expect(
+        () => expect({}, 'to have configurable property', 'foo'),
+        'to throw',
+        "expected {} to have configurable property 'foo'"
+      );
+    });
+
+    describe('with the not flag', function() {
+      it('succeeds when the property is absent', function() {
+        expect({}, 'not to have configurable property', 'foo');
+      });
+
+      it('succeeds when the property is present but does not have the given attribute', function() {
+        const obj = {};
+        Object.defineProperty(obj, 'foo', {
+          enumerable: false,
+          value: 123
+        });
+        expect(obj, 'not to have enumerable property', 'foo');
+      });
+
+      it('fails when the property is there and has the given attribute', function() {
+        expect(
+          () => expect({ foo: 123 }, 'not to have enumerable property', 'foo'),
+          'to throw',
+          "expected { foo: 123 } not to have enumerable property 'foo'"
+        );
+      });
+    });
   });
 
   it('throws when the assertion fails', () => {

--- a/test/assertions/to-have-property.spec.js
+++ b/test/assertions/to-have-property.spec.js
@@ -29,11 +29,8 @@ describe('to have property assertion', () => {
 
     it('asserts validity of property descriptor', () => {
       expect(subject, 'to have enumerable property', 'a');
-      expect(subject, 'not to have enumerable property', 'enumFalse');
       expect(subject, 'to have configurable property', 'a');
-      expect(subject, 'not to have configurable property', 'configFalse');
       expect(subject, 'to have writable property', 'a');
-      expect(subject, 'not to have writable property', 'writableFalse');
     });
 
     it('throws when assertion fails', () => {
@@ -70,29 +67,6 @@ describe('to have property assertion', () => {
         'to throw',
         "expected {} to have configurable property 'foo'"
       );
-    });
-
-    describe('with the not flag', function() {
-      it('succeeds when the property is absent', function() {
-        expect({}, 'not to have configurable property', 'foo');
-      });
-
-      it('succeeds when the property is present but does not have the given attribute', function() {
-        const obj = {};
-        Object.defineProperty(obj, 'foo', {
-          enumerable: false,
-          value: 123
-        });
-        expect(obj, 'not to have enumerable property', 'foo');
-      });
-
-      it('fails when the property is there and has the given attribute', function() {
-        expect(
-          () => expect({ foo: 123 }, 'not to have enumerable property', 'foo'),
-          'to throw',
-          "expected { foo: 123 } not to have enumerable property 'foo'"
-        );
-      });
     });
   });
 


### PR DESCRIPTION
The semantics of `not to have configurable/... property <string>` are unclear -- should the assertion pass when the property is there, but not configurable? Should it pass when the property is absent?

I think we should just remove this variant, as we already have `not to have property <string>`

Also, fix crash when the asserted property is absent.