### PR TITLE
Fix bug that caused expect({foo: 123}, 'to satisfy', {foo: undefined}) to pass

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1986,7 +1986,8 @@ module.exports = (expect) => {
       let forceExhaustivelyComparison = false;
       uniqueKeys.forEach((key, index) => {
         const subjectHasKey = subjectType.hasKey(subject, key);
-        const valueKey = valueType.hasKey(value, key, true)
+        const valueHasKey = valueType.hasKey(value, key, true);
+        const valueKey = valueHasKey
           ? valueType.valueForKey(value, key)
           : undefined;
         const valueKeyType = expect.findTypeOf(valueKey);
@@ -1995,7 +1996,7 @@ module.exports = (expect) => {
             // ensure value only expect.it key is marked missing
             forceExhaustivelyComparison = true;
           }
-        } else if (subjectHasKey && typeof valueKey === 'undefined') {
+        } else if (subjectHasKey && !valueHasKey) {
           // ignore subject only keys unless we are being exhaustive
           return;
         }

--- a/test/assertions/to-satisfy.spec.js
+++ b/test/assertions/to-satisfy.spec.js
@@ -1747,9 +1747,30 @@ describe('to satisfy assertion', () => {
     });
   });
 
-  it('should assert missing properties with undefined in the RHS object', () => {
-    expect({ foo: 123 }, 'to satisfy', {
-      bar: undefined,
+  describe('when asserting missing properties with undefined in the RHS object', () => {
+    describe('when the property is missing', () => {
+      it('should succeed', () => {
+        expect({ foo: 123 }, 'to satisfy', {
+          bar: undefined,
+        });
+      });
+    });
+
+    describe('when the property is present', () => {
+      it('should fail with an error', () => {
+        expect(
+          () =>
+            expect({ foo: 123 }, 'to satisfy', {
+              foo: undefined,
+            }),
+          'to throw',
+          'expected { foo: 123 } to satisfy { foo: undefined }\n' +
+            '\n' +
+            '{\n' +
+            '  foo: 123 // should equal undefined\n' +
+            '}'
+        );
+      });
     });
   });
 


### PR DESCRIPTION
Whoopsie...