### PR TITLE
Don't require `array-like` subtypes to have the same constructor in order to be equal

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -453,50 +453,49 @@ module.exports = function (expect) {
     equal(a, b, equal) {
       if (a === b) {
         return true;
-      } else if (a.constructor === b.constructor && a.length === b.length) {
-        let i;
-
-        // compare numerically indexed elements
-        for (i = 0; i < a.length; i += 1) {
-          if (!equal(this.valueForKey(a, i), this.valueForKey(b, i))) {
-            return false;
-          }
-        }
-
-        // compare non-numerical keys if enabled for the type
-        if (!this.numericalPropertiesOnly) {
-          const aKeys = this.getKeysNonNumerical(a).filter((key) => {
-            // include keys whose value is not undefined
-            return typeof this.valueForKey(a, key) !== 'undefined';
-          });
-          const bKeys = this.getKeysNonNumerical(b).filter((key) => {
-            // include keys whose value is not undefined on either LHS or RHS
-            return (
-              typeof this.valueForKey(b, key) !== 'undefined' ||
-              typeof this.valueForKey(a, key) !== 'undefined'
-            );
-          });
-
-          if (aKeys.length !== bKeys.length) {
-            return false;
-          }
-
-          for (i = 0; i < aKeys.length; i += 1) {
-            if (
-              !equal(
-                this.valueForKey(a, aKeys[i]),
-                this.valueForKey(b, bKeys[i])
-              )
-            ) {
-              return false;
-            }
-          }
-        }
-
-        return true;
-      } else {
+      } else if (a.length !== b.length) {
+        return false;
+      } else if (expect.findTypeOf(a) !== expect.findTypeOf(b)) {
         return false;
       }
+
+      let i;
+
+      // compare numerically indexed elements
+      for (i = 0; i < a.length; i += 1) {
+        if (!equal(this.valueForKey(a, i), this.valueForKey(b, i))) {
+          return false;
+        }
+      }
+
+      // compare non-numerical keys if enabled for the type
+      if (!this.numericalPropertiesOnly) {
+        const aKeys = this.getKeysNonNumerical(a).filter((key) => {
+          // include keys whose value is not undefined
+          return typeof this.valueForKey(a, key) !== 'undefined';
+        });
+        const bKeys = this.getKeysNonNumerical(b).filter((key) => {
+          // include keys whose value is not undefined on either LHS or RHS
+          return (
+            typeof this.valueForKey(b, key) !== 'undefined' ||
+            typeof this.valueForKey(a, key) !== 'undefined'
+          );
+        });
+
+        if (aKeys.length !== bKeys.length) {
+          return false;
+        }
+
+        for (i = 0; i < aKeys.length; i += 1) {
+          if (
+            !equal(this.valueForKey(a, aKeys[i]), this.valueForKey(b, bKeys[i]))
+          ) {
+            return false;
+          }
+        }
+      }
+
+      return true;
     },
     prefix(output) {
       return output.text('[');

--- a/lib/types.js
+++ b/lib/types.js
@@ -592,7 +592,7 @@ module.exports = function (expect) {
         return output;
       }
 
-      if (actual.constructor !== expected.constructor) {
+      if (expect.findTypeOf(actual) !== expect.findTypeOf(expected)) {
         return this.baseType.diff(actual, expected, output);
       }
 

--- a/test/types/array-like-type.spec.js
+++ b/test/types/array-like-type.spec.js
@@ -144,6 +144,38 @@ describe('array-like type', () => {
         }
       );
     }
+
+    it('should treat identical instances of the same subtype as equal, even though they have different constructors', () => {
+      clonedExpect.addType({
+        name: 'subtypeOfSimpleArrayLike',
+        base: 'simpleArrayLike',
+        identify(value) {
+          return value && value._subtypeOfSimpleArrayLike;
+        },
+      });
+
+      class MyArray extends Array {
+        constructor(value) {
+          super(value);
+          this._subtypeOfSimpleArrayLike = true;
+        }
+      }
+
+      class MyOtherArray extends Array {
+        constructor(value) {
+          super(value);
+          this._subtypeOfSimpleArrayLike = true;
+        }
+      }
+
+      const a = new MyArray();
+      a.push(123);
+      const b = new MyOtherArray();
+      b.push(123);
+
+      clonedExpect(a, 'to equal', b);
+      clonedExpect(b, 'to equal', a);
+    });
   });
 
   describe('with a subtype that disables indentation', () => {

--- a/test/types/array-like-type.spec.js
+++ b/test/types/array-like-type.spec.js
@@ -148,10 +148,11 @@ describe('array-like type', () => {
     describe('when comparing instances of different classes that are identified by the same array-like subtype', () => {
       clonedExpect.addType({
         name: 'subtypeOfSimpleArrayLike',
-        base: 'simpleArrayLike',
+        base: 'array-like',
         identify(value) {
           return value && value._subtypeOfSimpleArrayLike;
         },
+        numericalPropertiesOnly: true,
       });
 
       class MyArray extends Array {
@@ -169,31 +170,32 @@ describe('array-like type', () => {
       }
 
       it('should succeed when the elements match', () => {
-        const a = new MyArray();
-        a.push(123);
-        const b = new MyOtherArray();
-        b.push(123);
+        const a = new MyArray(1);
+        a.length = 1;
+        a[0] = 123;
+        const b = new MyOtherArray(1);
+        b.length = 1;
+        b[0] = 123;
 
         clonedExpect(a, 'to equal', b);
         clonedExpect(b, 'to equal', a);
       });
 
       it('should fail with a diff when the elements do not match', () => {
-        const a = new MyArray();
-        a.push(123);
-        const b = new MyOtherArray();
-        b.push(456);
+        const a = new MyArray(1);
+        a.length = 1;
+        a[0] = 123;
+        const b = new MyOtherArray(1);
+        b.length = 1;
+        b[0] = 456;
 
         expect(
           () => clonedExpect(a, 'to equal', b),
           'to throw',
-          'expected [ undefined, 123, _subtypeOfSimpleArrayLike: true ]\n' +
-            'to equal [ undefined, 456, _subtypeOfSimpleArrayLike: true ]\n' +
+          'expected [ 123 ] to equal [ 456 ]\n' +
             '\n' +
             '[\n' +
-            '  undefined,\n' +
-            '  123, // should equal 456\n' +
-            '  _subtypeOfSimpleArrayLike: true\n' +
+            '  123 // should equal 456\n' +
             ']'
         );
       });

--- a/test/types/array-like-type.spec.js
+++ b/test/types/array-like-type.spec.js
@@ -145,7 +145,7 @@ describe('array-like type', () => {
       );
     }
 
-    it('should treat identical instances of the same subtype as equal, even though they have different constructors', () => {
+    describe('when comparing instances of different classes that are identified by the same array-like subtype', () => {
       clonedExpect.addType({
         name: 'subtypeOfSimpleArrayLike',
         base: 'simpleArrayLike',
@@ -168,13 +168,35 @@ describe('array-like type', () => {
         }
       }
 
-      const a = new MyArray();
-      a.push(123);
-      const b = new MyOtherArray();
-      b.push(123);
+      it('should succeed when the elements match', () => {
+        const a = new MyArray();
+        a.push(123);
+        const b = new MyOtherArray();
+        b.push(123);
 
-      clonedExpect(a, 'to equal', b);
-      clonedExpect(b, 'to equal', a);
+        clonedExpect(a, 'to equal', b);
+        clonedExpect(b, 'to equal', a);
+      });
+
+      it('should fail with a diff when the elements do not match', () => {
+        const a = new MyArray();
+        a.push(123);
+        const b = new MyOtherArray();
+        b.push(456);
+
+        expect(
+          () => clonedExpect(a, 'to equal', b),
+          'to throw',
+          'expected [ undefined, 123, _subtypeOfSimpleArrayLike: true ]\n' +
+            'to equal [ undefined, 456, _subtypeOfSimpleArrayLike: true ]\n' +
+            '\n' +
+            '[\n' +
+            '  undefined,\n' +
+            '  123, // should equal 456\n' +
+            '  _subtypeOfSimpleArrayLike: true\n' +
+            ']'
+        );
+      });
     });
   });
 


### PR DESCRIPTION
Updating `jsdom` in `unexpected-dom` is [causing trouble](https://github.com/unexpectedjs/unexpected-dom/pull/464) because `NodeList` instances from different windows [have different constructors](https://github.com/jsdom/jsdom/issues/3575) in jsdom 16 and above.

Seems like the easiest way to get unexpected and unexpected-dom to DTRT in that kind of scenario is to relax this requirement a bit and only require the objects to have the same `array-like` subtype.