### PR TITLE
Inspect Date instances as ISO strings instead of the longer format that includes the weekday

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -886,21 +886,11 @@ module.exports = function (expect) {
     },
     inspect(date, depth, output, inspect) {
       // TODO: Inspect "new" as an operator and Date as a built-in once we have the styles defined:
-      let dateStr = date.toUTCString().replace(/UTC/, 'GMT');
-      const milliseconds = date.getUTCMilliseconds();
-      if (milliseconds > 0) {
-        let millisecondsStr = String(milliseconds);
-        while (millisecondsStr.length < 3) {
-          millisecondsStr = `0${millisecondsStr}`;
-        }
-        dateStr = dateStr.replace(' GMT', `.${millisecondsStr} GMT`);
-      }
-
       return output
         .jsKeyword('new')
         .sp()
         .text('Date(')
-        .append(inspect(dateStr).text(')'));
+        .append(inspect(date.toISOString().replace(/\.000Z$/, 'Z')).text(')'));
     },
   });
 

--- a/test/api/inspect.spec.js
+++ b/test/api/inspect.spec.js
@@ -224,8 +224,8 @@ describe('inspect', () => {
         "    age: 38, email: 'huntterry@medalert.com', phone: '+1 (803) 472-3209',\n" +
         "    address: '944 Milton Street, Madrid, Ohio, 1336',\n" +
         "    about: 'Ea consequat nulla duis incididunt ut irureirure cupidatat. Est tempor cillum commodo aliquaconsequat esse commodo. Culpa ipsum eu consectetur idenim quis sint. Aliqua deserunt dolore reprehenderitid anim exercitation laboris. Eiusmod aute consecteturexcepteur in nulla proident occaecatconsectetur.\\r\\n',\n" +
-        "    registered: new Date('Sun, 03 Jun 1984 09:36:47 GMT'),\n" +
-        '    latitude: 8.635553, longitude: -103.382498,\n' +
+        "    registered: new Date('1984-06-03T09:36:47Z'), latitude: 8.635553,\n" +
+        '    longitude: -103.382498,\n' +
         "    tags: [ 'tempor', 'dolore', 'non', 'sit', 'minim', 'aute', 'non' ],\n" +
         '    friends: [\n' +
         "      { id: 0, name: 'Jeanne Hyde' },\n" +
@@ -255,8 +255,8 @@ describe('inspect', () => {
         "    age: 34, email: 'peckhester@medalert.com',\n" +
         "    phone: '+1 (848) 599-3447',\n" +
         "    address: '323 Legion Street, Caspar, Delaware, 4117',\n" +
-        "    registered: new Date('Tue, 10 Mar 1981 17:02:53 GMT'),\n" +
-        '    latitude: -55.321712, longitude: -100.276818,\n' +
+        "    registered: new Date('1981-03-10T17:02:53Z'), latitude: -55.321712,\n" +
+        '    longitude: -100.276818,\n' +
         "    tags: [ 'Lorem', 'laboris', 'enim', 'anim', 'sint', 'incididunt', 'labore' ],\n" +
         '    friends: [\n' +
         "      { id: 0, name: 'Patterson Meadows' },\n" +
@@ -286,7 +286,7 @@ describe('inspect', () => {
         '  {\n' +
         "    guid: 'db550c87-1680-462a-bacc-655cecdd8907', isActive: false, age: 38, email: 'huntterry@medalert.com', phone: '+1 (803) 472-3209', address: '944 Milton Street, Madrid, Ohio, 1336',\n" +
         "    about: 'Ea consequat nulla duis incididunt ut irureirure cupidatat. Est tempor cillum commodo aliquaconsequat esse commodo. Culpa ipsum eu consectetur idenim quis sint. Aliqua deserunt dolore reprehenderitid anim exercitation laboris. Eiusmod aute consecteturexcepteur in nulla proident occaecatconsectetur.\\r\\n',\n" +
-        "    registered: new Date('Sun, 03 Jun 1984 09:36:47 GMT'), latitude: 8.635553, longitude: -103.382498, tags: [ 'tempor', 'dolore', 'non', 'sit', 'minim', 'aute', 'non' ],\n" +
+        "    registered: new Date('1984-06-03T09:36:47Z'), latitude: 8.635553, longitude: -103.382498, tags: [ 'tempor', 'dolore', 'non', 'sit', 'minim', 'aute', 'non' ],\n" +
         '    friends: [\n' +
         "      { id: 0, name: 'Jeanne Hyde' },\n" +
         "      { id: 1, name: 'Chavez Parker' },\n" +
@@ -312,7 +312,7 @@ describe('inspect', () => {
         '  },\n' +
         '  {\n' +
         "    guid: '904c2f38-071c-4b97-b968-f5c228aaf41a', isActive: false, age: 34, email: 'peckhester@medalert.com', phone: '+1 (848) 599-3447', address: '323 Legion Street, Caspar, Delaware, 4117',\n" +
-        "    registered: new Date('Tue, 10 Mar 1981 17:02:53 GMT'), latitude: -55.321712, longitude: -100.276818, tags: [ 'Lorem', 'laboris', 'enim', 'anim', 'sint', 'incididunt', 'labore' ],\n" +
+        "    registered: new Date('1981-03-10T17:02:53Z'), latitude: -55.321712, longitude: -100.276818, tags: [ 'Lorem', 'laboris', 'enim', 'anim', 'sint', 'incididunt', 'labore' ],\n" +
         '    friends: [\n' +
         "      { id: 0, name: 'Patterson Meadows' },\n" +
         "      { id: 1, name: 'Velasquez Joseph' },\n" +

--- a/test/types/Date-type.spec.js
+++ b/test/types/Date-type.spec.js
@@ -1,26 +1,14 @@
 /* global expect */
 describe('Date type', () => {
-  it('inspects without milliseconds when the milliseconds field is zero', () => {
-    expect(
-      new Date(0),
-      'to inspect as',
-      "new Date('Thu, 01 Jan 1970 00:00:00 GMT')"
-    );
-  });
-
-  it('inspects with three milliseconds digits when the milliseconds field has one digit', () => {
-    expect(
-      new Date(1),
-      'to inspect as',
-      "new Date('Thu, 01 Jan 1970 00:00:00.001 GMT')"
-    );
+  it('inspects as an ISO string', () => {
+    expect(new Date(0), 'to inspect as', "new Date('1970-01-01T00:00:00Z')");
   });
 
   it('inspects with three milliseconds digits when the milliseconds field has two digits', () => {
     expect(
       new Date(10),
       'to inspect as',
-      "new Date('Thu, 01 Jan 1970 00:00:00.010 GMT')"
+      "new Date('1970-01-01T00:00:00.010Z')"
     );
   });
 
@@ -28,7 +16,7 @@ describe('Date type', () => {
     expect(
       new Date(100),
       'to inspect as',
-      "new Date('Thu, 01 Jan 1970 00:00:00.100 GMT')"
+      "new Date('1970-01-01T00:00:00.100Z')"
     );
   });
 });


### PR DESCRIPTION
I got a bit annoyed with seeing this in diffs:

```js
    blabla: new Date('Sat, 09 Jan 2016 17:52:23.880 GMT') // should equal new Date('Fri, 01 Apr 2016 05:00:43.560 GMT')
```

I think we should switch to the more compact ISO-8601 timestamp format, `2016-01-09T17:52:23.880Z`