### PR TITLE
Always escape special characters in string diffs

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -417,14 +417,14 @@ module.exports = (expect) => {
               '+',
               value,
               'diffAddedLine',
-              undefined,
+              options.markUpSpecialCharacters,
               isAtEol
             );
             this.stringDiffFragment(
               '-',
               value,
               'diffRemovedLine',
-              undefined,
+              options.markUpSpecialCharacters,
               isAtEol
             );
           }

--- a/test/styles/stringDiff.spec.js
+++ b/test/styles/stringDiff.spec.js
@@ -188,6 +188,46 @@ describe('stringDiff', () => {
           .diffAddedLine(');')
       );
     });
+
+    it('escapes ansi codes in the differing parts', () => {
+      expect(
+        expect
+          .createOutput('ansi')
+          .stringDiff(
+            '\u001b[35mmagenta\u001b[39m\n\u001b[34mblue\u001b[39m\n\u001b[33myellow\u001b[39m',
+            '\u001b[37mwhite\u001b[39m\n\u001b[34mblue\u001b[39m\n\u001b[36mcyan\u001b[39m',
+            { markUpSpecialCharacters: true }
+          ),
+        'to equal',
+        expect
+          .createOutput('ansi')
+          .diffRemovedSpecialChar('\\x1B')
+          .diffRemovedLine('[')
+          .diffRemovedHighlight('35mmagenta')
+          .diffRemovedSpecialChar('\\x1B')
+          .diffRemovedLine('[39m')
+          .nl()
+          .diffAddedSpecialChar('\\x1B')
+          .diffAddedLine('[')
+          .diffAddedHighlight('37mwhite')
+          .diffAddedSpecialChar('\\x1B')
+          .diffAddedLine('[39m')
+          .nl()
+          .text('\x1b[34mblue\x1b[39m')
+          .nl()
+          .diffRemovedSpecialChar('\\x1B')
+          .diffRemovedLine('[')
+          .diffRemovedHighlight('33myellow')
+          .diffRemovedSpecialChar('\\x1B')
+          .diffRemovedLine('[39m')
+          .nl()
+          .diffAddedSpecialChar('\\x1B')
+          .diffAddedLine('[')
+          .diffAddedHighlight('36mcyan')
+          .diffAddedSpecialChar('\\x1B')
+          .diffAddedLine('[39m')
+      );
+    });
   });
 
   describe('stringDiffFragment', () => {


### PR DESCRIPTION
I ran into a failing build where a diff of strings containing ansi codes was less than helpful: https://github.com/unexpectedjs/magicpen-prism/runs/5255055332?check_suite_focus=true

I took a look, and it seems like we just don't propagate the `markUpSpecialCharacters` flag in some cases. I think this is a bug.

## Before

![2before](https://user-images.githubusercontent.com/373545/154869558-2b7cbc09-f43a-4d60-b257-e9c8f3ed12ae.png)

## After

![2after](https://user-images.githubusercontent.com/373545/154869556-aff46260-f735-4ad3-81a4-63e50233479a.png)

Here's a slightly simplified case that illustrates it:

## Before
![before](https://user-images.githubusercontent.com/373545/154869204-a96cff89-84eb-4c59-8af1-c691632be42d.png)

## After
![after](https://user-images.githubusercontent.com/373545/154869241-0dad5ee2-ace6-49f6-a6ff-e9c361c87635.png)



