### PR TITLE
Rewrite calculateLimits

### DIFF
--- a/lib/createTopLevelExpect.js
+++ b/lib/createTopLevelExpect.js
@@ -699,10 +699,10 @@ expectPrototype.addAssertion = function(
           flags,
           subject,
           args,
-          argsLimits: calculateLimits(args),
           testDescriptionString: text,
           declaration: pattern,
-          expect: childExpect
+          expect: childExpect,
+          ...calculateLimits(args)
         });
       });
     });
@@ -1251,12 +1251,9 @@ expectPrototype.lookupAssertionRule = function(
       return false;
     }
 
-    if (
-      args.length < handler.argsLimits.minimum ||
-      handler.argsLimits.maximum < args.length
-    ) {
+    if (args.length < handler.minimum || handler.maximum < args.length) {
       return false;
-    } else if (args.length === 0 && handler.argsLimits.maximum === 0) {
+    } else if (args.length === 0 && handler.maximum === 0) {
       return true;
     }
 

--- a/lib/createTopLevelExpect.js
+++ b/lib/createTopLevelExpect.js
@@ -1029,14 +1029,16 @@ expectPrototype.withError = (body, handler) =>
 expectPrototype.installPlugin = expectPrototype.use; // Legacy alias
 
 function calculateLimits(items) {
-  return items.reduce(
-    (result, { minimum, maximum }) => {
-      result.minimum += minimum;
-      result.maximum += maximum;
-      return result;
-    },
-    { minimum: 0, maximum: 0 }
-  );
+  let minimum = 0;
+  let maximum = 0;
+  items.forEach(item => {
+    minimum += item.minimum;
+    maximum += item.maximum;
+  });
+  return {
+    minimum,
+    maximum
+  };
 }
 
 expectPrototype.throwAssertionNotFoundError = function(

--- a/lib/createTopLevelExpect.js
+++ b/lib/createTopLevelExpect.js
@@ -693,6 +693,7 @@ expectPrototype.addAssertion = function(
             0
           )
         );
+        const limits = calculateLimits(args);
         assertionHandlers.push({
           handler,
           alternations,
@@ -702,7 +703,8 @@ expectPrototype.addAssertion = function(
           testDescriptionString: text,
           declaration: pattern,
           expect: childExpect,
-          ...calculateLimits(args)
+          minimum: limits.minimum,
+          maximum: limits.maximum
         });
       });
     });

--- a/lib/createTopLevelExpect.js
+++ b/lib/createTopLevelExpect.js
@@ -608,6 +608,19 @@ function calculateAssertionSpecificity({ subject, args }) {
   );
 }
 
+function calculateLimits(items) {
+  let minimum = 0;
+  let maximum = 0;
+  items.forEach(item => {
+    minimum += item.minimum;
+    maximum += item.maximum;
+  });
+  return {
+    minimum,
+    maximum
+  };
+}
+
 expectPrototype.addAssertion = function(
   patternOrPatterns,
   handler,
@@ -686,6 +699,7 @@ expectPrototype.addAssertion = function(
           flags,
           subject,
           args,
+          argsLimits: calculateLimits(args),
           testDescriptionString: text,
           declaration: pattern,
           expect: childExpect
@@ -1028,19 +1042,6 @@ expectPrototype.withError = (body, handler) =>
 
 expectPrototype.installPlugin = expectPrototype.use; // Legacy alias
 
-function calculateLimits(items) {
-  let minimum = 0;
-  let maximum = 0;
-  items.forEach(item => {
-    minimum += item.minimum;
-    maximum += item.maximum;
-  });
-  return {
-    minimum,
-    maximum
-  };
-}
-
 expectPrototype.throwAssertionNotFoundError = function(
   subject,
   testDescriptionString,
@@ -1250,14 +1251,12 @@ expectPrototype.lookupAssertionRule = function(
       return false;
     }
 
-    const requireArgumentsLength = calculateLimits(handler.args);
-
     if (
-      args.length < requireArgumentsLength.minimum ||
-      requireArgumentsLength.maximum < args.length
+      args.length < handler.argsLimits.minimum ||
+      handler.argsLimits.maximum < args.length
     ) {
       return false;
-    } else if (args.length === 0 && requireArgumentsLength.maximum === 0) {
+    } else if (args.length === 0 && handler.argsLimits.maximum === 0) {
       return true;
     }
 


### PR DESCRIPTION
Fixes weird heisenbug in the deno and Chrome Headless builds (see the failing builds in the other PRs I've opened). I'm trying to see if I can reproduce it in a smaller setting so I can report it to whomever it may concern.

Should be a nice optimization in itself to avoid computing those limits repeatedly in the very hot `lookupAssertionRule`.