### PR TITLE
utils.isArray: Use Array.isArray if available

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -105,9 +105,11 @@ const utils = (module.exports = {
     return arr;
   },
 
-  isArray(ar) {
-    return Object.prototype.toString.call(ar) === '[object Array]';
-  },
+  isArray:
+    Array.isArray ||
+    function(obj) {
+      return Object.prototype.toString.call(obj) === '[object Array]';
+    },
 
   isPromise(obj) {
     return obj && typeof obj.then === 'function';


### PR DESCRIPTION
Ought to be a lot faster than the "polyfill" we're currently using.