### PR TITLE
Inspect BigInts as `123n` instead of `BigInt(123)`

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -1307,10 +1307,7 @@ module.exports = function (expect) {
       return typeof value === 'bigint';
     },
     inspect(value, depth, output) {
-      return output
-        .code('BigInt(', 'javascript')
-        .jsNumber(value.toString())
-        .code(')', 'javascript');
+      return output.jsNumber(value.toString()).code('n', 'javascript');
     },
   });
 

--- a/test/assertions/to-be-greater-than-or-equal.spec.js
+++ b/test/assertions/to-be-greater-than-or-equal.spec.js
@@ -30,7 +30,7 @@ describe('greater than or equal assertion', () => {
             expect(BigInt(-1), 'to be greater than or equal to', BigInt(0));
           },
           'to throw exception',
-          'expected BigInt(-1) to be greater than or equal to BigInt(0)'
+          'expected -1n to be greater than or equal to 0n'
         );
       });
 
@@ -40,7 +40,7 @@ describe('greater than or equal assertion', () => {
             expect(BigInt(-1), 'to be greater than or equal to', 0);
           },
           'to throw',
-          'expected BigInt(-1) to be greater than or equal to 0\n' +
+          'expected -1n to be greater than or equal to 0\n' +
             '  The assertion does not have a matching signature for:\n' +
             '    <BigInt> to be greater than or equal to <number>\n' +
             '  did you mean:\n' +

--- a/test/assertions/to-be-greater-than.spec.js
+++ b/test/assertions/to-be-greater-than.spec.js
@@ -45,7 +45,7 @@ describe('greater than assertion', () => {
             expect(BigInt(0), 'to be greater than', BigInt(0));
           },
           'to throw exception',
-          'expected BigInt(0) to be greater than BigInt(0)'
+          'expected 0n to be greater than 0n'
         );
       });
 
@@ -55,7 +55,7 @@ describe('greater than assertion', () => {
             expect(BigInt(123), 'to be greater than', 1);
           },
           'to throw',
-          'expected BigInt(123) to be greater than 1\n' +
+          'expected 123n to be greater than 1\n' +
             '  The assertion does not have a matching signature for:\n' +
             '    <BigInt> to be greater than <number>\n' +
             '  did you mean:\n' +

--- a/test/assertions/to-be-less-than-or-equal.spec.js
+++ b/test/assertions/to-be-less-than-or-equal.spec.js
@@ -30,7 +30,7 @@ describe('less than or equal assertion', () => {
             expect(BigInt(0), 'to be less than or equal to', BigInt(-1));
           },
           'to throw exception',
-          'expected BigInt(0) to be less than or equal to BigInt(-1)'
+          'expected 0n to be less than or equal to -1n'
         );
       });
 
@@ -40,7 +40,7 @@ describe('less than or equal assertion', () => {
             expect(BigInt(123), 'to be less than or equal to', 1);
           },
           'to throw',
-          'expected BigInt(123) to be less than or equal to 1\n' +
+          'expected 123n to be less than or equal to 1\n' +
             '  The assertion does not have a matching signature for:\n' +
             '    <BigInt> to be less than or equal to <number>\n' +
             '  did you mean:\n' +

--- a/test/assertions/to-be-less-than.spec.js
+++ b/test/assertions/to-be-less-than.spec.js
@@ -29,7 +29,7 @@ describe('less than assertion', () => {
             expect(BigInt(0), 'to be less than', BigInt(0));
           },
           'to throw exception',
-          'expected BigInt(0) to be less than BigInt(0)'
+          'expected 0n to be less than 0n'
         );
       });
 
@@ -39,7 +39,7 @@ describe('less than assertion', () => {
             expect(BigInt(0), 'to be less than', 1);
           },
           'to throw exception',
-          'expected BigInt(0) to be less than 1\n' +
+          'expected 0n to be less than 1\n' +
             '  The assertion does not have a matching signature for:\n' +
             '    <BigInt> to be less than <number>\n' +
             '  did you mean:\n' +

--- a/test/assertions/to-be-negative.spec.js
+++ b/test/assertions/to-be-negative.spec.js
@@ -26,7 +26,7 @@ describe('negative assertion', () => {
             expect(BigInt(0), 'to be negative');
           },
           'to throw exception',
-          'expected BigInt(0) to be negative'
+          'expected 0n to be negative'
         );
       });
     });

--- a/test/assertions/to-be-positive.spec.js
+++ b/test/assertions/to-be-positive.spec.js
@@ -26,7 +26,7 @@ describe('positive assertion', () => {
             expect(BigInt(0), 'to be positive');
           },
           'to throw exception',
-          'expected BigInt(0) to be positive'
+          'expected 0n to be positive'
         );
       });
     });

--- a/test/assertions/to-be-within.spec.js
+++ b/test/assertions/to-be-within.spec.js
@@ -57,7 +57,7 @@ describe('within assertion', () => {
             expect(BigInt(4), 'not to be within', BigInt(0), BigInt(4));
           },
           'to throw exception',
-          'expected BigInt(4) not to be within BigInt(0)..BigInt(4)'
+          'expected 4n not to be within 0n..4n'
         );
       });
 
@@ -67,7 +67,7 @@ describe('within assertion', () => {
             expect(BigInt(123), 'to be within', 100, 200);
           },
           'to throw',
-          'expected BigInt(123) to be within 100, 200\n' +
+          'expected 123n to be within 100, 200\n' +
             '  The assertion does not have a matching signature for:\n' +
             '    <BigInt> to be within <number> <number>\n' +
             '  did you mean:\n' +

--- a/test/types/BigInt-type.spec.js
+++ b/test/types/BigInt-type.spec.js
@@ -17,13 +17,13 @@ if (typeof BigInt === 'function') {
       expect(
         () => expect(BigInt(1), 'to equal', 1),
         'to throw',
-        'expected BigInt(1) to equal 1'
+        'expected 1n to equal 1'
       );
     });
 
     it('should inspect as source code', () => {
       const a = BigInt(123);
-      expect(a, 'to inspect as', 'BigInt(123)');
+      expect(a, 'to inspect as', '123n');
     });
   });
 }


### PR DESCRIPTION
Reads nicer -- I wasn't aware of this syntax when I implemented the `BigInt` type.

Keep using the `BigInt(123)` syntax in the test suite to prevent breaking in environments where the parser doesn't allow it.