### PR TITLE
Avoid uncaught exception in 'to satisfy' when the diff is only in properties with symbol keys

### DIFF
--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -94,6 +94,9 @@ function extractPromisesFromObject(obj) {
     Object.keys(obj).forEach((key) => {
       promises.push(...extractPromisesFromObject(obj[key]));
     });
+    Object.getOwnPropertySymbols(obj).forEach((key) => {
+      promises.push(...extractPromisesFromObject(obj[key]));
+    });
     return promises;
   }
   return [];

--- a/test/types/Symbol-type.spec.js
+++ b/test/types/Symbol-type.spec.js
@@ -113,6 +113,31 @@ if (
             '}'
         );
       });
+
+      describe('when only symbol properties differ', function () {
+        // Regression test for not looping over Object.getOwnPropertySymbols(obj)
+        // in expect.promise.{any,all,settle} when an object is passed:
+        it('should error and include the Symbol properties in the diff', () => {
+          const a = {};
+          a[symbolA] = 'foo';
+          const b = {};
+          b[symbolA] = 'bar';
+          expect(
+            function () {
+              expect(a, 'to satisfy', b);
+            },
+            'to throw',
+            "expected { [Symbol('a')]: 'foo' } to satisfy { [Symbol('a')]: 'bar' }\n" +
+              '\n' +
+              '{\n' +
+              "  [Symbol('a')]: 'foo' // should equal 'bar'\n" +
+              '                       //\n' +
+              '                       // -foo\n' +
+              '                       // +bar\n' +
+              '}'
+          );
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
I ran into this rather nasty case when using `to satisfy` to compare objects that only have Symbol properties.