### PR TITLE
Remove legacy support for addAssertion without a subject type

### DIFF
--- a/lib/createTopLevelExpect.js
+++ b/lib/createTopLevelExpect.js
@@ -420,27 +420,11 @@ expectPrototype.parseAssertion = function (assertionString) {
     }
   );
 
-  let assertion;
-  if (tokens.length === 1 && typeof tokens[0] === 'string') {
-    if (!this._legacyTypelessAssertionWarned) {
-      console.warn(
-        'The typeless expect.addAssertion syntax is deprecated and will be removed in a future update\n' +
-          'Please refer to http://unexpected.js.org/api/addAssertion/'
-      );
-      this._legacyTypelessAssertionWarned = true;
-    }
-    assertion = {
-      subject: parseTypeToken('any'),
-      assertion: tokens[0],
-      args: [parseTypeToken('any*')],
-    };
-  } else {
-    assertion = {
-      subject: tokens[0],
-      assertion: tokens[1],
-      args: tokens.slice(2),
-    };
-  }
+  const assertion = {
+    subject: tokens[0],
+    assertion: tokens[1],
+    args: tokens.slice(2),
+  };
 
   if (!Array.isArray(assertion.subject)) {
     throw new SyntaxError(`Missing subject type in ${assertionString}`);

--- a/test/assertionParser.spec.js
+++ b/test/assertionParser.spec.js
@@ -73,40 +73,12 @@ describe('parseAssertion', () => {
     ]);
   });
 
-  describe('when the legacy typeless assertion syntax is used', () => {
-    // Poor man's sinon.stub:
-    const originalConsoleWarn = console.warn;
-    const consoleWarnCalls = [];
-    beforeEach(function () {
-      console.warn = (...args) => consoleWarnCalls.push(args);
-    });
-    afterEach(function () {
-      console.warn = originalConsoleWarn;
-    });
-
-    it('assumes <any> ... <any+>', () => {
-      const assertion = expect.parseAssertion('[not] to be');
-      expect(assertion, 'to satisfy', [
-        {
-          subject: { type: { name: 'any' }, minimum: 1, maximum: 1 },
-          assertion: '[not] to be',
-          args: [{ type: { name: 'any' }, minimum: 0, maximum: Infinity }],
-        },
-      ]);
-    });
-
-    it('outputs a warning the first time', () => {
-      expect.parseAssertion('[not] to be');
-      expect(consoleWarnCalls, 'to satisfy', [
-        [
-          'The typeless expect.addAssertion syntax is deprecated and will be removed in a future update\n' +
-            'Please refer to http://unexpected.js.org/api/addAssertion/',
-        ],
-      ]);
-
-      expect.parseAssertion('[not] to be');
-      expect(consoleWarnCalls, 'to have length', 1);
-    });
+  it('throws when the legacy typeless assertion syntax is used', () => {
+    expect(
+      () => expect.parseAssertion('[not] to be'),
+      'to throw',
+      'Missing subject type in [not] to be'
+    );
   });
 
   it('accepts assertions with no arguments', () => {


### PR DESCRIPTION
This syntax has been on its way out for 5 years (since [version 10](http://unexpected.js.org/releases/#v10-0-0-2015-10-08-)) where we added support for argument types. We've logged a warning to the console (implemented in #581) for almost two years now. Let's get rid of it for the next major release :)